### PR TITLE
Check-in: search, guests, and a desktop layout

### DIFF
--- a/apps/convex/__tests__/event-checkin.test.ts
+++ b/apps/convex/__tests__/event-checkin.test.ts
@@ -431,3 +431,121 @@ describe("event check-in — walk-ins", () => {
     expect(guestId).toBeDefined();
   });
 });
+
+describe("event check-in — a member's guests (plus-ones)", () => {
+  test("the Going roster exposes the plus-ones each member declared", async () => {
+    const t = convexTest(schema, modules);
+    const { leaderToken, meetingId, goingUserId } =
+      await seedCheckInFixture(t);
+
+    // Gina updates her RSVP to bring two people.
+    await t.run(async (ctx) => {
+      const rsvp = await ctx.db
+        .query("meetingRsvps")
+        .withIndex("by_meeting_user", (q) =>
+          q.eq("meetingId", meetingId).eq("userId", goingUserId)
+        )
+        .first();
+      await ctx.db.patch(rsvp!._id, { guestCount: 2 });
+    });
+
+    const roster = await t.query(api.functions.meetingRsvps.goingRoster, {
+      token: leaderToken,
+      meetingId,
+    });
+    expect(roster).toHaveLength(1);
+    expect(roster[0].guestCount).toBe(2);
+  });
+
+  test("a guest checked in under a member is linked to that member", async () => {
+    const t = convexTest(schema, modules);
+    const { leaderToken, meetingId, goingUserId } =
+      await seedCheckInFixture(t);
+
+    const guestId = await t.mutation(
+      api.functions.meetings.attendance.addGuest,
+      { token: leaderToken, meetingId, hostUserId: goingUserId }
+    );
+
+    const guests = await t.query(
+      api.functions.meetings.attendance.listGuests,
+      { token: leaderToken, meetingId }
+    );
+    expect(guests).toHaveLength(1);
+    expect(guests[0]._id).toBe(guestId);
+    // Checked in first, named later — the row is valid with no name at all.
+    expect(guests[0].hostUserId).toBe(goingUserId);
+    expect(guests[0].firstName).toBeUndefined();
+  });
+
+  test("a guest's name can be filled in after they are checked in", async () => {
+    const t = convexTest(schema, modules);
+    const { leaderToken, meetingId, goingUserId } =
+      await seedCheckInFixture(t);
+
+    const guestId = await t.mutation(
+      api.functions.meetings.attendance.addGuest,
+      { token: leaderToken, meetingId, hostUserId: goingUserId }
+    );
+
+    await t.mutation(api.functions.meetings.attendance.updateGuest, {
+      token: leaderToken,
+      guestId,
+      firstName: "Ada",
+      lastName: "Lovelace",
+    });
+
+    const guests = await t.query(
+      api.functions.meetings.attendance.listGuests,
+      { token: leaderToken, meetingId }
+    );
+    expect(guests[0]).toMatchObject({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      hostUserId: goingUserId,
+    });
+  });
+
+  test("undoing a guest check-in removes only that guest", async () => {
+    const t = convexTest(schema, modules);
+    const { leaderToken, meetingId, goingUserId } =
+      await seedCheckInFixture(t);
+
+    const first = await t.mutation(
+      api.functions.meetings.attendance.addGuest,
+      { token: leaderToken, meetingId, hostUserId: goingUserId }
+    );
+    await t.mutation(api.functions.meetings.attendance.addGuest, {
+      token: leaderToken,
+      meetingId,
+      hostUserId: goingUserId,
+      firstName: "Stays",
+    });
+
+    await t.mutation(api.functions.meetings.attendance.removeGuest, {
+      token: leaderToken,
+      guestId: first,
+    });
+
+    const guests = await t.query(
+      api.functions.meetings.attendance.listGuests,
+      { token: leaderToken, meetingId }
+    );
+    expect(guests).toHaveLength(1);
+    expect(guests[0].firstName).toBe("Stays");
+  });
+
+  test("a non-manager cannot check in someone else's guest", async () => {
+    const t = convexTest(schema, modules);
+    const { memberToken, meetingId, goingUserId } =
+      await seedCheckInFixture(t);
+
+    await expect(
+      t.mutation(api.functions.meetings.attendance.addGuest, {
+        token: memberToken,
+        meetingId,
+        hostUserId: goingUserId,
+      })
+    ).rejects.toThrow(/Only the event creator, group leaders, or community admins/);
+  });
+});

