### PR TITLE
Add group-giving to the admin feature-flags catalog

### DIFF
--- a/apps/mobile/features/admin/components/FeatureFlagsContent.tsx
+++ b/apps/mobile/features/admin/components/FeatureFlagsContent.tsx
@@ -53,6 +53,11 @@ const KNOWN_FLAGS: Array<{ key: string; description: string }> = [
       "Enables @Togather dev-assistant bot + bug pipeline (staff only).",
   },
   {
+    key: "group-giving",
+    description:
+      "Group giving & finances (ADR-032): community finance onboarding (Stripe + Increase), per-group funds, donations, and reimbursements. This flag only unlocks the feature — each community must complete onboarding, and a community admin must then enable giving per group.",
+  },
+  {
     key: "nearby-device-location",
     description:
       "Shows the compass (use-my-location) button on the Groups tab. Keep OFF until a native build that includes the iOS location-permission string is live — the current binary would mis-prompt. Zip-code search works regardless of this flag.",


### PR DESCRIPTION
## Why

The `/admin/features` screen seeds its list from the hardcoded `KNOWN_FLAGS` catalog in `FeatureFlagsContent.tsx`, because Convex `featureFlags` rows are created lazily on the first `setFeatureFlag` call. A flag missing from the catalog is invisible in the UI until someone flips it — which is impossible *from* the UI. The `group-giving` flag (ADR-032, #653) shipped without a catalog entry, so superusers had no way to turn it on (screenshot from staging confirmed it's absent).

## What

One entry added to `KNOWN_FLAGS`: key `group-giving`, with a description noting the flag only unlocks the feature — communities still onboard individually and admins enable giving per group.

## Testing

- `KNOWN_FLAGS` is referenced only by this screen; the merge logic already handles seed rows (`Never flipped` state).
- eslint (lint-staged) passed; unrelated pre-existing mobile `tsc` errors untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGAcCKMuK2LfcDgPy7uqnq)_