### PR TITLE
Show human copy for webhook-driven blocked states, not the raw enum

### DIFF
--- a/apps/mobile/features/finance/leader/FinanceOnboardingStatusView.tsx
+++ b/apps/mobile/features/finance/leader/FinanceOnboardingStatusView.tsx
@@ -78,6 +78,17 @@ export function FinanceOnboardingStatusView({
   const provisioningFailed = !!provisioningError;
   const provisioning = formSubmitted && !providersReady && !provisioningFailed;
 
+  // blockedReason arrives as the raw status enum when there's no stored
+  // provider error (webhook-driven blocks carry no message today) — map it
+  // to human copy instead of leaking "stripe_blocked" to a church admin.
+  // For a Stripe block the actionable fix IS the identity flow below.
+  const friendlyBlockedReason =
+    blockedReason === "stripe_blocked"
+      ? "Stripe needs more information — continue identity verification below."
+      : blockedReason === "increase_blocked"
+        ? "Our banking partner needs more information. We're on it — check back soon."
+        : blockedReason;
+
   const identityState: ChecklistItemState = paymentsVerified
     ? "done"
     : onboardingStatus === "stripe_blocked"
@@ -101,14 +112,14 @@ export function FinanceOnboardingStatusView({
       title: "Identity verification",
       description: "Stripe verifies your representative's identity",
       state: identityState,
-      blockedReason: identityState === "blocked" ? (provisioningError ?? blockedReason) : null,
+      blockedReason: identityState === "blocked" ? (provisioningError ?? friendlyBlockedReason) : null,
     },
     {
       key: "bank",
       title: "Bank accounts",
       description: "Receiving and general accounts for your community",
       state: bankState,
-      blockedReason: bankState === "blocked" ? (provisioningError ?? blockedReason) : null,
+      blockedReason: bankState === "blocked" ? (provisioningError ?? friendlyBlockedReason) : null,
     },
   ];
 

--- a/apps/mobile/features/finance/leader/__tests__/FinanceOnboardingStatusView.test.tsx
+++ b/apps/mobile/features/finance/leader/__tests__/FinanceOnboardingStatusView.test.tsx
@@ -44,6 +44,25 @@ describe("FinanceOnboardingStatusView", () => {
     expect(screen.getByText("We need a clearer photo ID.")).toBeTruthy();
   });
 
+  it("maps the raw stripe_blocked enum to human copy instead of leaking it", () => {
+    render(
+      <FinanceOnboardingStatusView
+        {...baseProps}
+        onboardingStatus="stripe_blocked"
+        blockedReason="stripe_blocked"
+      />
+    );
+
+    expect(screen.queryByText("stripe_blocked")).toBeNull();
+    expect(
+      screen.getByText(
+        "Stripe needs more information — continue identity verification below."
+      )
+    ).toBeTruthy();
+    // The actionable fix is the identity flow — the CTA must stay available.
+    expect(screen.getByText("Continue identity verification")).toBeTruthy();
+  });
+
   it("shows the live banner and hides all action buttons once fully live", () => {
     render(
       <FinanceOnboardingStatusView


### PR DESCRIPTION
## Why

With provisioning now completing end-to-end on staging (#683 verified: Church details Done, Bank accounts Done), the checklist showed the literal string **`stripe_blocked`** as the blocked reason. Webhook-driven blocks carry no stored error message, so the view fell back to the raw status enum — and a fresh connected account *always* reports requirements due before the identity wizard runs, so every new onboarding leaks the enum to a church admin.

## What

Map both enums to actionable copy in `FinanceOnboardingStatusView` (stored `provisioningError` strings still take precedence):
- `stripe_blocked` → "Stripe needs more information — continue identity verification below."
- `increase_blocked` → "Our banking partner needs more information. We're on it — check back soon."

## Testing

New view test: enum never rendered, human copy shown, "Continue identity verification" CTA stays available — suite 9/9.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGAcCKMuK2LfcDgPy7uqnq)_