--- a/apps/convex/functions/meetings/attendance.ts
+++ b/apps/convex/functions/meetings/attendance.ts
@@ -180,6 +180,11 @@ export const markAttendance = mutation({
 
 /**
  * Add guest to a meeting
+ *
+ * Covers both walk-ins (nobody's plus-one) and a member's guests — pass
+ * `hostUserId` for the latter so the check-in screen can nest them under the
+ * member who brought them. A guest row is one attending person either way, so
+ * headcount stats need no special-casing.
  */
 export const addGuest = mutation({
   args: {
@@ -189,6 +194,7 @@ export const addGuest = mutation({
     lastName: v.optional(v.string()),
     phoneNumber: v.optional(v.string()),
     notes: v.optional(v.string()),
+    hostUserId: v.optional(v.id("users")),
   },
   handler: async (ctx, args) => {
     const recordedById = await requireAuth(ctx, args.token);
@@ -215,6 +221,7 @@ export const addGuest = mutation({
       lastName: args.lastName,
       phoneNumber: args.phoneNumber,
       notes: args.notes,
+      hostUserId: args.hostUserId,
       recordedById,
       recordedAt: timestamp,
     });

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -981,6 +981,10 @@ export default defineSchema({
     meetingId: v.id("meetings"),
     userId: v.optional(v.id("users")), // Optional: if guest is linked to a user
     recordedById: v.optional(v.id("users")),
+    // The member who brought this guest — the plus-ones they declared on their
+    // "Going" RSVP (`meetingRsvps.guestCount`). Set when a leader checks a guest
+    // in under someone on the check-in roster; absent for unattached walk-ins.
+    hostUserId: v.optional(v.id("users")),
 
     firstName: v.optional(v.string()),
     lastName: v.optional(v.string()),

--- a/apps/mobile/app/(user)/leader-tools/[group_id]/events/[event_id]/checkin.tsx
+++ b/apps/mobile/app/(user)/leader-tools/[group_id]/events/[event_id]/checkin.tsx
@@ -25,15 +25,23 @@ import {
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { Avatar } from "@components/ui/Avatar";
 import { CustomModal } from "@components/ui/Modal";
+import { SearchBar } from "@components/ui/SearchBar";
 import { ToastManager } from "@components/ui/Toast";
 import { useTheme } from "@hooks/useTheme";
 import {
   ATTENDANCE_PRESENT,
   ATTENDANCE_ABSENT,
+  buildGuestSlots,
   computeCheckInSummary,
+  filterGoingUsers,
+  filterWalkIns,
+  fullName,
+  guestSlotLabel,
   indexAttendanceByUser,
   isCheckedIn,
+  partitionGuests,
   type GoingUser,
+  type GuestSlot,
 } from "@/features/leader-tools/utils/checkIn";
 
 const CHECKED_IN_COLOR = "#10B981"; // green-500
@@ -45,6 +53,13 @@ function formatCheckInTime(recordedAt?: number): string {
     minute: "2-digit",
   });
   return `Checked in · ${time}`;
+}
+
+/** The guest currently being named, identified by its persisted row. */
+interface NamingGuest {
+  guestId: string;
+  firstName: string;
+  lastName: string;
 }
 
 function CheckInPage() {
@@ -106,7 +121,8 @@ function CheckInPage() {
   );
   const isLoadingAttendance = canFetch && attendance === undefined;
 
-  // Walk-ins (guest records without an account). Manager-gated, pass token.
+  // Guest rows: members' plus-ones (hostUserId set) and unattached walk-ins.
+  // Manager-gated, pass token.
   const guests = useQuery(
     api.functions.meetings.attendance.listGuests,
     canFetch
@@ -121,13 +137,21 @@ function CheckInPage() {
   const addGuest = useAuthenticatedMutation(
     api.functions.meetings.attendance.addGuest
   );
+  const updateGuest = useAuthenticatedMutation(
+    api.functions.meetings.attendance.updateGuest
+  );
   const removeGuest = useAuthenticatedMutation(
     api.functions.meetings.attendance.removeGuest
   );
 
   const [pendingUserIds, setPendingUserIds] = useState<Set<string>>(new Set());
+  const [pendingGuestKeys, setPendingGuestKeys] = useState<Set<string>>(
+    new Set()
+  );
   const [showRestrictedModal, setShowRestrictedModal] = useState(false);
   const [showAddWalkIn, setShowAddWalkIn] = useState(false);
+  const [namingGuest, setNamingGuest] = useState<NamingGuest | null>(null);
+  const [search, setSearch] = useState("");
 
   const goingUsers: GoingUser[] = useMemo(
     () => goingRoster ?? [],
@@ -139,11 +163,25 @@ function CheckInPage() {
     [attendance]
   );
 
-  const walkIns = useMemo(() => guests ?? [], [guests]);
+  const { guestsByHost, walkIns } = useMemo(
+    () => partitionGuests(goingUsers, guests ?? []),
+    [goingUsers, guests]
+  );
 
+  // The summary counts the whole event, not the current search — a filtered
+  // "3 / 4 checked in" would be misleading while someone is typing.
   const summary = useMemo(
-    () => computeCheckInSummary(goingUsers, attendanceByUser, walkIns),
-    [goingUsers, attendanceByUser, walkIns]
+    () => computeCheckInSummary(goingUsers, attendanceByUser, guests ?? []),
+    [goingUsers, attendanceByUser, guests]
+  );
+
+  const visibleGoing = useMemo(
+    () => filterGoingUsers(goingUsers, guestsByHost, search),
+    [goingUsers, guestsByHost, search]
+  );
+  const visibleWalkIns = useMemo(
+    () => filterWalkIns(walkIns, search),
+    [walkIns, search]
   );
 
   const isLoading =
@@ -163,6 +201,20 @@ function CheckInPage() {
       router.back();
     } else {
       router.push(`/(user)/leader-tools/${group_id}/events/${eventIdParam}`);
+    }
+  };
+
+  const withGuestPending = async (key: string, action: () => Promise<void>) => {
+    if (pendingGuestKeys.has(key)) return;
+    setPendingGuestKeys((prev) => new Set(prev).add(key));
+    try {
+      await action();
+    } finally {
+      setPendingGuestKeys((prev) => {
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
     }
   };
 
@@ -189,6 +241,53 @@ function CheckInPage() {
     }
   };
 
+  /**
+   * Check a member's guest in. The guest row is created immediately (so the
+   * count moves on the first tap even if the leader never types a name), then
+   * the name sheet opens — names are the point of the feature, but a busy line
+   * can dismiss it and add the name later.
+   */
+  const handleCheckInGuest = async (user: GoingUser, slot: GuestSlot) => {
+    if (!meetingId) return;
+    await withGuestPending(`${user.id}:${slot.position}`, async () => {
+      try {
+        const guestId = await addGuest({
+          meetingId: meetingId as Id<"meetings">,
+          hostUserId: user.id as Id<"users">,
+        });
+        setNamingGuest({
+          guestId: guestId as unknown as string,
+          firstName: "",
+          lastName: "",
+        });
+      } catch (err) {
+        ToastManager.error(
+          err instanceof Error ? err.message : "Couldn't check in guest"
+        );
+      }
+    });
+  };
+
+  const handleRemoveGuest = async (guestId: string) => {
+    await withGuestPending(guestId, async () => {
+      try {
+        await removeGuest({ guestId: guestId as Id<"meetingGuests"> });
+      } catch (err) {
+        ToastManager.error(
+          err instanceof Error ? err.message : "Couldn't remove guest"
+        );
+      }
+    });
+  };
+
+  const handleSaveGuestName = async (guest: NamingGuest) => {
+    await updateGuest({
+      guestId: guest.guestId as Id<"meetingGuests">,
+      firstName: guest.firstName.trim(),
+      lastName: guest.lastName.trim(),
+    });
+  };
+
   const handleAddWalkIn = async (guest: {
     firstName: string;
     lastName?: string;
@@ -203,17 +302,12 @@ function CheckInPage() {
     });
   };
 
-  const handleRemoveWalkIn = async (guestId: string) => {
-    try {
-      await removeGuest({ guestId: guestId as Id<"meetingGuests"> });
-    } catch (err) {
-      ToastManager.error(
-        err instanceof Error ? err.message : "Couldn't remove walk-in"
-      );
-    }
-  };
-
   const rosterIsEmpty = goingUsers.length === 0 && walkIns.length === 0;
+  const searchFoundNothing =
+    !rosterIsEmpty &&
+    search.trim().length > 0 &&
+    visibleGoing.length === 0 &&
+    visibleWalkIns.length === 0;
 
   return (
     <UserRoute>
@@ -249,203 +343,281 @@ function CheckInPage() {
           // Restricted — modal (below) explains and sends them back.
           <View style={styles.loadingContainer} />
         ) : (
-          <ScrollView
-            style={styles.content}
-            contentContainerStyle={styles.contentContainer}
-          >
-            {/* Summary card */}
-            <View
-              style={[styles.summaryCard, { backgroundColor: colors.surface }]}
-            >
-              <Text style={[styles.summaryCount, { color: colors.text }]}>
-                {summary.checkedIn} / {summary.total} checked in
-              </Text>
+          <>
+            {/* Fixed controls. Summary, walk-ins and search stay put so they
+                stay reachable partway down a long roster. */}
+            <View style={styles.controls}>
               <View
-                style={[
-                  styles.progressTrack,
-                  { backgroundColor: colors.backgroundSecondary },
-                ]}
+                style={[styles.summaryCard, { backgroundColor: colors.surface }]}
               >
+                <Text style={[styles.summaryCount, { color: colors.text }]}>
+                  {summary.checkedIn} / {summary.total} checked in
+                </Text>
                 <View
                   style={[
-                    styles.progressFill,
-                    {
-                      backgroundColor: CHECKED_IN_COLOR,
-                      width: `${Math.round(summary.fraction * 100)}%`,
-                    },
+                    styles.progressTrack,
+                    { backgroundColor: colors.backgroundSecondary },
                   ]}
-                />
+                >
+                  <View
+                    style={[
+                      styles.progressFill,
+                      {
+                        backgroundColor: CHECKED_IN_COLOR,
+                        width: `${Math.round(summary.fraction * 100)}%`,
+                      },
+                    ]}
+                  />
+                </View>
               </View>
+
+              <TouchableOpacity
+                style={[
+                  styles.addWalkInButton,
+                  { borderColor: DEFAULT_PRIMARY_COLOR },
+                ]}
+                onPress={() => setShowAddWalkIn(true)}
+              >
+                <Ionicons name="add" size={20} color={DEFAULT_PRIMARY_COLOR} />
+                <Text
+                  style={[styles.addWalkInText, { color: DEFAULT_PRIMARY_COLOR }]}
+                >
+                  Add walk-in
+                </Text>
+              </TouchableOpacity>
+
+              <SearchBar
+                placeholder="Search by name"
+                value={search}
+                onChangeText={setSearch}
+                style={styles.searchBar}
+              />
             </View>
 
-            {/* Going section */}
-            {goingUsers.length > 0 && (
-              <View style={styles.section}>
-                <Text
-                  style={[styles.sectionTitle, { color: colors.textSecondary }]}
-                >
-                  Going ({goingUsers.length})
-                </Text>
-                {goingUsers.map((user) => {
-                  const checkedIn = isCheckedIn(user.id, attendanceByUser);
-                  const pending = pendingUserIds.has(user.id);
-                  const record = attendanceByUser.get(user.id);
-                  return (
-                    <TouchableOpacity
-                      key={user.id}
-                      style={[
-                        styles.userRow,
-                        { backgroundColor: colors.surface },
-                      ]}
-                      onPress={() => handleToggle(user)}
-                      disabled={pending}
-                      accessibilityRole="checkbox"
-                      accessibilityState={{ checked: checkedIn }}
-                      accessibilityLabel={`Check in ${user.firstName ?? ""} ${
-                        user.lastName ?? ""
-                      }`.trim()}
+            <ScrollView
+              style={styles.content}
+              contentContainerStyle={styles.contentContainer}
+              keyboardShouldPersistTaps="handled"
+            >
+              {/* Going section */}
+              {visibleGoing.length > 0 && (
+                <View style={styles.section}>
+                  <Text
+                    style={[styles.sectionTitle, { color: colors.textSecondary }]}
+                  >
+                    Going ({visibleGoing.length})
+                  </Text>
+                  {visibleGoing.map((user) => {
+                    const checkedIn = isCheckedIn(user.id, attendanceByUser);
+                    const pending = pendingUserIds.has(user.id);
+                    const record = attendanceByUser.get(user.id);
+                    const hostedGuests = guestsByHost.get(user.id) ?? [];
+                    const slots = buildGuestSlots(user.guestCount, hostedGuests);
+                    return (
+                      <View key={user.id} style={styles.personBlock}>
+                        <TouchableOpacity
+                          style={[
+                            styles.userRow,
+                            { backgroundColor: colors.surface },
+                          ]}
+                          onPress={() => handleToggle(user)}
+                          disabled={pending}
+                          accessibilityRole="checkbox"
+                          accessibilityState={{ checked: checkedIn }}
+                          accessibilityLabel={`Check in ${fullName(
+                            user.firstName,
+                            user.lastName
+                          )}`}
+                        >
+                          <Avatar
+                            name={fullName(user.firstName, user.lastName)}
+                            imageUrl={user.profileImage}
+                            size={48}
+                          />
+                          <View style={styles.userInfo}>
+                            <Text style={[styles.userName, { color: colors.text }]}>
+                              {user.firstName} {user.lastName}
+                            </Text>
+                            <Text
+                              style={[
+                                styles.userSub,
+                                {
+                                  color: checkedIn
+                                    ? CHECKED_IN_COLOR
+                                    : colors.textSecondary,
+                                },
+                              ]}
+                            >
+                              {checkedIn
+                                ? formatCheckInTime(record?.recordedAt)
+                                : "Tap to check in"}
+                            </Text>
+                          </View>
+                          {pending ? (
+                            <ActivityIndicator
+                              size="small"
+                              color={CHECKED_IN_COLOR}
+                              style={styles.checkControl}
+                            />
+                          ) : checkedIn ? (
+                            <Ionicons
+                              name="checkmark-circle"
+                              size={30}
+                              color={CHECKED_IN_COLOR}
+                              style={styles.checkControl}
+                            />
+                          ) : (
+                            <Ionicons
+                              name="ellipse-outline"
+                              size={30}
+                              color={colors.iconSecondary}
+                              style={styles.checkControl}
+                            />
+                          )}
+                        </TouchableOpacity>
+
+                        {/* Their guests */}
+                        {slots.map((slot) => (
+                          <GuestSlotRow
+                            key={slot.guest?._id ?? `empty-${slot.position}`}
+                            slot={slot}
+                            hostName={fullName(user.firstName, user.lastName)}
+                            pending={pendingGuestKeys.has(
+                              slot.guest?._id ?? `${user.id}:${slot.position}`
+                            )}
+                            onCheckIn={() => handleCheckInGuest(user, slot)}
+                            onRemove={() =>
+                              slot.guest && handleRemoveGuest(slot.guest._id)
+                            }
+                            onEditName={() =>
+                              slot.guest &&
+                              setNamingGuest({
+                                guestId: slot.guest._id,
+                                firstName: slot.guest.firstName ?? "",
+                                lastName: slot.guest.lastName ?? "",
+                              })
+                            }
+                          />
+                        ))}
+
+                        {/* An undeclared extra: someone brought a friend they
+                            didn't RSVP for. Only offered once the member is in,
+                            to keep the unchecked roster clean. */}
+                        {checkedIn && (
+                          <TouchableOpacity
+                            style={styles.addGuestLink}
+                            onPress={() =>
+                              handleCheckInGuest(user, {
+                                position: slots.length + 1,
+                                partySize: slots.length + 1,
+                              })
+                            }
+                            accessibilityRole="button"
+                            accessibilityLabel={`Add a guest for ${fullName(
+                              user.firstName,
+                              user.lastName
+                            )}`}
+                          >
+                            <Ionicons
+                              name="add"
+                              size={16}
+                              color={DEFAULT_PRIMARY_COLOR}
+                            />
+                            <Text
+                              style={[
+                                styles.addGuestLinkText,
+                                { color: DEFAULT_PRIMARY_COLOR },
+                              ]}
+                            >
+                              Add guest
+                            </Text>
+                          </TouchableOpacity>
+                        )}
+                      </View>
+                    );
+                  })}
+                </View>
+              )}
+
+              {/* Walk-ins section */}
+              {visibleWalkIns.length > 0 && (
+                <View style={styles.section}>
+                  <Text
+                    style={[styles.sectionTitle, { color: colors.textSecondary }]}
+                  >
+                    Walk-ins ({visibleWalkIns.length})
+                  </Text>
+                  {visibleWalkIns.map((guest) => (
+                    <View
+                      key={guest._id}
+                      style={[styles.userRow, { backgroundColor: colors.surface }]}
                     >
                       <Avatar
-                        name={`${user.firstName ?? ""} ${user.lastName ?? ""}`}
-                        imageUrl={user.profileImage}
+                        name={fullName(guest.firstName, guest.lastName)}
                         size={48}
                       />
                       <View style={styles.userInfo}>
-                        <Text
-                          style={[styles.userName, { color: colors.text }]}
-                        >
-                          {user.firstName} {user.lastName}
+                        <Text style={[styles.userName, { color: colors.text }]}>
+                          {fullName(guest.firstName, guest.lastName) || "Guest"}
                         </Text>
-                        <Text
-                          style={[
-                            styles.userSub,
-                            {
-                              color: checkedIn
-                                ? CHECKED_IN_COLOR
-                                : colors.textSecondary,
-                            },
-                          ]}
-                        >
-                          {checkedIn
-                            ? formatCheckInTime(record?.recordedAt)
-                            : "Tap to check in"}
+                        <Text style={[styles.userSub, { color: CHECKED_IN_COLOR }]}>
+                          {formatCheckInTime(guest.recordedAt)}
                         </Text>
                       </View>
-                      {pending ? (
-                        <ActivityIndicator
-                          size="small"
-                          color={CHECKED_IN_COLOR}
-                          style={styles.checkControl}
-                        />
-                      ) : checkedIn ? (
-                        <Ionicons
-                          name="checkmark-circle"
-                          size={30}
-                          color={CHECKED_IN_COLOR}
-                          style={styles.checkControl}
-                        />
-                      ) : (
-                        <Ionicons
-                          name="ellipse-outline"
-                          size={30}
-                          color={colors.iconSecondary}
-                          style={styles.checkControl}
-                        />
-                      )}
-                    </TouchableOpacity>
-                  );
-                })}
-              </View>
-            )}
-
-            {/* Walk-ins section */}
-            {walkIns.length > 0 && (
-              <View style={styles.section}>
-                <Text
-                  style={[styles.sectionTitle, { color: colors.textSecondary }]}
-                >
-                  Walk-ins ({walkIns.length})
-                </Text>
-                {walkIns.map((guest) => (
-                  <View
-                    key={guest._id}
-                    style={[styles.userRow, { backgroundColor: colors.surface }]}
-                  >
-                    <Avatar
-                      name={`${guest.firstName ?? ""} ${guest.lastName ?? ""}`}
-                      size={48}
-                    />
-                    <View style={styles.userInfo}>
-                      <Text style={[styles.userName, { color: colors.text }]}>
-                        {guest.firstName} {guest.lastName}
-                      </Text>
-                      <Text
-                        style={[styles.userSub, { color: CHECKED_IN_COLOR }]}
+                      <TouchableOpacity
+                        onPress={() => handleRemoveGuest(guest._id)}
+                        style={styles.checkControl}
+                        accessibilityRole="button"
+                        accessibilityLabel={`Remove walk-in ${fullName(
+                          guest.firstName,
+                          guest.lastName
+                        )}`}
                       >
-                        {formatCheckInTime(guest.recordedAt)}
-                      </Text>
+                        <Ionicons
+                          name="trash-outline"
+                          size={22}
+                          color={colors.iconSecondary}
+                        />
+                      </TouchableOpacity>
                     </View>
-                    <TouchableOpacity
-                      onPress={() => handleRemoveWalkIn(guest._id)}
-                      style={styles.checkControl}
-                      accessibilityRole="button"
-                      accessibilityLabel={`Remove walk-in ${
-                        guest.firstName ?? ""
-                      }`.trim()}
-                    >
-                      <Ionicons
-                        name="trash-outline"
-                        size={22}
-                        color={colors.iconSecondary}
-                      />
-                    </TouchableOpacity>
-                  </View>
-                ))}
-              </View>
-            )}
+                  ))}
+                </View>
+              )}
 
-            {/* Empty state — RSVP disabled or nobody going yet */}
-            {rosterIsEmpty && (
-              <View style={styles.emptyState}>
-                <Ionicons
-                  name="people-outline"
-                  size={48}
-                  color={colors.iconSecondary}
-                />
-                <Text
-                  style={[
-                    styles.emptyStateText,
-                    { color: colors.textSecondary },
-                  ]}
-                >
-                  No one has RSVPed yet. Add walk-ins to take a headcount.
-                </Text>
-              </View>
-            )}
+              {/* No search hits */}
+              {searchFoundNothing && (
+                <View style={styles.emptyState}>
+                  <Ionicons
+                    name="search-outline"
+                    size={48}
+                    color={colors.iconSecondary}
+                  />
+                  <Text
+                    style={[styles.emptyStateText, { color: colors.textSecondary }]}
+                  >
+                    No one matches "{search.trim()}". They may be a walk-in — add
+                    them above.
+                  </Text>
+                </View>
+              )}
 
-            {/* Add walk-in */}
-            <TouchableOpacity
-              style={[
-                styles.addWalkInButton,
-                { borderColor: DEFAULT_PRIMARY_COLOR },
-              ]}
-              onPress={() => setShowAddWalkIn(true)}
-            >
-              <Ionicons
-                name="add"
-                size={20}
-                color={DEFAULT_PRIMARY_COLOR}
-              />
-              <Text
-                style={[
-                  styles.addWalkInText,
-                  { color: DEFAULT_PRIMARY_COLOR },
-                ]}
-              >
-                Add walk-in
-              </Text>
-            </TouchableOpacity>
-          </ScrollView>
+              {/* Empty state — RSVP disabled or nobody going yet */}
+              {rosterIsEmpty && (
+                <View style={styles.emptyState}>
+                  <Ionicons
+                    name="people-outline"
+                    size={48}
+                    color={colors.iconSecondary}
+                  />
+                  <Text
+                    style={[styles.emptyStateText, { color: colors.textSecondary }]}
+                  >
+                    No one has RSVPed yet. Add walk-ins to take a headcount.
+                  </Text>
+                </View>
+              )}
+            </ScrollView>
+          </>
         )}
 
         {/* Add walk-in modal */}
@@ -453,6 +625,13 @@ function CheckInPage() {
           visible={showAddWalkIn}
           onClose={() => setShowAddWalkIn(false)}
           onAdd={handleAddWalkIn}
+        />
+
+        {/* Name a member's guest */}
+        <GuestNameModal
+          guest={namingGuest}
+          onClose={() => setNamingGuest(null)}
+          onSave={handleSaveGuestName}
         />
 
         {/* Restricted access modal */}
@@ -486,6 +665,222 @@ function CheckInPage() {
         </CustomModal>
       </View>
     </UserRoute>
+  );
+}
+
+/**
+ * One plus-one under a member: an empty slot to tap in, or a checked-in guest
+ * whose name can still be filled in. The name area and the check control are
+ * separate targets so editing a name never toggles the guest back out.
+ */
+function GuestSlotRow({
+  slot,
+  hostName,
+  pending,
+  onCheckIn,
+  onRemove,
+  onEditName,
+}: {
+  slot: GuestSlot;
+  hostName: string;
+  pending: boolean;
+  onCheckIn: () => void;
+  onRemove: () => void;
+  onEditName: () => void;
+}) {
+  const { colors } = useTheme();
+  const checkedIn = !!slot.guest;
+  const named = !!fullName(slot.guest?.firstName, slot.guest?.lastName);
+
+  return (
+    <View style={styles.guestRowWrapper}>
+      <View style={[styles.guestConnector, { backgroundColor: colors.border }]} />
+      <View style={[styles.guestRow, { backgroundColor: colors.surface }]}>
+        <TouchableOpacity
+          style={styles.guestLabel}
+          onPress={checkedIn ? onEditName : onCheckIn}
+          disabled={pending}
+          accessibilityRole="button"
+          accessibilityLabel={
+            checkedIn
+              ? `Edit name for ${guestSlotLabel(slot)}, guest of ${hostName}`
+              : `Check in ${guestSlotLabel(slot)} of ${hostName}`
+          }
+        >
+          <Ionicons
+            name="person-outline"
+            size={18}
+            color={colors.iconSecondary}
+          />
+          <View style={styles.guestText}>
+            <Text style={[styles.guestName, { color: colors.text }]}>
+              {guestSlotLabel(slot)}
+            </Text>
+            <Text
+              style={[
+                styles.guestSub,
+                {
+                  color: checkedIn ? CHECKED_IN_COLOR : colors.textSecondary,
+                },
+              ]}
+            >
+              {checkedIn
+                ? named
+                  ? formatCheckInTime(slot.guest?.recordedAt)
+                  : "Checked in · tap to add name"
+                : "Tap to check in"}
+            </Text>
+          </View>
+        </TouchableOpacity>
+
+        {pending ? (
+          <ActivityIndicator
+            size="small"
+            color={CHECKED_IN_COLOR}
+            style={styles.checkControl}
+          />
+        ) : (
+          <TouchableOpacity
+            onPress={checkedIn ? onRemove : onCheckIn}
+            style={styles.checkControl}
+            accessibilityRole="checkbox"
+            accessibilityState={{ checked: checkedIn }}
+            accessibilityLabel={
+              checkedIn
+                ? `Undo check-in for ${guestSlotLabel(slot)}`
+                : `Check in ${guestSlotLabel(slot)}`
+            }
+          >
+            <Ionicons
+              name={checkedIn ? "checkmark-circle" : "ellipse-outline"}
+              size={26}
+              color={checkedIn ? CHECKED_IN_COLOR : colors.iconSecondary}
+            />
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Name (or rename) a guest who has already been checked in. Both fields are
+ * optional — dismissing leaves the guest checked in but unnamed, which is the
+ * right trade when there's a queue at the door.
+ */
+function GuestNameModal({
+  guest,
+  onClose,
+  onSave,
+}: {
+  guest: NamingGuest | null;
+  onClose: () => void;
+  onSave: (guest: NamingGuest) => Promise<void>;
+}) {
+  const { colors } = useTheme();
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  // Re-seed the fields whenever a different guest is opened.
+  React.useEffect(() => {
+    setFirstName(guest?.firstName ?? "");
+    setLastName(guest?.lastName ?? "");
+    setSubmitting(false);
+  }, [guest]);
+
+  const handleSave = async () => {
+    if (!guest || submitting) return;
+    setSubmitting(true);
+    try {
+      await onSave({ ...guest, firstName, lastName });
+      onClose();
+    } catch (err) {
+      setSubmitting(false);
+      ToastManager.error(
+        err instanceof Error ? err.message : "Couldn't save guest name"
+      );
+    }
+  };
+
+  return (
+    <Modal
+      visible={!!guest}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <KeyboardAvoidingView
+        style={styles.modalRoot}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <TouchableOpacity
+          style={styles.modalBackdrop}
+          activeOpacity={1}
+          onPress={onClose}
+        />
+        <View style={[styles.sheet, { backgroundColor: colors.surface }]}>
+          <Text style={[styles.sheetTitle, { color: colors.text }]}>
+            Guest name
+          </Text>
+          <Text style={[styles.sheetSubtitle, { color: colors.textSecondary }]}>
+            They're already checked in — add a name if you have it.
+          </Text>
+
+          <Text style={[styles.inputLabel, { color: colors.textSecondary }]}>
+            First name
+          </Text>
+          <TextInput
+            style={[
+              styles.input,
+              { borderColor: colors.border, color: colors.text },
+            ]}
+            value={firstName}
+            onChangeText={setFirstName}
+            placeholder="First name"
+            placeholderTextColor={colors.textTertiary}
+            autoFocus
+          />
+
+          <Text style={[styles.inputLabel, { color: colors.textSecondary }]}>
+            Last name (optional)
+          </Text>
+          <TextInput
+            style={[
+              styles.input,
+              { borderColor: colors.border, color: colors.text },
+            ]}
+            value={lastName}
+            onChangeText={setLastName}
+            placeholder="Last name"
+            placeholderTextColor={colors.textTertiary}
+            onSubmitEditing={handleSave}
+          />
+
+          <TouchableOpacity
+            style={[
+              styles.sheetButton,
+              { backgroundColor: colors.buttonPrimary },
+            ]}
+            onPress={handleSave}
+            disabled={submitting}
+          >
+            {submitting ? (
+              <ActivityIndicator size="small" color={colors.textInverse} />
+            ) : (
+              <Text
+                style={[styles.sheetButtonText, { color: colors.textInverse }]}
+              >
+                Save name
+              </Text>
+            )}
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.sheetCancel} onPress={onClose}>
+            <Text style={{ color: colors.textSecondary }}>Skip for now</Text>
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
   );
 }
 
@@ -680,16 +1075,21 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
+  controls: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+  },
   content: {
     flex: 1,
   },
   contentContainer: {
-    padding: 16,
+    paddingHorizontal: 16,
+    paddingBottom: 24,
   },
   summaryCard: {
     borderRadius: 12,
     padding: 16,
-    marginBottom: 24,
+    marginBottom: 12,
   },
   summaryCount: {
     fontSize: 20,
@@ -705,6 +1105,9 @@ const styles = StyleSheet.create({
     height: 8,
     borderRadius: 4,
   },
+  searchBar: {
+    marginBottom: 12,
+  },
   section: {
     marginBottom: 24,
   },
@@ -714,12 +1117,14 @@ const styles = StyleSheet.create({
     marginBottom: 12,
     textTransform: "uppercase",
   },
+  personBlock: {
+    marginBottom: 8,
+  },
   userRow: {
     flexDirection: "row",
     alignItems: "center",
     borderRadius: 12,
     padding: 12,
-    marginBottom: 8,
   },
   userInfo: {
     flex: 1,
@@ -735,9 +1140,59 @@ const styles = StyleSheet.create({
   },
   checkControl: {
     marginLeft: 12,
-    minWidth: 30,
+    minWidth: 44,
+    minHeight: 44,
     alignItems: "center",
     justifyContent: "center",
+  },
+  // Guest slots, indented under the member who brought them.
+  guestRowWrapper: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: 4,
+    paddingLeft: 24,
+  },
+  guestConnector: {
+    width: 12,
+    height: 1,
+  },
+  guestRow: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+  },
+  guestLabel: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 4,
+  },
+  guestText: {
+    flex: 1,
+    marginLeft: 10,
+  },
+  guestName: {
+    fontSize: 15,
+    fontWeight: "500",
+  },
+  guestSub: {
+    fontSize: 12,
+    marginTop: 1,
+  },
+  addGuestLink: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    marginTop: 6,
+    paddingLeft: 36,
+    paddingVertical: 6,
+  },
+  addGuestLinkText: {
+    fontSize: 14,
+    fontWeight: "600",
   },
   emptyState: {
     alignItems: "center",
@@ -758,8 +1213,8 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderStyle: "dashed",
     borderRadius: 12,
-    paddingVertical: 14,
-    marginTop: 4,
+    paddingVertical: 12,
+    marginBottom: 12,
   },
   addWalkInText: {
     fontSize: 16,
@@ -801,7 +1256,7 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     color: "#fff",
   },
-  // Add walk-in sheet
+  // Bottom sheets
   modalRoot: {
     flex: 1,
     justifyContent: "flex-end",
@@ -819,6 +1274,11 @@ const styles = StyleSheet.create({
   sheetTitle: {
     fontSize: 20,
     fontWeight: "700",
+    marginBottom: 16,
+  },
+  sheetSubtitle: {
+    fontSize: 14,
+    marginTop: -12,
     marginBottom: 16,
   },
   inputLabel: {

--- a/apps/mobile/app/(user)/leader-tools/[group_id]/events/[event_id]/checkin.tsx
+++ b/apps/mobile/app/(user)/leader-tools/[group_id]/events/[event_id]/checkin.tsx
@@ -10,6 +10,7 @@ import {
   TextInput,
   KeyboardAvoidingView,
   Platform,
+  useWindowDimensions,
 } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
@@ -45,6 +46,25 @@ import {
 } from "@/features/leader-tools/utils/checkIn";
 
 const CHECKED_IN_COLOR = "#10B981"; // green-500
+
+/** Widest the content grows to before it stops stretching and centres. */
+const MAX_CONTENT_WIDTH = 1280;
+/** Gutter between roster columns; halved as padding on each column. */
+const COLUMN_GUTTER = 12;
+
+/**
+ * How many roster columns fit the current window.
+ *
+ * Phones (and any narrow window) always get 1, so native rendering is exactly
+ * as it was. Wider windows — the app also runs on the web — get 2 or 3, since a
+ * door list is far more useful when you can see more of it at once than when
+ * one phone-width column is stretched across a desktop.
+ */
+function rosterColumns(width: number): number {
+  if (width >= 1400) return 3;
+  if (width >= 900) return 2;
+  return 1;
+}
 
 function formatCheckInTime(recordedAt?: number): string {
   if (!recordedAt) return "Checked in";
@@ -152,6 +172,22 @@ function CheckInPage() {
   const [showAddWalkIn, setShowAddWalkIn] = useState(false);
   const [namingGuest, setNamingGuest] = useState<NamingGuest | null>(null);
   const [search, setSearch] = useState("");
+
+  const { width } = useWindowDimensions();
+  const columns = rosterColumns(width);
+  const isWide = columns > 1;
+  // Column sizing for the wrapping roster grid. RN has no `calc()`, so the
+  // gutter is padding inside each column, cancelled by a negative margin on the
+  // row — the standard flexbox gutter trick.
+  const columnStyle = isWide
+    ? {
+        width: `${100 / columns}%` as const,
+        paddingHorizontal: COLUMN_GUTTER / 2,
+      }
+    : null;
+  const gridStyle = isWide
+    ? { ...styles.grid, marginHorizontal: -COLUMN_GUTTER / 2 }
+    : null;
 
   const goingUsers: GoingUser[] = useMemo(
     () => goingRoster ?? [],
@@ -345,10 +381,15 @@ function CheckInPage() {
         ) : (
           <>
             {/* Fixed controls. Summary, walk-ins and search stay put so they
-                stay reachable partway down a long roster. */}
-            <View style={styles.controls}>
+                stay reachable partway down a long roster. On a wide window they
+                sit on one row rather than eating three rows of height. */}
+            <View style={[styles.controls, isWide && styles.controlsRow]}>
               <View
-                style={[styles.summaryCard, { backgroundColor: colors.surface }]}
+                style={[
+                  styles.summaryCard,
+                  { backgroundColor: colors.surface },
+                  isWide && styles.summaryCardWide,
+                ]}
               >
                 <Text style={[styles.summaryCount, { color: colors.text }]}>
                   {summary.checkedIn} / {summary.total} checked in
@@ -375,6 +416,7 @@ function CheckInPage() {
                 style={[
                   styles.addWalkInButton,
                   { borderColor: DEFAULT_PRIMARY_COLOR },
+                  isWide && styles.addWalkInButtonWide,
                 ]}
                 onPress={() => setShowAddWalkIn(true)}
               >
@@ -390,7 +432,7 @@ function CheckInPage() {
                 placeholder="Search by name"
                 value={search}
                 onChangeText={setSearch}
-                style={styles.searchBar}
+                style={[styles.searchBar, isWide && styles.searchBarWide]}
               />
             </View>
 
@@ -407,6 +449,7 @@ function CheckInPage() {
                   >
                     Going ({visibleGoing.length})
                   </Text>
+                  <View style={gridStyle}>
                   {visibleGoing.map((user) => {
                     const checkedIn = isCheckedIn(user.id, attendanceByUser);
                     const pending = pendingUserIds.has(user.id);
@@ -414,7 +457,10 @@ function CheckInPage() {
                     const hostedGuests = guestsByHost.get(user.id) ?? [];
                     const slots = buildGuestSlots(user.guestCount, hostedGuests);
                     return (
-                      <View key={user.id} style={styles.personBlock}>
+                      <View
+                        key={user.id}
+                        style={[styles.personBlock, columnStyle]}
+                      >
                         <TouchableOpacity
                           style={[
                             styles.userRow,
@@ -536,6 +582,7 @@ function CheckInPage() {
                       </View>
                     );
                   })}
+                  </View>
                 </View>
               )}
 
@@ -547,40 +594,57 @@ function CheckInPage() {
                   >
                     Walk-ins ({visibleWalkIns.length})
                   </Text>
-                  {visibleWalkIns.map((guest) => (
-                    <View
-                      key={guest._id}
-                      style={[styles.userRow, { backgroundColor: colors.surface }]}
-                    >
-                      <Avatar
-                        name={fullName(guest.firstName, guest.lastName)}
-                        size={48}
-                      />
-                      <View style={styles.userInfo}>
-                        <Text style={[styles.userName, { color: colors.text }]}>
-                          {fullName(guest.firstName, guest.lastName) || "Guest"}
-                        </Text>
-                        <Text style={[styles.userSub, { color: CHECKED_IN_COLOR }]}>
-                          {formatCheckInTime(guest.recordedAt)}
-                        </Text>
-                      </View>
-                      <TouchableOpacity
-                        onPress={() => handleRemoveGuest(guest._id)}
-                        style={styles.checkControl}
-                        accessibilityRole="button"
-                        accessibilityLabel={`Remove walk-in ${fullName(
-                          guest.firstName,
-                          guest.lastName
-                        )}`}
+                  <View style={gridStyle}>
+                    {visibleWalkIns.map((guest) => (
+                      <View
+                        key={guest._id}
+                        style={[styles.personBlock, columnStyle]}
                       >
-                        <Ionicons
-                          name="trash-outline"
-                          size={22}
-                          color={colors.iconSecondary}
-                        />
-                      </TouchableOpacity>
-                    </View>
-                  ))}
+                        <View
+                          style={[
+                            styles.userRow,
+                            { backgroundColor: colors.surface },
+                          ]}
+                        >
+                          <Avatar
+                            name={fullName(guest.firstName, guest.lastName)}
+                            size={48}
+                          />
+                          <View style={styles.userInfo}>
+                            <Text
+                              style={[styles.userName, { color: colors.text }]}
+                            >
+                              {fullName(guest.firstName, guest.lastName) ||
+                                "Guest"}
+                            </Text>
+                            <Text
+                              style={[
+                                styles.userSub,
+                                { color: CHECKED_IN_COLOR },
+                              ]}
+                            >
+                              {formatCheckInTime(guest.recordedAt)}
+                            </Text>
+                          </View>
+                          <TouchableOpacity
+                            onPress={() => handleRemoveGuest(guest._id)}
+                            style={styles.checkControl}
+                            accessibilityRole="button"
+                            accessibilityLabel={`Remove walk-in ${fullName(
+                              guest.firstName,
+                              guest.lastName
+                            )}`}
+                          >
+                            <Ionicons
+                              name="trash-outline"
+                              size={22}
+                              color={colors.iconSecondary}
+                            />
+                          </TouchableOpacity>
+                        </View>
+                      </View>
+                    ))}
+                  </View>
                 </View>
               )}
 
@@ -1078,18 +1142,40 @@ const styles = StyleSheet.create({
   controls: {
     paddingHorizontal: 16,
     paddingTop: 16,
+    width: "100%",
+    maxWidth: MAX_CONTENT_WIDTH,
+    alignSelf: "center",
+  },
+  // Wide windows: summary, Add walk-in and search share one row.
+  controlsRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
   },
   content: {
     flex: 1,
+    width: "100%",
+    maxWidth: MAX_CONTENT_WIDTH,
+    alignSelf: "center",
   },
   contentContainer: {
     paddingHorizontal: 16,
     paddingBottom: 24,
   },
+  // Wrapping roster grid; the negative margin cancels each column's gutter.
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "flex-start",
+  },
   summaryCard: {
     borderRadius: 12,
     padding: 16,
     marginBottom: 12,
+  },
+  summaryCardWide: {
+    flex: 2,
+    marginBottom: 0,
   },
   summaryCount: {
     fontSize: 20,
@@ -1107,6 +1193,10 @@ const styles = StyleSheet.create({
   },
   searchBar: {
     marginBottom: 12,
+  },
+  searchBarWide: {
+    flex: 3,
+    marginBottom: 0,
   },
   section: {
     marginBottom: 24,
@@ -1215,6 +1305,11 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     paddingVertical: 12,
     marginBottom: 12,
+  },
+  addWalkInButtonWide: {
+    flex: 1,
+    minWidth: 150,
+    marginBottom: 0,
   },
   addWalkInText: {
     fontSize: 16,

--- a/apps/mobile/features/leader-tools/utils/__tests__/checkIn.test.ts
+++ b/apps/mobile/features/leader-tools/utils/__tests__/checkIn.test.ts
@@ -1,7 +1,13 @@
 import {
+  buildGuestSlots,
   computeCheckInSummary,
+  filterGoingUsers,
+  filterWalkIns,
+  guestSlotLabel,
   indexAttendanceByUser,
   isCheckedIn,
+  nameMatchesQuery,
+  partitionGuests,
   resolveAttendanceEntry,
   ATTENDANCE_PRESENT,
   ATTENDANCE_ABSENT,
@@ -15,6 +21,15 @@ const going = (id: string): GoingUser => ({
   firstName: "F",
   lastName: id,
 });
+
+const present = (...userIds: string[]) =>
+  indexAttendanceByUser(
+    userIds.map((userId) => ({
+      userId,
+      status: ATTENDANCE_PRESENT,
+      recordedAt: 1,
+    }))
+  );
 
 describe("indexAttendanceByUser", () => {
   it("keeps the most recently recorded status per user", () => {
@@ -90,6 +105,154 @@ describe("computeCheckInSummary — live count", () => {
     expect(summary.checkedIn).toBe(3);
     expect(summary.total).toBe(3);
     expect(summary.fraction).toBe(1);
+  });
+});
+
+describe("partitionGuests — plus-ones vs. unattached walk-ins", () => {
+  it("nests guests under the member who brought them", () => {
+    const guests: WalkInLike[] = [
+      { _id: "g1", hostUserId: "u1", recordedAt: 20 },
+      { _id: "g2", hostUserId: "u1", recordedAt: 10 },
+      { _id: "g3", firstName: "Solo" },
+    ];
+    const { guestsByHost, walkIns } = partitionGuests([going("u1")], guests);
+    // Sorted by recordedAt so a slot never jumps position as names fill in.
+    expect(guestsByHost.get("u1")?.map((g) => g._id)).toEqual(["g2", "g1"]);
+    expect(walkIns.map((g) => g._id)).toEqual(["g3"]);
+  });
+
+  it("keeps a guest visible as a walk-in when their host is no longer Going", () => {
+    const guests: WalkInLike[] = [{ _id: "g1", hostUserId: "gone" }];
+    const { guestsByHost, walkIns } = partitionGuests([going("u1")], guests);
+    expect(guestsByHost.size).toBe(0);
+    expect(walkIns.map((g) => g._id)).toEqual(["g1"]);
+  });
+});
+
+describe("buildGuestSlots", () => {
+  it("offers one slot per declared plus-one, filled in order", () => {
+    const slots = buildGuestSlots(2, [{ _id: "g1", firstName: "Ada" }]);
+    expect(slots).toHaveLength(2);
+    expect(slots[0]).toMatchObject({ position: 1, partySize: 2 });
+    expect(slots[0].guest?._id).toBe("g1");
+    expect(slots[1].guest).toBeUndefined();
+  });
+
+  it("grows past the declared count when more people actually turn up", () => {
+    const slots = buildGuestSlots(1, [{ _id: "g1" }, { _id: "g2" }]);
+    expect(slots).toHaveLength(2);
+    expect(slots.every((s) => s.partySize === 2)).toBe(true);
+  });
+
+  it("has no slots when no guests were declared or added", () => {
+    expect(buildGuestSlots(0, [])).toEqual([]);
+    expect(buildGuestSlots(undefined, [])).toEqual([]);
+    expect(buildGuestSlots(-3, [])).toEqual([]);
+  });
+});
+
+describe("guestSlotLabel", () => {
+  it("uses the guest's name once it has been captured", () => {
+    const [slot] = buildGuestSlots(1, [
+      { _id: "g1", firstName: "Ada", lastName: "Lovelace" },
+    ]);
+    expect(guestSlotLabel(slot)).toBe("Ada Lovelace");
+  });
+
+  it("falls back to the position while the guest is unnamed", () => {
+    const slots = buildGuestSlots(2, []);
+    expect(guestSlotLabel(slots[0])).toBe("Guest 1 of 2");
+    expect(guestSlotLabel(slots[1])).toBe("Guest 2 of 2");
+    expect(guestSlotLabel(buildGuestSlots(1, [])[0])).toBe("Guest");
+  });
+});
+
+describe("search", () => {
+  it("matches on first, last, or full name, case-insensitively", () => {
+    expect(nameMatchesQuery("bri", "Brittany", "Smigielski")).toBe(true);
+    expect(nameMatchesQuery("SMIG", "Brittany", "Smigielski")).toBe(true);
+    expect(nameMatchesQuery("brittany smig", "Brittany", "Smigielski")).toBe(
+      true
+    );
+    expect(nameMatchesQuery("kevin", "Brittany", "Smigielski")).toBe(false);
+  });
+
+  it("matches everyone on an empty or whitespace query", () => {
+    expect(nameMatchesQuery("", "Amy", "Perez")).toBe(true);
+    expect(nameMatchesQuery("   ", "Amy", "Perez")).toBe(true);
+  });
+
+  it("filters the Going roster by name", () => {
+    const users: GoingUser[] = [
+      { id: "u1", firstName: "Amy", lastName: "Perez" },
+      { id: "u2", firstName: "Kevin", lastName: "Myers" },
+    ];
+    expect(filterGoingUsers(users, new Map(), "myer").map((u) => u.id)).toEqual(
+      ["u2"]
+    );
+    expect(filterGoingUsers(users, new Map(), "")).toHaveLength(2);
+  });
+
+  it("surfaces the host when a guest's name matches", () => {
+    const users: GoingUser[] = [
+      { id: "u1", firstName: "Amy", lastName: "Perez" },
+    ];
+    const guestsByHost = new Map<string, WalkInLike[]>([
+      ["u1", [{ _id: "g1", firstName: "Ada" }]],
+    ]);
+    expect(filterGoingUsers(users, guestsByHost, "ada").map((u) => u.id)).toEqual(
+      ["u1"]
+    );
+  });
+
+  it("filters walk-ins by name", () => {
+    const walkIns: WalkInLike[] = [
+      { _id: "g1", firstName: "Ada" },
+      { _id: "g2", firstName: "Ben" },
+    ];
+    expect(filterWalkIns(walkIns, "be").map((g) => g._id)).toEqual(["g2"]);
+  });
+});
+
+describe("computeCheckInSummary — plus-ones", () => {
+  it("counts declared plus-ones toward the expected headcount", () => {
+    const users: GoingUser[] = [
+      { id: "u1", guestCount: 2 },
+      { id: "u2", guestCount: 0 },
+    ];
+    // Nobody tapped in yet: 2 members + 2 declared guests are all expected.
+    const summary = computeCheckInSummary(users, new Map(), []);
+    expect(summary).toEqual({ checkedIn: 0, total: 4, fraction: 0 });
+  });
+
+  it("counts a checked-in guest toward the count without changing the total", () => {
+    const users: GoingUser[] = [{ id: "u1", guestCount: 2 }];
+    const summary = computeCheckInSummary(users, present("u1"), [
+      { _id: "g1", hostUserId: "u1" },
+    ]);
+    // Member + 1 of 2 guests in; total stays 3 (member + 2 declared).
+    expect(summary.checkedIn).toBe(2);
+    expect(summary.total).toBe(3);
+  });
+
+  it("grows the total when a member brings more guests than declared", () => {
+    const users: GoingUser[] = [{ id: "u1", guestCount: 1 }];
+    const summary = computeCheckInSummary(users, present("u1"), [
+      { _id: "g1", hostUserId: "u1" },
+      { _id: "g2", hostUserId: "u1" },
+    ]);
+    expect(summary.checkedIn).toBe(3);
+    expect(summary.total).toBe(3);
+    expect(summary.fraction).toBe(1);
+  });
+
+  it("still counts a guest whose host is no longer on the Going roster", () => {
+    const summary = computeCheckInSummary([going("u1")], new Map(), [
+      { _id: "g1", hostUserId: "someone-who-left" },
+    ]);
+    // Falls back to a walk-in: checked in, and part of the total.
+    expect(summary.checkedIn).toBe(1);
+    expect(summary.total).toBe(2);
   });
 });
 

--- a/apps/mobile/features/leader-tools/utils/checkIn.ts
+++ b/apps/mobile/features/leader-tools/utils/checkIn.ts
@@ -57,6 +57,11 @@ export interface GoingUser {
   firstName?: string | null;
   lastName?: string | null;
   profileImage?: string | null;
+  /**
+   * Plus-ones this person declared when they RSVPed (`meetingRsvps.guestCount`).
+   * Drives how many guest slots the check-in screen offers under their row.
+   */
+  guestCount?: number | null;
 }
 
 /** An attendance record as returned by listAttendance (only fields we read). */
@@ -66,12 +71,18 @@ export interface AttendanceLike {
   recordedAt?: number;
 }
 
-/** A walk-in guest as returned by listGuests (only fields we read). */
+/** A guest as returned by listGuests (only fields we read). */
 export interface WalkInLike {
   _id: string;
   firstName?: string | null;
   lastName?: string | null;
   recordedAt?: number;
+  /**
+   * The member who brought this guest (`meetingGuests.hostUserId`). Set for
+   * plus-ones checked in under someone on the Going roster; absent for
+   * unattached walk-ins.
+   */
+  hostUserId?: string | null;
 }
 
 /**
@@ -100,10 +111,138 @@ export function isCheckedIn(
   return attendanceByUser.get(userId)?.status === ATTENDANCE_PRESENT;
 }
 
+/**
+ * Split the meeting's guest rows into plus-ones (nested under the member who
+ * brought them) and unattached walk-ins (their own section).
+ *
+ * A guest whose `hostUserId` is not on the Going roster — the host switched
+ * their RSVP away from Going after the guest was checked in — is deliberately
+ * treated as an unattached walk-in rather than dropped, so a checked-in person
+ * can never vanish from the screen or the headcount.
+ */
+export function partitionGuests(
+  goingUsers: readonly GoingUser[],
+  guests: readonly WalkInLike[]
+): { guestsByHost: Map<string, WalkInLike[]>; walkIns: WalkInLike[] } {
+  const hostIds = new Set(goingUsers.map((u) => u.id));
+  const guestsByHost = new Map<string, WalkInLike[]>();
+  const walkIns: WalkInLike[] = [];
+
+  for (const guest of guests) {
+    const hostId = guest.hostUserId;
+    if (hostId && hostIds.has(hostId)) {
+      const existing = guestsByHost.get(hostId);
+      if (existing) {
+        existing.push(guest);
+      } else {
+        guestsByHost.set(hostId, [guest]);
+      }
+    } else {
+      walkIns.push(guest);
+    }
+  }
+
+  // Stable order so a slot doesn't jump position as names are filled in.
+  for (const list of guestsByHost.values()) {
+    list.sort((a, b) => (a.recordedAt ?? 0) - (b.recordedAt ?? 0));
+  }
+
+  return { guestsByHost, walkIns };
+}
+
+/** One plus-one position under a member: filled (checked in) or still empty. */
+export interface GuestSlot {
+  /** 1-based position within the member's party ("Guest 2 of 3"). */
+  position: number;
+  /** How many slots this member shows in total. */
+  partySize: number;
+  /** The persisted guest row once checked in; undefined while the slot is empty. */
+  guest?: WalkInLike;
+}
+
+/**
+ * Build the guest slots shown under a member.
+ *
+ * Slots come from the plus-ones they declared at RSVP, but a member who turns
+ * up with more people than they declared must still be checkable — so the count
+ * grows to fit whoever is actually checked in.
+ */
+export function buildGuestSlots(
+  declaredCount: number | null | undefined,
+  checkedInGuests: readonly WalkInLike[]
+): GuestSlot[] {
+  const declared = Math.max(0, Math.floor(declaredCount ?? 0));
+  const partySize = Math.max(declared, checkedInGuests.length);
+  return Array.from({ length: partySize }, (_, i) => ({
+    position: i + 1,
+    partySize,
+    guest: checkedInGuests[i],
+  }));
+}
+
+/** Full name, or "" when neither part is set. */
+export function fullName(
+  firstName?: string | null,
+  lastName?: string | null
+): string {
+  return `${firstName ?? ""} ${lastName ?? ""}`.replace(/\s+/g, " ").trim();
+}
+
+/** What a guest slot is labelled — their name once known, else the position. */
+export function guestSlotLabel(slot: GuestSlot): string {
+  const name = fullName(slot.guest?.firstName, slot.guest?.lastName);
+  if (name) return name;
+  return slot.partySize > 1
+    ? `Guest ${slot.position} of ${slot.partySize}`
+    : "Guest";
+}
+
+/** Case-insensitive "does this name contain the query" test. Empty query matches. */
+export function nameMatchesQuery(
+  query: string,
+  firstName?: string | null,
+  lastName?: string | null
+): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+  return fullName(firstName, lastName).toLowerCase().includes(needle);
+}
+
+/**
+ * Filter the Going roster by the search box. A member also matches when one of
+ * their named guests does — searching a guest's name should surface the row
+ * that guest is checked in under, not hide it.
+ */
+export function filterGoingUsers(
+  goingUsers: readonly GoingUser[],
+  guestsByHost: Map<string, WalkInLike[]>,
+  query: string
+): GoingUser[] {
+  if (!query.trim()) return [...goingUsers];
+  return goingUsers.filter(
+    (user) =>
+      nameMatchesQuery(query, user.firstName, user.lastName) ||
+      (guestsByHost.get(user.id) ?? []).some((g) =>
+        nameMatchesQuery(query, g.firstName, g.lastName)
+      )
+  );
+}
+
+/** Filter unattached walk-ins by the search box. */
+export function filterWalkIns(
+  walkIns: readonly WalkInLike[],
+  query: string
+): WalkInLike[] {
+  if (!query.trim()) return [...walkIns];
+  return walkIns.filter((g) =>
+    nameMatchesQuery(query, g.firstName, g.lastName)
+  );
+}
+
 export interface CheckInSummary {
-  /** How many people on the roster are checked in (Present Going + walk-ins). */
+  /** How many people are checked in (Present Going + their guests + walk-ins). */
   checkedIn: number;
-  /** Total roster size (everyone Going + walk-ins). */
+  /** Expected headcount (everyone Going + their declared plus-ones + walk-ins). */
   total: number;
   /** checkedIn / total, clamped to [0, 1]; 0 when the roster is empty. */
   fraction: number;
@@ -112,21 +251,31 @@ export interface CheckInSummary {
 /**
  * Compute the live "N / M checked in" summary.
  *
- * The roster is everyone who RSVPed Going plus any walk-ins. A Going person
- * counts as checked in when their attendance status is Present; walk-ins are
- * added already-present, so every walk-in counts toward both N and M.
+ * The roster is everyone who RSVPed Going, the plus-ones they declared, and any
+ * walk-ins. A Going person counts as checked in when their attendance status is
+ * Present; guests and walk-ins exist as rows only once checked in, so each
+ * counts toward both N and M — while an *un*checked declared plus-one still
+ * counts toward M, because the venue is expecting them.
  */
 export function computeCheckInSummary(
   goingUsers: readonly GoingUser[],
   attendanceByUser: Map<string, AttendanceLike>,
-  walkIns: readonly WalkInLike[]
+  guests: readonly WalkInLike[]
 ): CheckInSummary {
-  const goingCheckedIn = goingUsers.reduce(
-    (n, u) => (isCheckedIn(u.id, attendanceByUser) ? n + 1 : n),
-    0
-  );
-  const checkedIn = goingCheckedIn + walkIns.length;
-  const total = goingUsers.length + walkIns.length;
+  const { guestsByHost, walkIns } = partitionGuests(goingUsers, guests);
+
+  let checkedIn = walkIns.length;
+  let total = walkIns.length;
+
+  for (const user of goingUsers) {
+    total += 1;
+    if (isCheckedIn(user.id, attendanceByUser)) checkedIn += 1;
+
+    const hosted = guestsByHost.get(user.id) ?? [];
+    checkedIn += hosted.length;
+    total += buildGuestSlots(user.guestCount, hosted).length;
+  }
+
   const fraction = total === 0 ? 0 : Math.min(1, Math.max(0, checkedIn / total));
   return { checkedIn, total, fraction };
 }

--- a/apps/web/src/pages/guides/Events.tsx
+++ b/apps/web/src/pages/guides/Events.tsx
@@ -124,9 +124,11 @@ export function Events() {
           <Step n={6}>
             <strong>Check-in at the door.</strong> On the day, open the event
             and tap <Term>Check in</Term> to run down the <Term>Going</Term>{" "}
-            list, tapping each person as they arrive. Added names count as{" "}
-            <Term>Present</Term> in your attendance numbers, and walk-ins
-            without an account can be added by name. Once the event has wrapped,
+            list, tapping each person — and each guest they brought — as they
+            arrive. Added names count as <Term>Present</Term> in your attendance
+            numbers, and walk-ins without an account can be added by name. You
+            can search the list by name instead of scrolling it. Once the event
+            has wrapped,
             that same button becomes <Term>Take attendance</Term> and opens the
             full attendance editor for after-the-fact corrections. See{" "}
             <em>Check in: take attendance at the door</em> below.
@@ -179,10 +181,12 @@ export function Events() {
           <em>this</em> event. Open the event and tap <Term>Check in</Term>{" "}
           (the button sits with the other manager actions and only shows for
           people who can manage the event). You'll see everyone who RSVP'd{" "}
-          <Term>Going</Term>, each with a tap-to-check circle and a live{" "}
-          <Term>N / M checked in</Term> count at the top. After the event has
-          passed, the same button reads <Term>Take attendance</Term> and opens
-          the full attendance editor instead.
+          <Term>Going</Term> — along with any guests they said they were
+          bringing — each with a tap-to-check circle, plus a live{" "}
+          <Term>N / M checked in</Term> count, <Term>Add walk-in</Term>, and a
+          search box pinned at the top. After the event has passed, the same
+          button reads <Term>Take attendance</Term> and opens the full
+          attendance editor instead.
         </P>
 
         <Steps>
@@ -193,16 +197,39 @@ export function Events() {
             in on their own phone sees the same list update live.
           </Step>
           <Step n={2}>
-            <strong>Walk-ins.</strong> Someone showed up who didn't RSVP — or
-            doesn't have a Togather account? Tap <Term>Add walk-in</Term>,
-            enter a first name (last name and phone are optional), and they're
-            added already checked in. Added by mistake? Remove them with the
-            trash icon.
+            <strong>Search for a name.</strong> A big event is a long list, so
+            the <Term>Search by name</Term> box at the top filters the roster as
+            you type — first name, last name, or both. Guest names are searched
+            too, so looking up a guest surfaces the member who brought them.
+            The <Term>N / M checked in</Term> count always covers the whole
+            event, not just what the search is showing.
           </Step>
           <Step n={3}>
+            <strong>Their guests.</strong> When someone RSVP'd{" "}
+            <Term>Going</Term> with plus-ones, those show up as their own rows
+            tucked under that person — <Term>Guest 1 of 2</Term>,{" "}
+            <Term>Guest 2 of 2</Term> — each with its own check circle, so you
+            count who actually walked in rather than assuming the whole party
+            came. Checking a guest in opens a quick <Term>Guest name</Term>{" "}
+            sheet: type the name if you have it, or tap <Term>Skip for now</Term>{" "}
+            and add it later by tapping the row. Someone brought a friend they
+            never RSVP'd for? <Term>Add guest</Term> under the member adds an
+            extra one.
+          </Step>
+          <Step n={4}>
+            <strong>Walk-ins.</strong> Someone showed up who didn't RSVP — or
+            doesn't have a Togather account? Tap <Term>Add walk-in</Term> at the
+            top of the screen, enter a first name (last name and phone are
+            optional), and they're added already checked in. Added by mistake?
+            Remove them with the trash icon.
+          </Step>
+          <Step n={5}>
             <strong>It feeds your numbers.</strong> A check-in is the same{" "}
             <Term>Present</Term> record the app already uses, so attendance and
             member-health stats stay correct — you're not tracking it twice.
+            Declared plus-ones count toward the expected headcount from the
+            start, so <Term>N / M</Term> tells you how much of the room you're
+            still waiting on.
           </Step>
         </Steps>
 
@@ -215,7 +242,7 @@ export function Events() {
           </p>
         </Callout>
 
-        <Figure caption="The Check-in screen: a live checked-in count, the Going list with tap-to-check circles, and Add walk-in. Rendered mock — labels match the real screen.">
+        <Figure caption="The Check-in screen: a live checked-in count, Add walk-in and search pinned at the top, then the Going list with tap-to-check circles and each person's guests nested underneath. Rendered mock — labels match the real screen.">
           {/* swap-in: <img src="/images/guides/events-checkin.png" /> */}
           <CheckInMock />
         </Figure>
@@ -314,28 +341,65 @@ function ToggleOn() {
 }
 
 /**
- * Check-in screen — mirrors the real screen: a summary card with the live
- * "N / M checked in" count and progress bar, the Going list with tap-to-check
- * circles (filled green = checked in, empty = not yet), a Walk-ins row, and the
- * dashed "Add walk-in" button.
+ * Check-in screen — mirrors the real screen: the pinned controls (summary card
+ * with the live "N / M checked in" count and progress bar, the dashed "Add
+ * walk-in" button, and the search box), then the Going list with tap-to-check
+ * circles (filled green = checked in, empty = not yet), each member's guest
+ * slots nested underneath, and the Walk-ins section.
  */
 function CheckInMock() {
   const going = [
-    { name: "Gina Going", initials: "GG", color: "bg-primary-400", checkedIn: true, time: "6:58 PM" },
-    { name: "Mel Member", initials: "MM", color: "bg-accent-500", checkedIn: true, time: "7:01 PM" },
-    { name: "Sam Rivera", initials: "SR", color: "bg-amber-500", checkedIn: false, time: null },
+    {
+      name: "Gina Going",
+      initials: "GG",
+      color: "bg-primary-400",
+      checkedIn: true,
+      time: "6:58 PM",
+      // Gina RSVP'd with two plus-ones; one is in and named, one hasn't arrived.
+      guests: [
+        { label: "Ada Lovelace", checkedIn: true, sub: "Checked in · 7:00 PM" },
+        { label: "Guest 2 of 2", checkedIn: false, sub: "Tap to check in" },
+      ],
+    },
+    {
+      name: "Mel Member",
+      initials: "MM",
+      color: "bg-accent-500",
+      checkedIn: true,
+      time: "7:01 PM",
+      guests: [
+        { label: "Guest", checkedIn: true, sub: "Checked in · tap to add name" },
+      ],
+    },
+    {
+      name: "Sam Rivera",
+      initials: "SR",
+      color: "bg-amber-500",
+      checkedIn: false,
+      time: null,
+      guests: [],
+    },
   ];
   return (
     <PhoneFrame title="Check in">
       <div className="bg-neutral-50 p-3">
-        {/* Summary card. */}
+        {/* Pinned controls: summary, Add walk-in, search. */}
         <div className="rounded-xl bg-white p-3.5 shadow-sm">
           <div className="text-[17px] font-bold text-neutral-900">
-            3 / 4 checked in
+            5 / 7 checked in
           </div>
           <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-neutral-100">
-            <div className="h-2 rounded-full bg-emerald-500" style={{ width: "75%" }} />
+            <div className="h-2 rounded-full bg-emerald-500" style={{ width: "71%" }} />
           </div>
+        </div>
+
+        <div className="mt-3 flex items-center justify-center gap-1.5 rounded-xl border border-dashed border-primary-400 py-2.5 text-[14px] font-semibold text-primary-600">
+          <span className="text-[16px] leading-none">＋</span> Add walk-in
+        </div>
+
+        <div className="mt-3 flex items-center gap-2 rounded-xl border-2 border-neutral-200 bg-neutral-100 px-3 py-2.5">
+          <span className="text-[13px] leading-none text-neutral-400">🔍</span>
+          <span className="text-[13px] text-neutral-400">Search by name</span>
         </div>
 
         {/* Going list. */}
@@ -344,20 +408,50 @@ function CheckInMock() {
         </div>
         <div className="mt-2 space-y-2">
           {going.map((p) => (
-            <div key={p.name} className="flex items-center gap-3 rounded-xl bg-white p-3 shadow-sm">
-              <span className={`inline-flex h-9 w-9 items-center justify-center rounded-full ${p.color} text-[11px] font-semibold text-white`}>
-                {p.initials}
-              </span>
-              <div className="flex-1">
-                <div className="text-[14px] font-semibold text-neutral-900">{p.name}</div>
-                <div className={`text-[12px] ${p.checkedIn ? "text-emerald-600" : "text-neutral-500"}`}>
-                  {p.checkedIn ? `Checked in · ${p.time}` : "Tap to check in"}
+            <div key={p.name}>
+              <div className="flex items-center gap-3 rounded-xl bg-white p-3 shadow-sm">
+                <span className={`inline-flex h-9 w-9 items-center justify-center rounded-full ${p.color} text-[11px] font-semibold text-white`}>
+                  {p.initials}
+                </span>
+                <div className="flex-1">
+                  <div className="text-[14px] font-semibold text-neutral-900">{p.name}</div>
+                  <div className={`text-[12px] ${p.checkedIn ? "text-emerald-600" : "text-neutral-500"}`}>
+                    {p.checkedIn ? `Checked in · ${p.time}` : "Tap to check in"}
+                  </div>
                 </div>
+                {p.checkedIn ? (
+                  <span className="text-[22px] leading-none text-emerald-500">✅</span>
+                ) : (
+                  <span className="inline-block h-[22px] w-[22px] rounded-full border-2 border-neutral-300" />
+                )}
               </div>
-              {p.checkedIn ? (
-                <span className="text-[22px] leading-none text-emerald-500">✅</span>
-              ) : (
-                <span className="inline-block h-[22px] w-[22px] rounded-full border-2 border-neutral-300" />
+
+              {/* Their guests, indented under them. */}
+              {p.guests.map((g) => (
+                <div key={g.label} className="mt-1 flex items-center pl-6">
+                  <span className="h-px w-3 bg-neutral-200" />
+                  <div className="flex flex-1 items-center gap-2.5 rounded-lg bg-white px-3 py-2 shadow-sm">
+                    <span className="text-[13px] leading-none text-neutral-400">👤</span>
+                    <div className="flex-1">
+                      <div className="text-[13px] font-medium text-neutral-900">{g.label}</div>
+                      <div className={`text-[11px] ${g.checkedIn ? "text-emerald-600" : "text-neutral-500"}`}>
+                        {g.sub}
+                      </div>
+                    </div>
+                    {g.checkedIn ? (
+                      <span className="text-[18px] leading-none text-emerald-500">✅</span>
+                    ) : (
+                      <span className="inline-block h-[18px] w-[18px] rounded-full border-2 border-neutral-300" />
+                    )}
+                  </div>
+                </div>
+              ))}
+
+              {/* Undeclared extra, offered once the member is in. */}
+              {p.checkedIn && (
+                <div className="mt-1.5 flex items-center gap-1 pl-9 text-[12px] font-semibold text-primary-600">
+                  <span className="text-[13px] leading-none">＋</span> Add guest
+                </div>
               )}
             </div>
           ))}
@@ -369,18 +463,13 @@ function CheckInMock() {
         </div>
         <div className="mt-2 flex items-center gap-3 rounded-xl bg-white p-3 shadow-sm">
           <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-neutral-400 text-[11px] font-semibold text-white">
-            AD
+            JT
           </span>
           <div className="flex-1">
-            <div className="text-[14px] font-semibold text-neutral-900">Ada</div>
+            <div className="text-[14px] font-semibold text-neutral-900">Jo Tan</div>
             <div className="text-[12px] text-emerald-600">Checked in · 7:03 PM</div>
           </div>
           <span className="text-[16px] leading-none text-neutral-400">🗑️</span>
-        </div>
-
-        {/* Add walk-in. */}
-        <div className="mt-3 flex items-center justify-center gap-1.5 rounded-xl border border-dashed border-primary-400 py-3 text-[14px] font-semibold text-primary-600">
-          <span className="text-[16px] leading-none">＋</span> Add walk-in
         </div>
       </div>
     </PhoneFrame>

--- a/apps/web/src/pages/guides/Events.tsx
+++ b/apps/web/src/pages/guides/Events.tsx
@@ -224,6 +224,13 @@ export function Events() {
             Remove them with the trash icon.
           </Step>
           <Step n={5}>
+            <strong>Running check-in from a laptop.</strong> Check-in works in
+            the browser as well as the app. On a wide screen the roster splits
+            into two or three columns and the controls move onto one row, so a
+            big door list fits on screen instead of scrolling — handy when
+            someone's running the welcome desk from a laptop.
+          </Step>
+          <Step n={6}>
             <strong>It feeds your numbers.</strong> A check-in is the same{" "}
             <Term>Present</Term> record the app already uses, so attendance and
             member-health stats stay correct — you're not tracking it twice.


### PR DESCRIPTION
Running a 59-person door list meant scrolling the whole roster to find one name, scrolling to the bottom to add a walk-in, and having nowhere at all to put the guests people said they were bringing.

## What changed

**Search.** A `Search by name` box filters the Going list and walk-ins as you type. A member also matches when one of *their* guests does, so looking up a guest surfaces the row they're checked in under. The `N / M` count stays event-wide — a count that moved with the search box would misreport the room.

**Add walk-in moved to the top.** The summary, `Add walk-in`, and search are pinned above the scroll area so they stay reachable partway down a long roster.

**Guests can be checked in, and named.** `goingRoster` was already returning each RSVP's `guestCount` — the screen just threw it away. Each member's declared plus-ones now render as their own slots under their row (`Guest 1 of 2`), each with its own check circle. Checking one in creates the guest immediately (the count moves on the first tap) and opens a name sheet that can be skipped and filled in later. Slots grow past the declared count via `Add guest`, so someone who turns up with an undeclared friend is still checkable.

**A real desktop layout.** The app runs on the web, where this screen was one phone-width column stretched across 1440px. On windows ≥900px the controls share one row and the roster flows into 2 columns (3 at ≥1400px), capped at 1280px and centred. Guest slots stay inside their member's block, so a column break never separates someone from their guests. Phones are untouched — `rosterColumns()` returns 1 below 900px, which is every native viewport.

## Backend

Guest rows had nowhere to record *whose* guest they were, so `meetingGuests` gains an optional `hostUserId` and `addGuest` accepts it. A guest row is still one attending person either way, so `admin/stats`, `publicApi`, and the attendance editor keep working untouched — walk-ins are simply guests with no host.

## Behavior change worth flagging

Declared-but-not-yet-arrived guests now count toward the total, so the bar answers "how much of the room is still out?" rather than only counting people already inside. On existing events with plus-ones this changes what `N / M` reads.

## Also fixed

Walk-in cards were sitting flush against each other — the row spacing had moved onto the person-block wrapper, which walk-in rows didn't use.

## Testing

- 25 util tests covering slot math, host/walk-in partitioning, search, and the summary; 16 backend tests including the `hostUserId` link, naming after check-in, and the non-manager rejection.
- 314 leader-tools tests still green; convex + web typecheck clean; both native-safety gates pass and `pnpm-lock.yaml` is untouched (no dependency changes).
- Layout verified by rendering the real screen through Expo web at 390 / 1000 / 1440 / 1680px.

**Not device-verified.** No native deps or native views are added and the lockfile is unchanged, so ADR-030's device rule doesn't apply — but the native layout itself hasn't been run on hardware.

## Docs

`apps/web/src/pages/guides/Events.tsx` — the check-in section's prose and its rendered mock both describe this screen, so both were updated (search, guest slots, `Add walk-in` at the top, and the wide-screen layout).

---
_Generated by [Claude Code](https://claude.ai/code/session_016gNzMV3G2CYteMoGktgvXQ)_