### PR TITLE
Pin sync-secrets to the framework sha carrying the GITHUB_TOKEN fix

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -53,7 +53,11 @@ on:
 jobs:
   sync:
     name: Sync ${{ inputs.environment || 'both' }} secrets
-    uses: Supa-Media/supa-framework/.github/workflows/sync-secrets.yml@v1
+    # Pinned to the exact sha of Supa-Media/supa-framework#33 (GITHUB_TOKEN
+    # export fix — without it the npx install 401s against the project
+    # .npmrc). TODO: re-pin to @v1 once the floating v1 tag advances past
+    # 592d5b4e (tag pushes need maintainer credentials).
+    uses: Supa-Media/supa-framework/.github/workflows/sync-secrets.yml@592d5b4e01a727aff400c117b8a08b91458cf542
     with:
       vault: Togather
       allowlist-path: ee/secrets-allowlist.json


### PR DESCRIPTION
## What

Supa-Media/supa-framework#33 (merged, `592d5b4e`) fixes the secrets-sync 401: the reusable workflow now exports `GITHUB_TOKEN` so the caller's project `.npmrc` (`_authToken=${GITHUB_TOKEN}`, adopted here in #628 — which is exactly when the sync started failing) authenticates the `@supa-media/scripts` install.

The floating `v1` tag hasn't advanced past that fix yet (tag force-pushes need maintainer credentials this session doesn't have), so pin the caller to the exact fix sha. TODO comment marks re-pinning to `@v1` once the tag moves.

## Testing

Will re-dispatch `sync-secrets.yml -f environment=both` after merge — expecting the first green sync since 2026-07-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGAcCKMuK2LfcDgPy7uqnq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGAcCKMuK2LfcDgPy7uqnq)_