### PR TITLE
Donation payment completion via hosted Stripe Checkout

### DIFF
--- a/apps/convex/__tests__/finance-giving.test.ts
+++ b/apps/convex/__tests__/finance-giving.test.ts
@@ -408,6 +408,159 @@ describe("getGivingContext", () => {
 });
 
 // ============================================================================
+// prepareDonationIntent — the shared validation seam behind BOTH
+// createDonationIntent (native-payment-sheet path) and
+// createDonationCheckoutSession (hosted-Checkout path). Exercised directly
+// here rather than via the live Stripe-calling actions, per repo convention
+// (see this file's header comment).
+// ============================================================================
+
+describe("prepareDonationIntent", () => {
+  test("throws when the group-giving flag is off", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedGivingFixture(t);
+    await t.run(async (ctx) => {
+      const flag = await ctx.db
+        .query("featureFlags")
+        .withIndex("by_key", (q) => q.eq("key", "group-giving"))
+        .first();
+      await ctx.db.patch(flag!._id, { enabled: false });
+    });
+
+    await expect(
+      t.query(internal.functions.finance.giving.prepareDonationIntent, {
+        token: await tokenFor(s.donorUserId),
+        fundId: s.fundId,
+        amountCents: 1000,
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("throws when the fund isn't active", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedGivingFixture(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.fundId, { status: "frozen" });
+    });
+
+    await expect(
+      t.query(internal.functions.finance.giving.prepareDonationIntent, {
+        token: await tokenFor(s.donorUserId),
+        fundId: s.fundId,
+        amountCents: 1000,
+      }),
+    ).rejects.toThrow("This fund isn't currently accepting gifts");
+  });
+
+  test("throws when the community's giving onboarding isn't live", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedGivingFixture(t);
+    await t.run(async (ctx) => {
+      const finance = await ctx.db
+        .query("communityFinance")
+        .withIndex("by_community", (q) => q.eq("communityId", s.communityId))
+        .first();
+      await ctx.db.patch(finance!._id, { onboardingStatus: "collecting" });
+    });
+
+    await expect(
+      t.query(internal.functions.finance.giving.prepareDonationIntent, {
+        token: await tokenFor(s.donorUserId),
+        fundId: s.fundId,
+        amountCents: 1000,
+      }),
+    ).rejects.toThrow("Giving isn't set up for this community yet");
+  });
+
+  test("rejects an amount below the minimum, above the maximum, or non-integer", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedGivingFixture(t);
+    const token = await tokenFor(s.donorUserId);
+
+    await expect(
+      t.query(internal.functions.finance.giving.prepareDonationIntent, {
+        token,
+        fundId: s.fundId,
+        amountCents: 50, // below MIN_DONATION_CENTS (100)
+      }),
+    ).rejects.toThrow("Donation amount must be between");
+
+    await expect(
+      t.query(internal.functions.finance.giving.prepareDonationIntent, {
+        token,
+        fundId: s.fundId,
+        amountCents: 3_000_000, // above MAX_DONATION_CENTS (2_000_000)
+      }),
+    ).rejects.toThrow("Donation amount must be between");
+
+    await expect(
+      t.query(internal.functions.finance.giving.prepareDonationIntent, {
+        token,
+        fundId: s.fundId,
+        amountCents: 1000.5,
+      }),
+    ).rejects.toThrow("Donation amount must be between");
+  });
+
+  test("rejects a negative or non-integer coverFeesCents", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedGivingFixture(t);
+    const token = await tokenFor(s.donorUserId);
+
+    await expect(
+      t.query(internal.functions.finance.giving.prepareDonationIntent, {
+        token,
+        fundId: s.fundId,
+        amountCents: 1000,
+        coverFeesCents: -5,
+      }),
+    ).rejects.toThrow("Invalid fee-cover amount");
+  });
+
+  test("returns the connected-account context, fund name, and groupId for a valid request", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedGivingFixture(t);
+
+    const result = await t.query(internal.functions.finance.giving.prepareDonationIntent, {
+      token: await tokenFor(s.donorUserId),
+      fundId: s.fundId,
+      amountCents: 1000,
+      coverFeesCents: 60,
+    });
+
+    expect(result).toEqual({
+      userId: s.donorUserId,
+      communityId: s.communityId,
+      groupId: s.groupId,
+      fundName: "Young Adults Fund",
+      stripeConnectedAccountId: "acct_test123",
+      feeCoverCents: 60,
+    });
+  });
+
+  test("rejects a user with no access to the fund's group, same as getFundOverview", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedGivingFixture(t);
+    const outsiderId = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        firstName: "Outsider",
+        isActive: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    await expect(
+      t.query(internal.functions.finance.giving.prepareDonationIntent, {
+        token: await tokenFor(outsiderId),
+        fundId: s.fundId,
+        amountCents: 1000,
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ============================================================================
 // recordDonationSucceeded
 // ============================================================================
 

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -376,10 +376,16 @@ export const prepareDonationIntent = internalQuery({
       throw new Error("Giving isn't set up for this community yet");
     }
 
+    // The group's shortId powers the Checkout return URL: /g/<shortId> is
+    // environment-aware via DOMAIN_CONFIG AND already claimed by the Android
+    // App Link intent filters (app.config.js), unlike /groups/... paths.
+    const group = fund.groupId ? await ctx.db.get(fund.groupId) : null;
+
     return {
       userId,
       communityId: fund.communityId,
       groupId: fund.groupId,
+      groupShortId: group?.shortId,
       fundName: fund.name,
       stripeConnectedAccountId: communityFinance.stripeConnectedAccountId,
       feeCoverCents,
@@ -487,15 +493,31 @@ export const createDonationIntent = action({
 // ============================================================================
 
 /**
- * The https universal link the Checkout session redirects back to on
- * completion/cancellation — NOT the custom "togather://" scheme, mirroring
- * FinanceOnboardingStatusScreen's FINANCE_SETUP_DEEP_LINK: Stripe Checkout
- * requires https success/cancel URLs, and the app registers applinks for
- * togather.nyc (app.config.js associatedDomains) so this re-opens the app
- * when installed. Convex reactivity — not the redirect itself — is what
- * actually refreshes the fund screen once the donation lands.
+ * The https link the Checkout session redirects back to on completion/
+ * cancellation — NOT the custom "togather://" scheme (Stripe requires
+ * https). Built from DOMAIN_CONFIG so staging redirects stay on
+ * staging.togather.nyc, and preferring the /g/<shortId> share link because
+ * that path is claimed by BOTH the iOS associated domains and the Android
+ * App Link intent filters (app.config.js) — /groups/... paths are not
+ * Android-claimed, so they'd strand Android donors in the browser. Convex
+ * reactivity — not the redirect itself — refreshes the fund screen once
+ * the donation lands.
  */
-const GIVING_CHECKOUT_BASE_URL = "https://togather.nyc";
+function checkoutReturnUrl(
+  groupShortId: string | undefined,
+  groupId: string,
+): string {
+  if (groupShortId) {
+    return DOMAIN_CONFIG.groupShareUrl(groupShortId);
+  }
+  // Fallback for groups without a shortId: environment-correct, reopens the
+  // app on iOS; Android lands on web (acceptable degradation, logged so we
+  // can see if it ever actually happens).
+  console.warn(
+    `[finance] checkoutReturnUrl: group ${groupId} has no shortId — Android return degrades to browser`,
+  );
+  return `${DOMAIN_CONFIG.appUrl}/groups/${groupId}/fund`;
+}
 
 /**
  * Creates a Stripe Checkout Session (hosted page) on the community's
@@ -542,7 +564,7 @@ export const createDonationCheckoutSession = action({
     });
 
     const totalCents = args.amountCents + context.feeCoverCents;
-    const fundUrl = `${GIVING_CHECKOUT_BASE_URL}/groups/${context.groupId}/fund`;
+    const fundUrl = checkoutReturnUrl(context.groupShortId, context.groupId);
 
     // Created ON the community's connected account (`stripeAccount`) — same
     // direct-charge topology as createDonationIntent, per ADR-032 §1.

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -3,13 +3,20 @@
  * §3, Phase 1 — "Donations + ledger + receipts").
  *
  * Money flow implemented here:
- *   1. `getGivingContext` / `createDonationIntent` power the give sheet —
- *      a Stripe PaymentIntent is created ON the community's connected
- *      account, tagged with `metadata.fundId`.
- *   2. The Stripe webhook layer (owned by another agent — NOT this file)
- *      calls `recordDonationSucceeded` on `payment_intent.succeeded`, which
- *      writes the `donations` row, posts the ledger credit, and schedules
- *      the receipt email.
+ *   1. `getGivingContext` powers the give sheet's amount-entry step;
+ *      `createDonationCheckoutSession` then creates a hosted Stripe Checkout
+ *      Session ON the community's connected account (ADR-032 §3/§7 Phase 1
+ *      decision — zero native dependencies, ships via OTA, Apple Pay works in
+ *      the browser sheet) for the donor to complete in-browser.
+ *      `createDonationIntent` is the not-yet-used native-payment-sheet
+ *      alternative kept for ADR-032's still-open question.
+ *   2. The Stripe webhook layer (functions/finance/webhooks.ts) calls
+ *      `recordDonationSucceeded` on `payment_intent.succeeded` — Checkout's
+ *      `payment_intent_data.metadata` lands on that PaymentIntent exactly
+ *      like `createDonationIntent`'s own metadata does, so this webhook path
+ *      is unchanged by which donation-creation action ran — which writes the
+ *      `donations` row, posts the ledger credit, and schedules the receipt
+ *      email.
  *   3. `getFundOverview` powers the member-facing transparency screen.
  *
  * Every query here first authorizes the caller, then (for `getFundOverview`)
@@ -290,19 +297,62 @@ export const getGivingContext = query({
 });
 
 // ============================================================================
-// createDonationIntent
+// prepareDonationIntent — shared validation seam for BOTH donation-creation
+// actions below (createDonationIntent's native-payment-sheet path and
+// createDonationCheckoutSession's hosted-Checkout path). Actions don't have
+// `ctx.db`, so all the auth/authorization/eligibility/amount checks that
+// need it live here — mirrors `verifyBillingAccess` in functions/ee/billing.ts.
 // ============================================================================
 
 /**
- * Internal query backing `createDonationIntent`. Actions don't have `ctx.db`,
- * so all the auth/authorization/eligibility checks that need it live here —
- * mirrors `verifyBillingAccess` in functions/ee/billing.ts.
+ * Validates the donor-chosen amount is within Stripe/our own bounds and
+ * normalizes `coverFeesCents` to a non-negative integer. Pure (no `ctx`) so
+ * it's trivial to unit test directly, but only called from
+ * `prepareDonationIntent` — the ONE place that gates every donation-creating
+ * action, per the ADR-032 rule that money-initiating actions share one
+ * validation path rather than duplicating checks per Stripe surface.
+ */
+function validateDonationAmount(
+  amountCents: number,
+  coverFeesCents: number | undefined,
+): { feeCoverCents: number } {
+  if (
+    !Number.isInteger(amountCents) ||
+    amountCents < MIN_DONATION_CENTS ||
+    amountCents > MAX_DONATION_CENTS
+  ) {
+    throw new Error(
+      `Donation amount must be between $${MIN_DONATION_CENTS / 100} and $${MAX_DONATION_CENTS / 100}`,
+    );
+  }
+  const feeCoverCents = coverFeesCents ?? 0;
+  if (!Number.isInteger(feeCoverCents) || feeCoverCents < 0) {
+    throw new Error("Invalid fee-cover amount");
+  }
+  return { feeCoverCents };
+}
+
+/**
+ * Shared validation for creating a donation on Stripe, however it's
+ * collected: flag gate, amount bounds, fund-active, community-live. Both
+ * `createDonationIntent` (native payment-sheet path) and
+ * `createDonationCheckoutSession` (hosted Checkout path) call this FIRST and
+ * build their respective Stripe object from its return value — this is the
+ * "refactor shared logic rather than duplicate" seam the two donation
+ * actions are built on.
  */
 export const prepareDonationIntent = internalQuery({
-  args: { token: v.string(), fundId: v.id("funds") },
+  args: {
+    token: v.string(),
+    fundId: v.id("funds"),
+    amountCents: v.number(),
+    coverFeesCents: v.optional(v.number()),
+  },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
     await requireGroupGivingEnabled(ctx); // Gate donation creation at the source.
+
+    const { feeCoverCents } = validateDonationAmount(args.amountCents, args.coverFeesCents);
 
     const fund = await ctx.db.get(args.fundId);
     if (!fund) {
@@ -329,10 +379,23 @@ export const prepareDonationIntent = internalQuery({
     return {
       userId,
       communityId: fund.communityId,
+      groupId: fund.groupId,
+      fundName: fund.name,
       stripeConnectedAccountId: communityFinance.stripeConnectedAccountId,
+      feeCoverCents,
     };
   },
 });
+
+// ============================================================================
+// createDonationIntent — the native payment-sheet path. NOT called by the
+// mobile client today (GiveScreen uses createDonationCheckoutSession's
+// hosted-Checkout flow per ADR-032's Phase-1 decision: zero native-dep risk,
+// ships via OTA, Apple Pay works in the browser sheet). Kept exported and
+// tested for ADR-032's still-open question of whether a later phase adopts
+// `@stripe/stripe-react-native`'s native payment sheet for better Apple Pay
+// conversion — see the ADR's "Open questions".
+// ============================================================================
 
 /**
  * Creates a Stripe PaymentIntent on the community's connected account for a
@@ -360,23 +423,14 @@ export const createDonationIntent = action({
     ctx,
     args,
   ): Promise<{ clientSecret: string; paymentIntentId: string }> => {
-    if (
-      !Number.isInteger(args.amountCents) ||
-      args.amountCents < MIN_DONATION_CENTS ||
-      args.amountCents > MAX_DONATION_CENTS
-    ) {
-      throw new Error(
-        `Donation amount must be between $${MIN_DONATION_CENTS / 100} and $${MAX_DONATION_CENTS / 100}`,
-      );
-    }
-    const feeCoverCents = args.coverFeesCents ?? 0;
-    if (!Number.isInteger(feeCoverCents) || feeCoverCents < 0) {
-      throw new Error("Invalid fee-cover amount");
-    }
-
     const context = await ctx.runQuery(
       internal.functions.finance.giving.prepareDonationIntent,
-      { token: args.token, fundId: args.fundId },
+      {
+        token: args.token,
+        fundId: args.fundId,
+        amountCents: args.amountCents,
+        coverFeesCents: args.coverFeesCents,
+      },
     );
 
     const Stripe = (await import("stripe")).default;
@@ -389,14 +443,14 @@ export const createDonationIntent = action({
     // per the acquiring topology in ADR-032 §1.
     const paymentIntent = await stripe.paymentIntents.create(
       {
-        amount: args.amountCents + feeCoverCents,
+        amount: args.amountCents + context.feeCoverCents,
         currency: "usd",
         automatic_payment_methods: { enabled: true },
         metadata: {
           fundId: args.fundId,
           donorUserId: context.userId,
           communityId: context.communityId,
-          feeCoverCents: String(feeCoverCents),
+          feeCoverCents: String(context.feeCoverCents),
         },
       },
       {
@@ -423,6 +477,121 @@ export const createDonationIntent = action({
       clientSecret: paymentIntent.client_secret,
       paymentIntentId: paymentIntent.id,
     };
+  },
+});
+
+// ============================================================================
+// createDonationCheckoutSession — the hosted Stripe Checkout path (ADR-032
+// §3/§6 Phase 1 decision: zero native dependencies, ships via OTA, Apple Pay
+// works in the browser sheet). This is what GiveScreen actually calls.
+// ============================================================================
+
+/**
+ * The https universal link the Checkout session redirects back to on
+ * completion/cancellation — NOT the custom "togather://" scheme, mirroring
+ * FinanceOnboardingStatusScreen's FINANCE_SETUP_DEEP_LINK: Stripe Checkout
+ * requires https success/cancel URLs, and the app registers applinks for
+ * togather.nyc (app.config.js associatedDomains) so this re-opens the app
+ * when installed. Convex reactivity — not the redirect itself — is what
+ * actually refreshes the fund screen once the donation lands.
+ */
+const GIVING_CHECKOUT_BASE_URL = "https://togather.nyc";
+
+/**
+ * Creates a Stripe Checkout Session (hosted page) on the community's
+ * connected account for a donation to `fundId`.
+ *
+ * CRITICAL: Checkout session-level `metadata` does NOT propagate to the
+ * PaymentIntent Checkout creates under the hood — only `payment_intent_data.
+ * metadata` does. The existing `payment_intent.succeeded` webhook path
+ * (functions/finance/webhooks.ts's `handleFinanceStripeEvent`, including the
+ * connected-account cross-check and `splitDonationAmounts`) reads metadata
+ * off the PaymentIntent event object, so it MUST land there, unchanged from
+ * what `createDonationIntent` sets directly.
+ */
+export const createDonationCheckoutSession = action({
+  args: {
+    token: v.string(),
+    fundId: v.id("funds"),
+    amountCents: v.number(),
+    coverFeesCents: v.optional(v.number()),
+    // Same contract as createDonationIntent's idempotencyNonce — see that
+    // action's doc comment.
+    idempotencyNonce: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<{ url: string; sessionId: string }> => {
+    const context = await ctx.runQuery(
+      internal.functions.finance.giving.prepareDonationIntent,
+      {
+        token: args.token,
+        fundId: args.fundId,
+        amountCents: args.amountCents,
+        coverFeesCents: args.coverFeesCents,
+      },
+    );
+    if (!context.groupId) {
+      // The success/cancel universal links land on a group's fund screen
+      // (`/groups/[group_id]/fund`) — a community-wide general fund has no
+      // such screen yet, so hosted Checkout isn't wired for it.
+      throw new Error("Checkout isn't available for this fund yet");
+    }
+
+    const Stripe = (await import("stripe")).default;
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: "2026-02-25.clover",
+    });
+
+    const totalCents = args.amountCents + context.feeCoverCents;
+    const fundUrl = `${GIVING_CHECKOUT_BASE_URL}/groups/${context.groupId}/fund`;
+
+    // Created ON the community's connected account (`stripeAccount`) — same
+    // direct-charge topology as createDonationIntent, per ADR-032 §1.
+    const session = await stripe.checkout.sessions.create(
+      {
+        mode: "payment",
+        line_items: [
+          {
+            price_data: {
+              currency: "usd",
+              unit_amount: totalCents,
+              product_data: { name: `Gift to ${context.fundName}` },
+            },
+            quantity: 1,
+          },
+        ],
+        success_url: `${fundUrl}?giving=success`,
+        cancel_url: `${fundUrl}?giving=cancelled`,
+        payment_intent_data: {
+          description: `Donation — ${context.fundName}`,
+          // Same shape recordDonationSucceeded/handleFinanceStripeEvent
+          // already expect from createDonationIntent's direct PaymentIntent
+          // metadata — see the file-level CRITICAL note above.
+          metadata: {
+            fundId: args.fundId,
+            donorUserId: context.userId,
+            communityId: context.communityId,
+            feeCoverCents: String(context.feeCoverCents),
+          },
+        },
+      },
+      {
+        stripeAccount: context.stripeConnectedAccountId,
+        // Mirrors createDonationIntent's own idempotency handling (FIX 5) —
+        // a double-tapped "Continue" resolves to the SAME Checkout Session
+        // instead of creating a second one.
+        ...(args.idempotencyNonce
+          ? {
+              idempotencyKey: `donation-checkout:${args.fundId}:${args.idempotencyNonce}`,
+            }
+          : {}),
+      },
+    );
+
+    if (!session.url) {
+      throw new Error("Stripe did not return a Checkout URL");
+    }
+
+    return { url: session.url, sessionId: session.id };
   },
 });
 

--- a/apps/mobile/features/finance/member/GiveScreen.tsx
+++ b/apps/mobile/features/finance/member/GiveScreen.tsx
@@ -68,6 +68,12 @@ export function GiveScreen() {
 
   const handleBack = () => {
     if (step === "confirmation") {
+      // Editing the gift after a session was created starts a NEW submission
+      // — drop the stale session so "Reopen" can't relaunch the old amount.
+      // (The nonce was already rotated when that session was created, so the
+      // next Continue gets a fresh idempotency key; reusing the old key with
+      // different params would make Stripe reject the request.)
+      setCheckoutSession(null);
       setStep("amount");
       return;
     }
@@ -106,6 +112,11 @@ export function GiveScreen() {
         idempotencyNonce: idempotencyNonceRef.current,
       });
       setCheckoutSession(result);
+      // Rotate the nonce now that this submission has its session: a failed
+      // call keeps the old nonce (retry = same idempotency key = no double
+      // session), while the donor's NEXT gift — after Done/back — gets a
+      // fresh key instead of colliding with this one.
+      idempotencyNonceRef.current = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
       setStep("confirmation");
       await openCheckoutUrl(result.url);
     } catch (err) {

--- a/apps/mobile/features/finance/member/GiveScreen.tsx
+++ b/apps/mobile/features/finance/member/GiveScreen.tsx
@@ -5,9 +5,17 @@
  *
  * All Convex/router wiring lives here; the actual UI is `GiveScreenView`,
  * kept prop-only so a verification harness can render it with mock data.
+ *
+ * Payment collection is a hosted Stripe Checkout page (ADR-032 §3/§7 Phase 1
+ * decision: zero native dependencies, ships via OTA, Apple Pay works in the
+ * browser sheet) — "Continue" creates a Checkout Session, then opens its
+ * `url` via expo-web-browser, the same `openBrowserAsync` pattern
+ * FinanceOnboardingStatusScreen uses for Stripe's hosted onboarding.
  */
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
+import { Platform } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import * as WebBrowser from "expo-web-browser";
 import {
   useAuthenticatedQuery,
   useAuthenticatedAction,
@@ -17,7 +25,17 @@ import type { Id } from "@services/api/convex";
 import { formatError } from "@/utils/error-handling";
 import { GiveScreenView, type GiveStep } from "./GiveScreenView";
 import { estimateCoverFeesCents, resolveGiveAmountCents } from "./amount";
-import type { DonationIntent } from "./types";
+import type { CheckoutSession } from "./types";
+
+/** Opens a URL in the platform's browser sheet — mirrors
+ * FinanceOnboardingStatusScreen's handleContinueIdentityVerification. */
+async function openCheckoutUrl(url: string): Promise<void> {
+  if (Platform.OS === "web") {
+    window.location.href = url;
+  } else {
+    await WebBrowser.openBrowserAsync(url);
+  }
+}
 
 export function GiveScreen() {
   const params = useLocalSearchParams<{ group_id: string }>();
@@ -29,8 +47,8 @@ export function GiveScreen() {
     groupId ? { groupId: groupId as Id<"groups"> } : "skip",
   );
 
-  const createDonationIntent = useAuthenticatedAction(
-    api.functions.finance.giving.createDonationIntent,
+  const createDonationCheckoutSession = useAuthenticatedAction(
+    api.functions.finance.giving.createDonationCheckoutSession,
   );
 
   const [step, setStep] = useState<GiveStep>("amount");
@@ -39,7 +57,14 @@ export function GiveScreen() {
   const [coverFees, setCoverFees] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [intent, setIntent] = useState<DonationIntent | null>(null);
+  const [checkoutSession, setCheckoutSession] = useState<CheckoutSession | null>(null);
+
+  // Minted once per give-sheet session (not per tap) so a retried/double-tapped
+  // "Continue" reuses the same Stripe idempotency key instead of creating a
+  // second Checkout Session — see createDonationCheckoutSession's doc comment.
+  const idempotencyNonceRef = useRef<string>(
+    `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
 
   const handleBack = () => {
     if (step === "confirmation") {
@@ -74,18 +99,25 @@ export function GiveScreen() {
     setError(null);
     try {
       const coverFeesCents = coverFees ? estimateCoverFeesCents(amountCents) : 0;
-      const result = await createDonationIntent({
+      const result = await createDonationCheckoutSession({
         fundId: context.fundId as Id<"funds">,
         amountCents,
         coverFeesCents,
+        idempotencyNonce: idempotencyNonceRef.current,
       });
-      setIntent(result);
+      setCheckoutSession(result);
       setStep("confirmation");
+      await openCheckoutUrl(result.url);
     } catch (err) {
       setError(formatError(err, "Couldn't start this gift. Please try again."));
     } finally {
       setSubmitting(false);
     }
+  };
+
+  const handleReopenCheckout = async () => {
+    if (!checkoutSession) return;
+    await openCheckoutUrl(checkoutSession.url);
   };
 
   return (
@@ -97,12 +129,13 @@ export function GiveScreen() {
       coverFees={coverFees}
       submitting={submitting}
       error={error}
-      intent={intent}
+      checkoutSession={checkoutSession}
       onBack={handleBack}
       onSelectPreset={handleSelectPreset}
       onCustomAmountChange={handleCustomAmountChange}
       onToggleCoverFees={setCoverFees}
       onContinue={handleContinue}
+      onReopenCheckout={handleReopenCheckout}
     />
   );
 }

--- a/apps/mobile/features/finance/member/GiveScreenView.tsx
+++ b/apps/mobile/features/finance/member/GiveScreenView.tsx
@@ -2,22 +2,23 @@
  * GiveScreenView — presentational give sheet (ADR-032 §3/§7 Phase 1). Pure
  * props in, no Convex/router imports.
  *
- * PAYMENT STEP IS STUBBED: the "confirmation" step just proves a Stripe
- * PaymentIntent was created (masked client secret + amount). Wiring an
- * actual payment sheet ships with the Stripe payment-sheet decision — ADR-032
- * open question: native `@stripe/stripe-react-native` sheet (better Apple Pay
- * conversion, but a new native dependency that must be gated per ADR-013) vs.
- * a web-based Stripe Checkout (zero native-dep risk). Do NOT import
- * `@stripe/stripe-react-native` here until that's decided.
+ * Payment is collected on a hosted Stripe Checkout page (ADR-032 §3/§7 Phase
+ * 1 decision: zero native dependencies, ships via OTA, Apple Pay works in
+ * the browser sheet). The "confirmation" step here isn't a payment
+ * confirmation at all — it's a "finish in the browser" waypoint shown right
+ * after `GiveScreen` launches the Checkout URL, since the actual payment
+ * completes outside this screen (in the browser sheet, then via the
+ * `success_url`/`cancel_url` universal link back to the fund screen; Convex
+ * reactivity — not the redirect — is what updates the fund balance/activity).
  */
 import React from "react";
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Platform } from "react-native";
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
 import { Button, Input, Switch, Skeleton, EmptyState } from "@components/ui";
 import { formatCents } from "../format";
 import { estimateCoverFeesCents, resolveGiveAmountCents } from "./amount";
-import type { DonationIntent, GivingContext } from "./types";
+import type { CheckoutSession, GivingContext } from "./types";
 
 export type GiveStep = "amount" | "confirmation";
 
@@ -30,18 +31,13 @@ export interface GiveScreenViewProps {
   coverFees: boolean;
   submitting: boolean;
   error: string | null;
-  intent: DonationIntent | null;
+  checkoutSession: CheckoutSession | null;
   onBack: () => void;
   onSelectPreset: (cents: number) => void;
   onCustomAmountChange: (text: string) => void;
   onToggleCoverFees: (value: boolean) => void;
   onContinue: () => void;
-}
-
-/** "pi_3P...secret_1a2b" -> "pi_3P••••••••1a2b" — never render the full secret. */
-export function maskClientSecret(secret: string): string {
-  if (secret.length <= 12) return "•".repeat(secret.length);
-  return `${secret.slice(0, 6)}${"•".repeat(8)}${secret.slice(-4)}`;
+  onReopenCheckout: () => void;
 }
 
 export function GiveScreenView({
@@ -52,12 +48,13 @@ export function GiveScreenView({
   coverFees,
   submitting,
   error,
-  intent,
+  checkoutSession,
   onBack,
   onSelectPreset,
   onCustomAmountChange,
   onToggleCoverFees,
   onContinue,
+  onReopenCheckout,
 }: GiveScreenViewProps) {
   const { colors } = useTheme();
 
@@ -102,13 +99,13 @@ export function GiveScreenView({
       ) : step === "confirmation" ? (
         <ScrollView contentContainerStyle={styles.scrollContent}>
           <View style={[styles.confirmationPanel, { backgroundColor: colors.surfaceSecondary }]}>
-            <Ionicons name="checkmark-circle" size={40} color={colors.success} />
+            <Ionicons name="lock-closed" size={40} color={colors.success} />
             <Text style={[styles.confirmationTitle, { color: colors.text }]}>
-              Payment intent created
+              Finish your gift in the browser
             </Text>
             <Text style={[styles.confirmationSubtitle, { color: colors.textSecondary }]}>
-              STUBBED — the payment sheet that collects the card and confirms
-              this intent isn't wired up yet (see ADR-032 open questions).
+              Complete your gift in the secure Stripe page that just opened.
+              Once it's done, you can close that page and come back here.
             </Text>
             <View style={styles.confirmationRow}>
               <Text style={[styles.confirmationLabel, { color: colors.textSecondary }]}>
@@ -126,19 +123,17 @@ export function GiveScreenView({
                 {context.fundName}
               </Text>
             </View>
-            {!!intent && (
-              <View style={styles.confirmationRow}>
-                <Text style={[styles.confirmationLabel, { color: colors.textSecondary }]}>
-                  Client secret
-                </Text>
-                <Text
-                  style={[styles.confirmationValue, styles.mono, { color: colors.textTertiary }]}
-                >
-                  {maskClientSecret(intent.clientSecret)}
-                </Text>
-              </View>
-            )}
           </View>
+
+          <Button
+            onPress={onReopenCheckout}
+            disabled={!checkoutSession}
+            variant="secondary"
+          >
+            Reopen payment page
+          </Button>
+
+          <Button onPress={onBack}>Done</Button>
         </ScrollView>
       ) : (
         <ScrollView contentContainerStyle={styles.scrollContent}>
@@ -259,5 +254,4 @@ const styles = StyleSheet.create({
   },
   confirmationLabel: { fontSize: 14 },
   confirmationValue: { fontSize: 14, fontWeight: "600" },
-  mono: { fontFamily: Platform.select({ ios: "Menlo", android: "monospace", default: "monospace" }) },
 });

--- a/apps/mobile/features/finance/member/__tests__/GiveScreenView.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/GiveScreenView.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react-native";
-import { GiveScreenView, maskClientSecret } from "../GiveScreenView";
+import { GiveScreenView } from "../GiveScreenView";
 import { estimateCoverFeesCents } from "../amount";
 import { formatCents } from "../../format";
 import type { GivingContext } from "../types";
@@ -91,12 +91,13 @@ const baseProps = {
   coverFees: false,
   submitting: false,
   error: null,
-  intent: null,
+  checkoutSession: null,
   onBack: noop,
   onSelectPreset: noop,
   onCustomAmountChange: noop,
   onToggleCoverFees: noop,
   onContinue: noop,
+  onReopenCheckout: noop,
 };
 
 describe("GiveScreenView", () => {
@@ -156,19 +157,52 @@ describe("GiveScreenView", () => {
     ).toBeTruthy();
   });
 
-  it("renders the stubbed confirmation panel with a masked client secret", () => {
+  it("shows the 'finish in the browser' confirmation panel with amount and fund after Checkout launches", () => {
     render(
       <GiveScreenView
         {...baseProps}
         step="confirmation"
         selectedPresetCents={5000}
-        intent={{ clientSecret: "pi_123abc_secret_xyz789", paymentIntentId: "pi_123abc" }}
+        checkoutSession={{ url: "https://checkout.stripe.com/c/pay/cs_test_123", sessionId: "cs_test_123" }}
       />,
     );
-    expect(screen.getByText("Payment intent created")).toBeTruthy();
+    expect(screen.getByText("Finish your gift in the browser")).toBeTruthy();
     expect(
-      screen.getByText(maskClientSecret("pi_123abc_secret_xyz789")),
+      screen.getByText(
+        "Complete your gift in the secure Stripe page that just opened. Once it's done, you can close that page and come back here.",
+      ),
     ).toBeTruthy();
     expect(screen.getByText(formatCents(5000))).toBeTruthy();
+    expect(screen.getByText("Young Adults — Manhattan")).toBeTruthy();
+  });
+
+  it("calls onReopenCheckout when 'Reopen payment page' is tapped", () => {
+    const onReopenCheckout = jest.fn();
+    render(
+      <GiveScreenView
+        {...baseProps}
+        step="confirmation"
+        selectedPresetCents={5000}
+        checkoutSession={{ url: "https://checkout.stripe.com/c/pay/cs_test_123", sessionId: "cs_test_123" }}
+        onReopenCheckout={onReopenCheckout}
+      />,
+    );
+    fireEvent.press(screen.getByLabelText("Reopen payment page"));
+    expect(onReopenCheckout).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onBack when 'Done' is tapped on the confirmation step", () => {
+    const onBack = jest.fn();
+    render(
+      <GiveScreenView
+        {...baseProps}
+        step="confirmation"
+        selectedPresetCents={5000}
+        checkoutSession={{ url: "https://checkout.stripe.com/c/pay/cs_test_123", sessionId: "cs_test_123" }}
+        onBack={onBack}
+      />,
+    );
+    fireEvent.press(screen.getByLabelText("Done"));
+    expect(onBack).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/features/finance/member/types.ts
+++ b/apps/mobile/features/finance/member/types.ts
@@ -53,7 +53,9 @@ export interface GivingContext {
   givingLive: boolean;
 }
 
-export interface DonationIntent {
-  clientSecret: string;
-  paymentIntentId: string;
+/** Return shape of `createDonationCheckoutSession` — the hosted Stripe
+ * Checkout page the give sheet launches (ADR-032 §3/§7 Phase 1). */
+export interface CheckoutSession {
+  url: string;
+  sessionId: string;
 }


### PR DESCRIPTION
## What

Closes the deliberately-stubbed gap from #653: the give sheet now completes real payments via **hosted Stripe Checkout** (ADR-032 open question resolved — zero native dependencies, ships via OTA, Apple Pay works in the browser sheet; the native payment sheet remains the documented future upgrade).

**Backend** (`functions/finance/giving.ts`):
- `prepareDonationIntent` is now the single validation seam for both payment paths (flag gate → amount bounds → fund active → community live → member access).
- New action `createDonationCheckoutSession` — Checkout Session created directly on the church's connected account; `payment_intent_data.metadata` carries `{fundId, donorUserId, communityId, feeCoverCents}` so the existing `payment_intent.succeeded` webhook path (connected-account cross-check, `splitDonationAmounts`, idempotent recording, receipts) works **unchanged**. Success/cancel URLs are `togather.nyc` universal links back to the fund screen; Convex reactivity updates the balance.
- `createDonationIntent` kept as the documented future native-sheet path.

**Mobile** (`features/finance/member/`):
- "Continue" creates the session and opens it via `expo-web-browser` (same pattern as the onboarding verification link); per-sheet idempotency nonce prevents double-charging on double-tap.
- The confirmation step is now a real "Finish your gift in the browser" panel with amount/fund, "Reopen payment page," and "Done" — stub language and the masked client secret removed.

## Testing

- +7 backend tests on the shared validation seam; giving+flag suites 41 green; `tsc --noEmit` 0 errors.
- Mobile finance suites 57 green (8 suites); full mobile suite green on pre-push (1,936 passed).
- No new dependencies; no native-graph changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGAcCKMuK2LfcDgPy7uqnq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGAcCKMuK2LfcDgPy7uqnq)_