### PR TITLE
Cover the attendance event picker's centering behaviour

### DIFF
--- a/apps/mobile/features/leader-tools/components/EventsList.tsx
+++ b/apps/mobile/features/leader-tools/components/EventsList.tsx
@@ -308,7 +308,12 @@ export function EventsList({
   return (
     <View style={styles.container}>
       <WaSectionLabel variant="header">Events</WaSectionLabel>
-      <View onLayout={handleLayout} style={styles.scrollViewContainer}>
+      {/* testID: the centering test measures this viewport to drive the scroll. */}
+      <View
+        testID="events-list-viewport"
+        onLayout={handleLayout}
+        style={styles.scrollViewContainer}
+      >
         <ScrollView
           ref={scrollViewRef}
           horizontal

--- a/apps/mobile/features/leader-tools/components/__tests__/EventsList.centering.test.tsx
+++ b/apps/mobile/features/leader-tools/components/__tests__/EventsList.centering.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * The Attendance event picker scrolls the relevant event card to the middle of
+ * the strip. `EventsList.scroll.test.ts` covers the arithmetic in isolation;
+ * this covers the wiring around it — which card gets chosen, and that the
+ * measured viewport actually reaches the scroll call.
+ *
+ * Expected offsets are written out longhand from the card metrics (132pt card,
+ * 12pt gap, 16pt screen margin) rather than by calling the component's own
+ * helper, so a drift in either the metrics or the helper fails this test.
+ */
+import React from "react";
+import { render, fireEvent, act } from "@testing-library/react-native";
+import { ScrollView } from "react-native";
+
+const mockUseQuery = jest.fn();
+
+jest.mock("@services/api/convex", () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  api: {
+    functions: { meetings: { index: { listByGroup: "listByGroup" } } },
+  },
+}));
+
+import { EventsList } from "../EventsList";
+
+const CARD_PITCH = 132 + 12;
+const MARGIN = 16;
+const HALF_CARD = 132 / 2;
+const VIEWPORT = 390;
+
+/** Offset that puts card `index` in the middle of a `VIEWPORT`-wide strip. */
+const centeredOffset = (index: number) =>
+  Math.max(0, MARGIN + index * CARD_PITCH + HALF_CARD - VIEWPORT / 2);
+
+const DAY = 24 * 60 * 60 * 1000;
+const now = Date.now();
+
+/** Four past events then one future one, oldest first. */
+const MEETINGS = [
+  { _id: "m0", title: "Four weeks ago", scheduledAt: now - 28 * DAY },
+  { _id: "m1", title: "Three weeks ago", scheduledAt: now - 21 * DAY },
+  { _id: "m2", title: "Two weeks ago", scheduledAt: now - 14 * DAY },
+  { _id: "m3", title: "Last week", scheduledAt: now - 7 * DAY },
+  { _id: "m4", title: "Next week", scheduledAt: now + 7 * DAY },
+];
+
+let scrollToSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  scrollToSpy = jest.spyOn(ScrollView.prototype, "scrollTo").mockImplementation();
+  mockUseQuery.mockReturnValue(MEETINGS);
+});
+
+afterEach(() => {
+  scrollToSpy.mockRestore();
+  jest.useRealTimers();
+});
+
+/** Render, then report the measured viewport width the component asks for. */
+function renderStrip(selectedDate: string | null = null) {
+  const utils = render(
+    <EventsList groupId="group_1" selectedDate={selectedDate} onEventSelect={jest.fn()} />
+  );
+  return utils;
+}
+
+function measureViewport(getByTestId: (id: string) => unknown) {
+  fireEvent(getByTestId("events-list-viewport") as never, "layout", {
+    nativeEvent: { layout: { width: VIEWPORT, height: 160 } },
+  });
+  act(() => {
+    jest.advanceTimersByTime(500);
+  });
+}
+
+describe("EventsList centering", () => {
+  it("centers the most recent past event when no date is selected", () => {
+    const { getByTestId } = renderStrip();
+    measureViewport(getByTestId);
+
+    // "Last week" is index 3 of the ascending strip — the most recent past
+    // event, not the future one.
+    expect(scrollToSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ x: centeredOffset(3) })
+    );
+  });
+
+  it("centers the selected event instead", () => {
+    const selected = new Date(now + 7 * DAY).toISOString();
+    const { getByTestId } = renderStrip(selected);
+    measureViewport(getByTestId);
+
+    expect(scrollToSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ x: centeredOffset(4) })
+    );
+  });
+
+  it("does not scroll until the viewport has been measured", () => {
+    renderStrip();
+    // No layout event: width is still 0, so any offset would be meaningless.
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(scrollToSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not scroll when there are no events", () => {
+    mockUseQuery.mockReturnValue([]);
+    const { queryByTestId } = renderStrip();
+
+    // The empty state replaces the strip entirely.
+    expect(queryByTestId("events-list-viewport")).toBeNull();
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(scrollToSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/features/leader-tools/components/__tests__/EventsList.centering.test.tsx
+++ b/apps/mobile/features/leader-tools/components/__tests__/EventsList.centering.test.tsx
@@ -7,9 +7,13 @@
  * Expected offsets are written out longhand from the card metrics (132pt card,
  * 12pt gap, 16pt screen margin) rather than by calling the component's own
  * helper, so a drift in either the metrics or the helper fails this test.
+ *
+ * Fixtures arrive newest-first, matching the backend — `listByGroup` queries
+ * `.order("desc")` — so the component's own ascending re-sort is exercised
+ * rather than accidentally pre-satisfied.
  */
 import React from "react";
-import { render, fireEvent, act } from "@testing-library/react-native";
+import { render, fireEvent, act, screen } from "@testing-library/react-native";
 import { ScrollView } from "react-native";
 
 const mockUseQuery = jest.fn();
@@ -35,13 +39,22 @@ const centeredOffset = (index: number) =>
 const DAY = 24 * 60 * 60 * 1000;
 const now = Date.now();
 
-/** Four past events then one future one, oldest first. */
+const meeting = (id: string, title: string, offsetDays: number) => ({
+  _id: id,
+  title,
+  scheduledAt: now + offsetDays * DAY,
+});
+
+/**
+ * Newest-first, as the backend returns them. Sorted ascending by the component,
+ * "Last week" lands at index 3 and "Next week" at index 4.
+ */
 const MEETINGS = [
-  { _id: "m0", title: "Four weeks ago", scheduledAt: now - 28 * DAY },
-  { _id: "m1", title: "Three weeks ago", scheduledAt: now - 21 * DAY },
-  { _id: "m2", title: "Two weeks ago", scheduledAt: now - 14 * DAY },
-  { _id: "m3", title: "Last week", scheduledAt: now - 7 * DAY },
-  { _id: "m4", title: "Next week", scheduledAt: now + 7 * DAY },
+  meeting("m4", "Next week", 7),
+  meeting("m3", "Last week", -7),
+  meeting("m2", "Two weeks ago", -14),
+  meeting("m1", "Three weeks ago", -21),
+  meeting("m0", "Four weeks ago", -28),
 ];
 
 let scrollToSpy: jest.SpyInstance;
@@ -58,16 +71,15 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-/** Render, then report the measured viewport width the component asks for. */
 function renderStrip(selectedDate: string | null = null) {
-  const utils = render(
+  render(
     <EventsList groupId="group_1" selectedDate={selectedDate} onEventSelect={jest.fn()} />
   );
-  return utils;
 }
 
-function measureViewport(getByTestId: (id: string) => unknown) {
-  fireEvent(getByTestId("events-list-viewport") as never, "layout", {
+/** Report a viewport width to the strip and let its deferred scroll run. */
+function measureViewport() {
+  fireEvent(screen.getByTestId("events-list-viewport"), "layout", {
     nativeEvent: { layout: { width: VIEWPORT, height: 160 } },
   });
   act(() => {
@@ -75,26 +87,61 @@ function measureViewport(getByTestId: (id: string) => unknown) {
   });
 }
 
+/**
+ * Every scroll the strip performed. The component schedules from two separate
+ * effects, so the same offset can legitimately arrive more than once — assert
+ * on the offsets rather than the call count.
+ */
+const scrolledOffsets = () =>
+  Array.from(new Set(scrollToSpy.mock.calls.map((call) => call[0].x)));
+
 describe("EventsList centering", () => {
   it("centers the most recent past event when no date is selected", () => {
-    const { getByTestId } = renderStrip();
-    measureViewport(getByTestId);
+    renderStrip();
+    measureViewport();
 
-    // "Last week" is index 3 of the ascending strip — the most recent past
-    // event, not the future one.
+    // The most recent PAST event, not the nearer future one.
+    expect(scrolledOffsets()).toEqual([centeredOffset(3)]);
     expect(scrollToSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ x: centeredOffset(3) })
+      expect.objectContaining({ animated: false })
     );
   });
 
   it("centers the selected event instead", () => {
-    const selected = new Date(now + 7 * DAY).toISOString();
-    const { getByTestId } = renderStrip(selected);
-    measureViewport(getByTestId);
+    renderStrip(new Date(now + 7 * DAY).toISOString());
+    measureViewport();
 
-    expect(scrollToSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ x: centeredOffset(4) })
-    );
+    expect(scrolledOffsets()).toEqual([centeredOffset(4)]);
+  });
+
+  it("prefers today's event over the most recent past one", () => {
+    mockUseQuery.mockReturnValue([
+      meeting("future", "Next week", 7),
+      meeting("today", "Today", 0),
+      meeting("past", "Two weeks ago", -14),
+    ]);
+
+    renderStrip();
+    measureViewport();
+
+    // Ascending: [past, today, future] — today is index 1.
+    expect(scrolledOffsets()).toEqual([centeredOffset(1)]);
+  });
+
+  it("falls back to the first future event when nothing is past", () => {
+    mockUseQuery.mockReturnValue([
+      meeting("later", "In three weeks", 21),
+      meeting("soon", "Next week", 7),
+    ]);
+
+    renderStrip();
+    measureViewport();
+
+    // Ascending: [soon, later] — the closest future event is index 0, which
+    // clamps to the strip's leading edge. Still a scroll, unlike the cases
+    // below where none happens at all.
+    expect(scrollToSpy).toHaveBeenCalled();
+    expect(scrolledOffsets()).toEqual([centeredOffset(0)]);
   });
 
   it("does not scroll until the viewport has been measured", () => {
@@ -109,10 +156,10 @@ describe("EventsList centering", () => {
 
   it("does not scroll when there are no events", () => {
     mockUseQuery.mockReturnValue([]);
-    const { queryByTestId } = renderStrip();
+    renderStrip();
 
     // The empty state replaces the strip entirely.
-    expect(queryByTestId("events-list-viewport")).toBeNull();
+    expect(screen.queryByTestId("events-list-viewport")).toBeNull();
     act(() => {
       jest.advanceTimersByTime(500);
     });


### PR DESCRIPTION
## Why

Follow-up to #680, closing one of the two gaps I flagged there.

#680 extracted `eventCardScrollOffset` and unit-tested the arithmetic, but nothing covered the **wiring** around it: which card the strip decides to centre, and whether the measured viewport actually reaches the `scrollTo` call. That path only runs against a Convex-backed `EventsList`, so neither the unit test nor the `/ui-test/attendance` visual harness could reach it — the harness renders `EventCard`s in a plain ScrollView with no centering logic at all.

The centering had a real bug before #680 (the scroll math assumed a 152pt card against a `minWidth: 140 / maxWidth: 160` one), so this is not a hypothetical failure mode.

## What

`EventsList.centering.test.tsx` mounts the real component over a mocked `useQuery` and asserts the `scrollTo` offset for four cases:

- most recent **past** event centred by default (not the future one — the selection logic prefers today → most recent past → first future)
- an explicitly selected event centred instead
- viewport never measured → no scroll at all
- empty strip → no viewport, no scroll

Expected offsets are written out longhand from the card metrics (132 + 12 gap, 16 margin) rather than by calling the component's own helper, so the test fails on a drift in **either** the metrics or the helper — not just when they disagree with each other.

## Verification

Temporarily changed `CARD_WIDTH` 132 → 140: **4 tests fail** across this file and `EventsList.scroll.test.ts`. Restored, full `features/leader-tools` suite is 38 suites / 337 tests green.

## The one product-code change

A `testID="events-list-viewport"` on the wrapper `View`. Firing the layout event needs a handle on that node; the alternative was an `UNSAFE_getAllByType(View)` scan looking for whichever node carries `onLayout`, which breaks the moment the tree is reshuffled.

## Still not covered

The other #680 gap — **real cover images through `AppImage`/R2** — is untouched here. That needs a backend or a fixture server; a data-URI stand-in falls back to the placeholder glyph, so it proves nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnekAsUZjkkvZ42wUdasNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnekAsUZjkkvZ42wUdasNS)_