### PR TITLE
Allocate payouts on Stripe NET, and never strand a failed item

### DIFF
--- a/apps/convex/__tests__/finance-allocation.test.ts
+++ b/apps/convex/__tests__/finance-allocation.test.ts
@@ -44,7 +44,7 @@ const stubs = vi.hoisted(() => ({
     | {
         charges: unknown[];
         reversedPaymentIntentIds?: string[];
-        unattributedReversalCents?: number;
+        unattributedNetCents?: number;
       }
     | { error: string }
   >(),
@@ -71,6 +71,10 @@ vi.mock("../lib/finance/stripeConnect", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/finance/stripeConnect")>();
   return {
     ...actual,
+    // The real one takes `payoutCents` too and refuses a composition whose
+    // nets don't add up to it — that guard is exercised against raw Stripe
+    // rows in finance-payout-nets.test.ts. Here the composition is the
+    // fixture, so the third argument is irrelevant.
     getPayoutComposition: vi.fn(async (_accountId: string, payoutId: string) => {
       const stub = stubs.payouts.get(payoutId);
       if (!stub) {
@@ -82,7 +86,7 @@ vi.mock("../lib/finance/stripeConnect", async (importOriginal) => {
       return {
         charges: stub.charges as PayoutChargeNet[],
         reversedPaymentIntentIds: stub.reversedPaymentIntentIds ?? [],
-        unattributedReversalCents: stub.unattributedReversalCents ?? 0,
+        unattributedNetCents: stub.unattributedNetCents ?? 0,
       };
     }),
   };
@@ -1285,6 +1289,106 @@ describe("refunds and allocation", () => {
     ).toEqual({ ok: true, driftCents: 0 });
   });
 
+  test("P1-7: a partial refund settling in a LATER payout transfers only what's left of the gift", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    // $100 gift, $30 refunded before the payout settles. Stripe does NOT
+    // guarantee the refund's balance transaction shares the charge's payout,
+    // so this payout still carries the charge at its FULL net (9680) — the
+    // netting in `getPayoutComposition` cannot help here, and the gift stays
+    // legitimately "pending" so the full-refund belt-and-braces doesn't reach
+    // it either. Taking Stripe's net verbatim moved 9680 while the ledger
+    // said 7000, leaving 2680 of returned donor money spendable on the
+    // group's card.
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_late_refund",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    await refundDonation(t, {
+      paymentIntentId: "pi_late_refund",
+      chargeId: "ch_late_refund",
+      amountRefundedCents: 3_000,
+    });
+
+    stubs.payouts.set("po_late_refund", {
+      charges: [{ paymentIntentId: "pi_late_refund", netCents: 9_680 }],
+    });
+
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_late_refund",
+      payoutCents: 9_680,
+    });
+
+    // What the bank was actually ASKED to move is the assertion that matters.
+    expect(stubs.transferCalls).toEqual([
+      {
+        toAccountId: "account_fund_a",
+        amountCents: 7_000, // 10000 gross − 3000 refunded, NOT Stripe's 9680
+        idempotencyKey: `alloc:${donationId}`,
+      },
+    ]);
+
+    const donation = await getDonation(t, donationId);
+    expect(donation?.allocationStatus).toBe("allocated");
+    expect(donation?.payoutNetCents).toBe(7_000);
+
+    // Ledger and bank agree exactly: credit 10000, refund 3000, no fee left
+    // to realise on the part the fund kept.
+    const entries = await t.run((ctx) =>
+      ctx.db
+        .query("ledgerEntries")
+        .withIndex("by_fund", (q) => q.eq("fundId", fundAId))
+        .collect(),
+    );
+    expect(entries.map((e) => `${e.kind}:${e.direction}:${e.amountCents}`)).toEqual([
+      "donation:credit:10000",
+      "refund:debit:3000",
+    ]);
+    expect((await t.run((ctx) => ctx.db.get(fundAId)))?.balanceCents).toBe(7_000);
+  });
+
+  test("P1-7: the retry cron resumes a bound gift at the refunded-down amount, not its stale stamped net", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_bound_then_partial",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    // Bound at the full net by a pass whose transfer never landed — it
+    // couldn't have known about a refund that hadn't happened yet.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(donationId, {
+        allocationPayoutId: "po_bound_partial_retry",
+        payoutNetCents: 9_680,
+      });
+    });
+    await refundDonation(t, {
+      paymentIntentId: "pi_bound_then_partial",
+      chargeId: "ch_bound_partial_retry",
+      amountRefundedCents: 3_000,
+    });
+
+    await t.action(internal.functions.finance.jobs.retryStaleAllocations, {});
+
+    expect(stubs.transferCalls).toEqual([
+      {
+        toAccountId: "account_fund_a",
+        amountCents: 7_000,
+        idempotencyKey: `alloc:${donationId}`,
+      },
+    ]);
+    expect((await t.run((ctx) => ctx.db.get(fundAId)))?.balanceCents).toBe(7_000);
+  });
+
   test("a gift refunded while bound to a payout is dropped by the retry cron, not transferred", async () => {
     const t = convexTest(schema, modules);
     const { communityId, fundAId } = await seedAllocFixture(t);
@@ -1517,6 +1621,176 @@ describe("unmatched payouts are observable", () => {
     });
 
     expect(await auditActions(t, communityId)).toContain("allocation.payout_unmatched");
+  });
+
+  test("P1-8: replaying a HEALTHY payout raises no unmatched alarm — that's the success condition", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_healthy",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    stubs.payouts.set("po_healthy", {
+      charges: [{ paymentIntentId: "pi_healthy", netCents: 9_680 }],
+    });
+
+    const first = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_healthy",
+      payoutCents: 9_680,
+    });
+    expect(first).toEqual({ allocated: 1, failed: 0 });
+
+    // webhooks.ts routes `payout.reconciliation_completed` to this same
+    // handler, and Stripe emits it after EVERY payout — so this second pass
+    // is the normal course of business, not an edge case. The gift is
+    // already allocated, so the plan is empty; treating an empty plan as
+    // "matched nothing" wrote a full-payout `payout_unmatched` row (with
+    // leftoverCents equal to the entire payout) on every healthy payout,
+    // forever, drowning the one signal that has no automatic recovery.
+    const second = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_healthy",
+      payoutCents: 9_680,
+    });
+    expect(second).toEqual({ allocated: 0, failed: 0 });
+
+    expect(await auditActions(t, communityId)).toEqual(["donation.allocated"]);
+  });
+
+  test("P1-8: a payout that finished some items but genuinely lost the rest still alarms", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_known",
+      amountCents: 1_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    // 941 of a 50000 payout maps to a gift we know. The alarm must survive
+    // the P1-8 guard: "something was already allocated" is not a licence to
+    // stop looking at the 49059 we cannot account for.
+    stubs.payouts.set("po_partial_known", {
+      charges: [{ paymentIntentId: "pi_known", netCents: 941 }],
+    });
+
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_partial_known",
+      payoutCents: 50_000,
+    });
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_partial_known",
+      payoutCents: 50_000,
+    });
+
+    const unmatched = (await auditActions(t, communityId)).filter(
+      (a) => a === "allocation.payout_unmatched",
+    );
+    expect(unmatched).toHaveLength(2);
+  });
+
+  test("P1-6: a payout short by money we can't attribute is REFUSED, not allocated around", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_healthy",
+      amountCents: 50_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    // A reversal Stripe attributed to this payout that we could not tie to
+    // any PaymentIntent. The charge rows now sum to MORE than the payout
+    // delivered, so funding them all would move money that never arrived —
+    // and the residual-budget check would quietly strand whichever gift
+    // sorted last instead, with leftoverCents at 0.
+    stubs.payouts.set("po_short", {
+      charges: [{ paymentIntentId: "pi_healthy", netCents: 48_500 }],
+      unattributedNetCents: -48_500,
+    });
+
+    const result = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_short",
+      payoutCents: 0,
+    });
+
+    expect(result).toEqual({ allocated: 0, failed: 0 });
+    expect(stubs.transferCalls).toEqual([]);
+    const donation = await getDonation(t, donationId);
+    expect(donation?.allocationStatus).toBe("pending");
+    expect(donation?.allocationPayoutId).toBeUndefined();
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("financeAuditEvents")
+        .withIndex("by_community", (q) => q.eq("communityId", communityId))
+        .collect(),
+    );
+    const unmatched = rows.find((r) => r.action === "allocation.payout_unmatched");
+    expect(JSON.parse(unmatched!.detailsJson!)).toMatchObject({
+      stripePayoutId: "po_short",
+      refused: true,
+      unattributedNetCents: -48_500,
+    });
+  });
+
+  test("P1-6: a gift skipped for overrunning the payout alarms instead of vanishing", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_a",
+      amountCents: 50_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_b",
+      amountCents: 50_000,
+      createdAt: 2_000,
+      creditLedger: true,
+    });
+    // Both gifts are in the payout at 49600, but the payout only carried one
+    // of them. The second is skipped — correctly, it can't be funded — and
+    // leftoverCents then comes out at 0, which used to look perfectly
+    // healthy. A stranded gift is not a healthy pass.
+    stubs.payouts.set("po_overrun", {
+      charges: [
+        { paymentIntentId: "pi_a", netCents: 49_600 },
+        { paymentIntentId: "pi_b", netCents: 49_600 },
+      ],
+    });
+
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_overrun",
+      payoutCents: 49_600,
+    });
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("financeAuditEvents")
+        .withIndex("by_community", (q) => q.eq("communityId", communityId))
+        .collect(),
+    );
+    const unmatched = rows.find((r) => r.action === "allocation.payout_unmatched");
+    expect(unmatched).toBeDefined();
+    expect(JSON.parse(unmatched!.detailsJson!)).toMatchObject({
+      leftoverCents: 0, // the number that made this invisible
+      overrunSkippedCount: 1,
+    });
   });
 
   test("a fully matched payout does not alarm", async () => {

--- a/apps/convex/__tests__/finance-allocation.test.ts
+++ b/apps/convex/__tests__/finance-allocation.test.ts
@@ -1,0 +1,898 @@
+/**
+ * Payout allocation: NET matching, never-stall selection, per-item failure
+ * recovery, and honest reconcile (ADR-032 §3 + Phase-2 requirement 6).
+ *
+ * Unlike the other finance suites, this one drives `runAllocation` — the
+ * internalAction itself — end to end, because the bugs it covers live in the
+ * action's control flow (what it claims before it transfers, what it does
+ * when transfer N of M throws, what a redelivered webhook re-does). Both
+ * providers the action lazy-imports are mocked at the module boundary:
+ * `listPayoutChargeNets` (Stripe balance transactions) and
+ * `createAccountTransfer` (Increase).
+ *
+ * Deliberately NO suite-wide `vi.useFakeTimers()` (see finance-cards.test.ts
+ * for why the other suites need it): nothing here goes through
+ * `ctx.scheduler`, so freezing timers would only risk making an awaited
+ * action look like it ran when it didn't.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/finance-allocation.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+import type { PayoutChargeNet } from "../lib/finance/stripeConnect";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+// ============================================================================
+// Provider mocks
+//
+// `vi.hoisted` because `vi.mock` factories are hoisted above the module body —
+// the shared state they close over has to be hoisted with them.
+// ============================================================================
+
+const stubs = vi.hoisted(() => ({
+  /** payoutId -> charges Stripe reports for it, or an error to throw. */
+  payouts: new Map<string, { charges: unknown[] } | { error: string }>(),
+  /** Increase idempotency keys that should fail this run. */
+  failTransferKeys: new Set<string>(),
+  /** Every createAccountTransfer call, in order. */
+  transferCalls: [] as Array<{
+    toAccountId: string;
+    amountCents: number;
+    idempotencyKey: string;
+  }>,
+}));
+
+vi.mock("../lib/finance/stripeConnect", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/finance/stripeConnect")>();
+  return {
+    ...actual,
+    listPayoutChargeNets: vi.fn(async (_accountId: string, payoutId: string) => {
+      const stub = stubs.payouts.get(payoutId);
+      if (!stub) {
+        throw new Error(`test stub missing for payout ${payoutId}`);
+      }
+      if ("error" in stub) {
+        throw new Error(stub.error);
+      }
+      return stub.charges as PayoutChargeNet[];
+    }),
+  };
+});
+
+vi.mock("../lib/finance/increase", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/finance/increase")>();
+  return {
+    ...actual,
+    createAccountTransfer: vi.fn(
+      async (input: {
+        toAccountId: string;
+        amountCents: number;
+        idempotencyKey: string;
+      }) => {
+        stubs.transferCalls.push({
+          toAccountId: input.toAccountId,
+          amountCents: input.amountCents,
+          idempotencyKey: input.idempotencyKey,
+        });
+        if (stubs.failTransferKeys.has(input.idempotencyKey)) {
+          throw new Error(
+            "Increase API POST /account_transfers failed (503): service unavailable",
+          );
+        }
+        return { id: `at_${input.idempotencyKey}`, status: "pending" };
+      },
+    ),
+  };
+});
+
+beforeEach(() => {
+  stubs.payouts.clear();
+  stubs.failTransferKeys.clear();
+  stubs.transferCalls.length = 0;
+});
+
+// ============================================================================
+// Fixture
+// ============================================================================
+
+interface AllocFixture {
+  communityId: Id<"communities">;
+  fundAId: Id<"funds">;
+  fundBId: Id<"funds">;
+  generalFundId: Id<"funds">;
+}
+
+const RECEIVING_ACCOUNT = "account_receiving";
+
+async function seedAllocFixture(
+  t: ReturnType<typeof convexTest>,
+  options: { receivingAccount?: string | null } = {},
+): Promise<AllocFixture> {
+  return await t.run(async (ctx) => {
+    const timestamp = Date.now();
+    const communityId = await ctx.db.insert("communities", {
+      name: "Allocation Church",
+      slug: `allocation-church-${Math.floor(Math.random() * 1_000_000)}`,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    const mkFund = async (
+      name: string,
+      type: "group" | "general",
+      increaseAccountId: string,
+    ) =>
+      ctx.db.insert("funds", {
+        communityId,
+        name,
+        type,
+        increaseAccountId,
+        status: "active",
+        balanceCents: 0,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+
+    const fundAId = await mkFund("Fund A", "group", "account_fund_a");
+    const fundBId = await mkFund("Fund B", "group", "account_fund_b");
+    const generalFundId = await mkFund("General", "general", "account_general");
+
+    const receiving =
+      options.receivingAccount === undefined
+        ? RECEIVING_ACCOUNT
+        : options.receivingAccount;
+
+    await ctx.db.insert("communityFinance", {
+      communityId,
+      stripeConnectedAccountId: "acct_alloc",
+      increaseEntityId: "entity_alloc",
+      ...(receiving ? { increaseReceivingAccountId: receiving } : {}),
+      onboardingStatus: "live",
+      legalName: "Allocation Church Inc.",
+      ein: "12-3456789",
+      address: {
+        addressLine1: "1 Main St",
+        city: "Austin",
+        state: "TX",
+        zipCode: "78701",
+      },
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    return { communityId, fundAId, fundBId, generalFundId };
+  });
+}
+
+/** Insert a pending donation directly — `recordDonationSucceeded` would also
+ * schedule a receipt email, which this suite has no interest in. Returns the
+ * donation id; the ledger credit is simulated by bumping the fund cache. */
+async function seedDonation(
+  t: ReturnType<typeof convexTest>,
+  args: {
+    fundId: Id<"funds">;
+    paymentIntentId: string;
+    amountCents: number;
+    feeCoverCents?: number;
+    createdAt: number;
+    creditLedger?: boolean;
+  },
+): Promise<Id<"donations">> {
+  return await t.run(async (ctx) => {
+    const grossCents = args.amountCents + (args.feeCoverCents ?? 0);
+    const donationId = await ctx.db.insert("donations", {
+      fundId: args.fundId,
+      amountCents: args.amountCents,
+      feeCoverCents: args.feeCoverCents ?? 0,
+      stripePaymentIntentId: args.paymentIntentId,
+      allocationStatus: "pending",
+      receiptEmailStatus: "sent",
+      createdAt: args.createdAt,
+    });
+    if (args.creditLedger) {
+      const fund = (await ctx.db.get(args.fundId))!;
+      await ctx.db.insert("ledgerEntries", {
+        fundId: args.fundId,
+        communityId: fund.communityId,
+        direction: "credit",
+        amountCents: grossCents,
+        kind: "donation",
+        idempotencyKey: `donation:${args.paymentIntentId}`,
+        createdAt: args.createdAt,
+      });
+      await ctx.db.patch(args.fundId, {
+        balanceCents: fund.balanceCents + grossCents,
+      });
+    }
+    return donationId;
+  });
+}
+
+async function getDonation(t: ReturnType<typeof convexTest>, id: Id<"donations">) {
+  return await t.run((ctx) => ctx.db.get(id));
+}
+
+async function auditActions(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+): Promise<string[]> {
+  const rows = await t.run((ctx) =>
+    ctx.db
+      .query("financeAuditEvents")
+      .withIndex("by_community", (q) => q.eq("communityId", communityId))
+      .collect(),
+  );
+  return rows.map((r) => r.action);
+}
+
+// ============================================================================
+// planAllocations — NET matching
+// ============================================================================
+
+describe("planAllocations (net matching)", () => {
+  test("THE STALL: a lone donation whose GROSS exceeds the payout's NET still allocates", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    // $100 gift; Stripe keeps 2.9% + 30c = 320c, so the payout is 9680.
+    // The old gross matcher compared 10000 against 9680, never fit it, and
+    // `break`ed — the queue never advanced again.
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_stall",
+      amountCents: 10_000,
+      createdAt: 1_000,
+    });
+
+    const result = await t.mutation(internal.functions.finance.jobs.planAllocations, {
+      communityId,
+      payoutCents: 9_680,
+      stripePayoutId: "po_stall",
+      charges: [{ paymentIntentId: "pi_stall", netCents: 9_680 }],
+    });
+
+    expect(result.plan).toHaveLength(1);
+    expect(result.plan[0]).toMatchObject({
+      donationId,
+      fundId: fundAId,
+      amountCents: 9_680, // net, not the 10000 gross
+    });
+    expect(result.leftoverCents).toBe(0);
+    expect(result.alreadyClaimed).toBe(false);
+
+    const donation = await getDonation(t, donationId);
+    expect(donation?.allocationPayoutId).toBe("po_stall");
+    expect(donation?.payoutNetCents).toBe(9_680);
+  });
+
+  test("a donation the payout doesn't contain is skipped; the ones it does contain still allocate", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId, fundBId } = await seedAllocFixture(t);
+
+    // Oldest donation settled too late for this payout — Stripe reports no
+    // balance transaction for it. It must not block the two that did settle.
+    const laterId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_not_in_payout",
+      amountCents: 50_000,
+      createdAt: 1_000,
+    });
+    const firstId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_a",
+      amountCents: 2_000,
+      createdAt: 2_000,
+    });
+    const secondId = await seedDonation(t, {
+      fundId: fundBId,
+      paymentIntentId: "pi_b",
+      amountCents: 3_000,
+      feeCoverCents: 100,
+      createdAt: 3_000,
+    });
+
+    const result = await t.mutation(internal.functions.finance.jobs.planAllocations, {
+      communityId,
+      // A real payout equals the sum of its charges' nets, plus (here) 118c
+      // of charges we can't map to a donation — the expected leftover.
+      payoutCents: 4_950,
+      stripePayoutId: "po_partial_cycle",
+      charges: [
+        { paymentIntentId: "pi_a", netCents: 1_912 },
+        { paymentIntentId: "pi_b", netCents: 2_920 },
+      ],
+    });
+
+    expect(result.plan.map((p) => p.donationId)).toEqual([firstId, secondId]);
+    expect(result.plan.map((p) => p.amountCents)).toEqual([1_912, 2_920]);
+    expect(result.leftoverCents).toBe(118);
+
+    expect((await getDonation(t, laterId))?.allocationPayoutId).toBeUndefined();
+  });
+
+  test("an item that would overrun the payout is SKIPPED, not terminal — later items still plan", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    // Deliberately inconsistent stub (nets summing above the payout) to force
+    // the defensive budget branch. The old code `break`ed here; the queue
+    // behind an oversized item never drained.
+    const bigId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_big",
+      amountCents: 300,
+      createdAt: 1_000,
+    });
+    const smallId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_small",
+      amountCents: 120,
+      createdAt: 2_000,
+    });
+
+    const result = await t.mutation(internal.functions.finance.jobs.planAllocations, {
+      communityId,
+      payoutCents: 150,
+      stripePayoutId: "po_overrun",
+      charges: [
+        { paymentIntentId: "pi_big", netCents: 200 },
+        { paymentIntentId: "pi_small", netCents: 100 },
+      ],
+    });
+
+    expect(result.plan).toHaveLength(1);
+    expect(result.plan[0].donationId).toBe(smallId);
+    expect((await getDonation(t, bigId))?.allocationPayoutId).toBeUndefined();
+    expect((await getDonation(t, smallId))?.payoutNetCents).toBe(100);
+  });
+
+  test("a donation already bound to another payout is never re-selected", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_bound",
+      amountCents: 1_000,
+      createdAt: 1_000,
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(donationId, {
+        allocationPayoutId: "po_earlier",
+        payoutNetCents: 950,
+      });
+    });
+
+    const result = await t.mutation(internal.functions.finance.jobs.planAllocations, {
+      communityId,
+      payoutCents: 950,
+      stripePayoutId: "po_later",
+      charges: [{ paymentIntentId: "pi_bound", netCents: 950 }],
+    });
+
+    expect(result.plan).toHaveLength(0);
+    expect((await getDonation(t, donationId))?.allocationPayoutId).toBe("po_earlier");
+  });
+
+  test("re-planning the same payout returns the same still-pending items and re-stamps nothing", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_replan",
+      amountCents: 5_000,
+      createdAt: 1_000,
+    });
+
+    const args = {
+      communityId,
+      payoutCents: 4_825,
+      stripePayoutId: "po_replan",
+      charges: [{ paymentIntentId: "pi_replan", netCents: 4_825 }],
+    };
+    const first = await t.mutation(internal.functions.finance.jobs.planAllocations, args);
+    const second = await t.mutation(internal.functions.finance.jobs.planAllocations, args);
+
+    expect(first.alreadyClaimed).toBe(false);
+    expect(second.alreadyClaimed).toBe(true);
+    expect(second.plan.map((p) => p.donationId)).toEqual([donationId]);
+    expect(second.plan[0].amountCents).toBe(4_825);
+
+    const payoutRows = await t.run((ctx) =>
+      ctx.db.query("processedStripePayouts").collect(),
+    );
+    expect(payoutRows).toHaveLength(1);
+  });
+
+  test("a nonsense net from Stripe is ignored rather than allocated", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_bad_net",
+      amountCents: 1_000,
+      createdAt: 1_000,
+    });
+
+    for (const netCents of [0, -100, 12.5]) {
+      const result = await t.mutation(
+        internal.functions.finance.jobs.planAllocations,
+        {
+          communityId,
+          payoutCents: 1_000,
+          stripePayoutId: `po_bad_${netCents}`,
+          charges: [{ paymentIntentId: "pi_bad_net", netCents }],
+        },
+      );
+      expect(result.plan).toHaveLength(0);
+    }
+  });
+});
+
+// ============================================================================
+// runAllocation — the action, with both providers mocked
+// ============================================================================
+
+describe("runAllocation", () => {
+  test("transfers each matched donation's NET and records it", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId, fundBId, generalFundId } = await seedAllocFixture(t);
+
+    const aId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_1",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    const bId = await seedDonation(t, {
+      fundId: fundBId,
+      paymentIntentId: "pi_2",
+      amountCents: 5_000,
+      createdAt: 2_000,
+      creditLedger: true,
+    });
+    const gId = await seedDonation(t, {
+      fundId: generalFundId,
+      paymentIntentId: "pi_3",
+      amountCents: 2_000,
+      createdAt: 3_000,
+      creditLedger: true,
+    });
+
+    stubs.payouts.set("po_happy", {
+      charges: [
+        { paymentIntentId: "pi_1", netCents: 9_680 },
+        { paymentIntentId: "pi_2", netCents: 4_825 },
+        { paymentIntentId: "pi_3", netCents: 1_912 },
+      ],
+    });
+
+    const result = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_happy",
+      payoutCents: 16_417,
+    });
+
+    expect(result).toEqual({ allocated: 3, failed: 0 });
+
+    // Group funds get a transfer each; the general fund does not (its Account
+    // is where unearmarked money already belongs).
+    expect(stubs.transferCalls).toEqual([
+      { toAccountId: "account_fund_a", amountCents: 9_680, idempotencyKey: `alloc:${aId}` },
+      { toAccountId: "account_fund_b", amountCents: 4_825, idempotencyKey: `alloc:${bId}` },
+    ]);
+
+    for (const id of [aId, bId, gId]) {
+      expect((await getDonation(t, id))?.allocationStatus).toBe("allocated");
+    }
+
+    // The fee Stripe kept is realised as a "fee" debit, so each fund's ledger
+    // now reflects what the bank will actually hold.
+    const fundA = await t.run((ctx) => ctx.db.get(fundAId));
+    expect(fundA?.balanceCents).toBe(9_680);
+    const feeEntries = await t.run((ctx) =>
+      ctx.db
+        .query("ledgerEntries")
+        .withIndex("by_fund", (q) => q.eq("fundId", fundAId))
+        .collect(),
+    );
+    const fee = feeEntries.find((e) => e.kind === "fee");
+    expect(fee).toMatchObject({ direction: "debit", amountCents: 320 });
+    expect(fee?.stripeObjectId).toBe("po_happy");
+  });
+
+  test("PARTIAL FAILURE: item 2 of 3 fails, 1 and 3 still land, and a redelivery finishes 2 without re-transferring 1", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId, fundBId } = await seedAllocFixture(t);
+
+    const oneId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_1",
+      amountCents: 1_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    const twoId = await seedDonation(t, {
+      fundId: fundBId,
+      paymentIntentId: "pi_2",
+      amountCents: 2_000,
+      createdAt: 2_000,
+      creditLedger: true,
+    });
+    const threeId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_3",
+      amountCents: 3_000,
+      createdAt: 3_000,
+      creditLedger: true,
+    });
+
+    stubs.payouts.set("po_partial", {
+      charges: [
+        { paymentIntentId: "pi_1", netCents: 941 },
+        { paymentIntentId: "pi_2", netCents: 1_912 },
+        { paymentIntentId: "pi_3", netCents: 2_883 },
+      ],
+    });
+    stubs.failTransferKeys.add(`alloc:${twoId}`);
+
+    const first = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_partial",
+      payoutCents: 5_736,
+    });
+
+    expect(first).toEqual({ allocated: 2, failed: 1 });
+    expect((await getDonation(t, oneId))?.allocationStatus).toBe("allocated");
+    expect((await getDonation(t, threeId))?.allocationStatus).toBe("allocated");
+
+    // The failed item keeps its payout binding — that's what makes it
+    // re-selectable by exactly this payout and nothing else.
+    const two = await getDonation(t, twoId);
+    expect(two?.allocationStatus).toBe("pending");
+    expect(two?.allocationPayoutId).toBe("po_partial");
+    expect(two?.payoutNetCents).toBe(1_912);
+
+    expect(await auditActions(t, communityId)).toContain("allocation.transfer_failed");
+
+    // --- Stripe redelivers payout.paid; Increase is healthy again. ---
+    stubs.failTransferKeys.clear();
+    stubs.transferCalls.length = 0;
+
+    const second = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_partial",
+      payoutCents: 5_736,
+    });
+
+    expect(second).toEqual({ allocated: 1, failed: 0 });
+    // ONLY the unfinished item moved. Items 1 and 3 were not re-transferred.
+    expect(stubs.transferCalls).toEqual([
+      {
+        toAccountId: "account_fund_b",
+        amountCents: 1_912,
+        idempotencyKey: `alloc:${twoId}`,
+      },
+    ]);
+    expect((await getDonation(t, twoId))?.allocationStatus).toBe("allocated");
+
+    // Every fund now nets out to what the bank holds — one fee debit per
+    // donation, never two.
+    const fundA = await t.run((ctx) => ctx.db.get(fundAId));
+    expect(fundA?.balanceCents).toBe(941 + 2_883);
+    const fundB = await t.run((ctx) => ctx.db.get(fundBId));
+    expect(fundB?.balanceCents).toBe(1_912);
+
+    const allFeeEntries = await t.run((ctx) =>
+      ctx.db
+        .query("ledgerEntries")
+        .withIndex("by_community", (q) => q.eq("communityId", communityId))
+        .collect(),
+    );
+    expect(allFeeEntries.filter((e) => e.kind === "fee")).toHaveLength(3);
+  });
+
+  test("replaying a fully successful payout is a no-op — no second transfer, no second fee entry", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_1",
+      amountCents: 4_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    stubs.payouts.set("po_replay", {
+      charges: [{ paymentIntentId: "pi_1", netCents: 3_854 }],
+    });
+
+    const first = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_replay",
+      payoutCents: 3_854,
+    });
+    expect(first).toEqual({ allocated: 1, failed: 0 });
+
+    stubs.transferCalls.length = 0;
+    const second = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_replay",
+      payoutCents: 3_854,
+    });
+
+    expect(second).toEqual({ allocated: 0, failed: 0 });
+    expect(stubs.transferCalls).toHaveLength(0);
+
+    const entries = await t.run((ctx) =>
+      ctx.db
+        .query("ledgerEntries")
+        .withIndex("by_fund", (q) => q.eq("fundId", fundAId))
+        .collect(),
+    );
+    expect(entries.filter((e) => e.kind === "fee")).toHaveLength(1);
+    expect((await t.run((ctx) => ctx.db.get(fundAId)))?.balanceCents).toBe(3_854);
+
+    const allocatedAudits = (await auditActions(t, communityId)).filter(
+      (a) => a === "donation.allocated",
+    );
+    expect(allocatedAudits).toHaveLength(1);
+    expect((await getDonation(t, donationId))?.allocationStatus).toBe("allocated");
+  });
+
+  test("an unreachable Stripe leaves the payout entirely untouched, so a retry can still run it", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_1",
+      amountCents: 4_000,
+      createdAt: 1_000,
+    });
+    stubs.payouts.set("po_stripe_down", { error: "Stripe API unreachable" });
+
+    await expect(
+      t.action(internal.functions.finance.jobs.runAllocation, {
+        communityId,
+        stripePayoutId: "po_stripe_down",
+        payoutCents: 3_854,
+      }),
+    ).rejects.toThrow("Stripe API unreachable");
+
+    expect(await t.run((ctx) => ctx.db.query("processedStripePayouts").collect())).toHaveLength(0);
+    const donation = await getDonation(t, donationId);
+    expect(donation?.allocationStatus).toBe("pending");
+    expect(donation?.allocationPayoutId).toBeUndefined();
+    expect(stubs.transferCalls).toHaveLength(0);
+  });
+
+  test("a matched payout with no receiving Account leaves every item pending and reports them failed", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t, {
+      receivingAccount: null,
+    });
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_1",
+      amountCents: 4_000,
+      createdAt: 1_000,
+    });
+    stubs.payouts.set("po_no_receiving", {
+      charges: [{ paymentIntentId: "pi_1", netCents: 3_854 }],
+    });
+
+    const result = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_no_receiving",
+      payoutCents: 3_854,
+    });
+
+    expect(result).toEqual({ allocated: 0, failed: 1 });
+    expect((await getDonation(t, donationId))?.allocationStatus).toBe("pending");
+    expect(stubs.transferCalls).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// retryStaleAllocations — recovery for items stranded by a partial failure
+// ============================================================================
+
+describe("retryStaleAllocations", () => {
+  test("resumes a payout-bound donation whose transfer never landed, without a payout webhook", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const staleCreatedAt = Date.now() - 5 * 24 * 60 * 60 * 1000;
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_stranded",
+      amountCents: 4_000,
+      createdAt: staleCreatedAt,
+      creditLedger: true,
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(donationId, {
+        allocationPayoutId: "po_gone",
+        payoutNetCents: 3_854,
+      });
+    });
+
+    await t.action(internal.functions.finance.jobs.retryStaleAllocations, {});
+
+    expect(stubs.transferCalls).toEqual([
+      {
+        toAccountId: "account_fund_a",
+        amountCents: 3_854,
+        idempotencyKey: `alloc:${donationId}`,
+      },
+    ]);
+    expect((await getDonation(t, donationId))?.allocationStatus).toBe("allocated");
+    expect((await t.run((ctx) => ctx.db.get(fundAId)))?.balanceCents).toBe(3_854);
+  });
+
+  test("resumes a FRESH stranded item too — a partial failure isn't made to wait out the 3-day window", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_fresh_stranded",
+      amountCents: 4_000,
+      createdAt: Date.now(), // minutes old, nowhere near stale
+      creditLedger: true,
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(donationId, {
+        allocationPayoutId: "po_fresh",
+        payoutNetCents: 3_854,
+      });
+    });
+
+    await t.action(internal.functions.finance.jobs.retryStaleAllocations, {});
+
+    expect((await getDonation(t, donationId))?.allocationStatus).toBe("allocated");
+    // Not stale, so no alert — just a quiet recovery.
+    expect(await auditActions(t, communityId)).not.toContain("allocation.stale_pending");
+  });
+
+  test("a stale donation with no payout binding is alerted on, never transferred against a guessed amount", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_unbound",
+      amountCents: 4_000,
+      createdAt: Date.now() - 5 * 24 * 60 * 60 * 1000,
+      creditLedger: true,
+    });
+
+    await t.action(internal.functions.finance.jobs.retryStaleAllocations, {});
+
+    expect(stubs.transferCalls).toHaveLength(0);
+    expect(await auditActions(t, communityId)).toContain("allocation.stale_pending");
+  });
+});
+
+// ============================================================================
+// Reconcile honesty — a stranded allocation must show up as drift
+// ============================================================================
+
+describe("reconcile on the net basis", () => {
+  test("a stranded allocation drifts by the realised fee instead of being masked", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId, fundBId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_1",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    stubs.payouts.set("po_recon", {
+      charges: [{ paymentIntentId: "pi_1", netCents: 9_680 }],
+    });
+    stubs.failTransferKeys.add(`alloc:${donationId}`);
+
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_recon",
+      payoutCents: 9_680,
+    });
+
+    // Pending is now NET (9680), not the 10000 gross that used to make the
+    // invariant balance against a ledger that had never been debited.
+    const pending = await t.mutation(
+      internal.functions.finance.jobs.computePendingAllocationCents,
+      { communityId },
+    );
+    expect(pending.find((p) => p.fundId === fundAId)?.pendingCents).toBe(9_680);
+
+    const fund = await t.run((ctx) => ctx.db.get(fundAId));
+    const stranded = await t.mutation(
+      internal.functions.finance.jobs.recordReconcileResult,
+      {
+        fundId: fundAId,
+        communityId,
+        ledgerBalanceCents: fund!.balanceCents, // 10000, no fee debit yet
+        bankBalanceCents: 0, // the transfer never landed
+        pendingAllocationCents: 9_680,
+      },
+    );
+    expect(stranded).toEqual({ ok: false, driftCents: 320 });
+    expect(await auditActions(t, communityId)).toContain("reconcile.drift");
+
+    // --- And once the retry lands it, the invariant closes exactly. ---
+    stubs.failTransferKeys.clear();
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_recon",
+      payoutCents: 9_680,
+    });
+
+    const settledFund = await t.run((ctx) => ctx.db.get(fundAId));
+    expect(settledFund?.balanceCents).toBe(9_680);
+    const settledPending = await t.mutation(
+      internal.functions.finance.jobs.computePendingAllocationCents,
+      { communityId },
+    );
+    expect(settledPending.find((p) => p.fundId === fundAId)?.pendingCents).toBe(0);
+    expect(
+      await t.mutation(internal.functions.finance.jobs.recordReconcileResult, {
+        fundId: fundAId,
+        communityId,
+        ledgerBalanceCents: settledFund!.balanceCents,
+        bankBalanceCents: 9_680,
+        pendingAllocationCents: 0,
+      }),
+    ).toEqual({ ok: true, driftCents: 0 });
+
+    // Untouched fund, untouched invariant.
+    expect(
+      (await t.run((ctx) => ctx.db.get(fundBId)))?.balanceCents,
+    ).toBe(0);
+  });
+
+  test("a donation still in the Stripe pipeline is pending at GROSS, so the invariant holds pre-payout", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_inflight",
+      amountCents: 2_500,
+      feeCoverCents: 150,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+
+    const pending = await t.mutation(
+      internal.functions.finance.jobs.computePendingAllocationCents,
+      { communityId },
+    );
+    expect(pending.find((p) => p.fundId === fundAId)?.pendingCents).toBe(2_650);
+
+    const fund = await t.run((ctx) => ctx.db.get(fundAId));
+    expect(
+      await t.mutation(internal.functions.finance.jobs.recordReconcileResult, {
+        fundId: fundAId,
+        communityId,
+        ledgerBalanceCents: fund!.balanceCents,
+        bankBalanceCents: 0,
+        pendingAllocationCents: 2_650,
+      }),
+    ).toEqual({ ok: true, driftCents: 0 });
+  });
+});

--- a/apps/convex/__tests__/finance-allocation.test.ts
+++ b/apps/convex/__tests__/finance-allocation.test.ts
@@ -7,8 +7,10 @@
  * action's control flow (what it claims before it transfers, what it does
  * when transfer N of M throws, what a redelivered webhook re-does). Both
  * providers the action lazy-imports are mocked at the module boundary:
- * `listPayoutChargeNets` (Stripe balance transactions) and
- * `createAccountTransfer` (Increase).
+ * `getPayoutComposition` (Stripe balance transactions) and
+ * `createAccountTransfer` (Increase — including its idempotency-key
+ * behaviour, so the "same key returns the same transfer" lock is genuinely
+ * exercised rather than assumed).
  *
  * Deliberately NO suite-wide `vi.useFakeTimers()` (see finance-cards.test.ts
  * for why the other suites need it): nothing here goes through
@@ -36,8 +38,16 @@ process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 // ============================================================================
 
 const stubs = vi.hoisted(() => ({
-  /** payoutId -> charges Stripe reports for it, or an error to throw. */
-  payouts: new Map<string, { charges: unknown[] } | { error: string }>(),
+  /** payoutId -> composition Stripe reports for it, or an error to throw. */
+  payouts: new Map<
+    string,
+    | {
+        charges: unknown[];
+        reversedPaymentIntentIds?: string[];
+        unattributedReversalCents?: number;
+      }
+    | { error: string }
+  >(),
   /** Increase idempotency keys that should fail this run. */
   failTransferKeys: new Set<string>(),
   /** Every createAccountTransfer call, in order. */
@@ -46,13 +56,22 @@ const stubs = vi.hoisted(() => ({
     amountCents: number;
     idempotencyKey: string;
   }>,
+  /**
+   * Idempotency key -> the transfer Increase already minted for it. Modeling
+   * this matters: `alloc:{donationId}` is one of the locks the exactly-once
+   * claim rests on, and a mock that mints a fresh id every call can never
+   * exercise it.
+   */
+  transfersByKey: new Map<string, { id: string; status: string }>(),
+  /** Keys Increase collapsed into an existing transfer rather than creating one. */
+  dedupedKeys: [] as string[],
 }));
 
 vi.mock("../lib/finance/stripeConnect", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/finance/stripeConnect")>();
   return {
     ...actual,
-    listPayoutChargeNets: vi.fn(async (_accountId: string, payoutId: string) => {
+    getPayoutComposition: vi.fn(async (_accountId: string, payoutId: string) => {
       const stub = stubs.payouts.get(payoutId);
       if (!stub) {
         throw new Error(`test stub missing for payout ${payoutId}`);
@@ -60,7 +79,11 @@ vi.mock("../lib/finance/stripeConnect", async (importOriginal) => {
       if ("error" in stub) {
         throw new Error(stub.error);
       }
-      return stub.charges as PayoutChargeNet[];
+      return {
+        charges: stub.charges as PayoutChargeNet[],
+        reversedPaymentIntentIds: stub.reversedPaymentIntentIds ?? [],
+        unattributedReversalCents: stub.unattributedReversalCents ?? 0,
+      };
     }),
   };
 });
@@ -85,7 +108,16 @@ vi.mock("../lib/finance/increase", async (importOriginal) => {
             "Increase API POST /account_transfers failed (503): service unavailable",
           );
         }
-        return { id: `at_${input.idempotencyKey}`, status: "pending" };
+        // Increase's documented behaviour: at most one object per key. A
+        // repeat returns the SAME transfer instead of moving money again.
+        const existing = stubs.transfersByKey.get(input.idempotencyKey);
+        if (existing) {
+          stubs.dedupedKeys.push(input.idempotencyKey);
+          return existing;
+        }
+        const transfer = { id: `at_${input.idempotencyKey}`, status: "pending" };
+        stubs.transfersByKey.set(input.idempotencyKey, transfer);
+        return transfer;
       },
     ),
   };
@@ -95,6 +127,8 @@ beforeEach(() => {
   stubs.payouts.clear();
   stubs.failTransferKeys.clear();
   stubs.transferCalls.length = 0;
+  stubs.transfersByKey.clear();
+  stubs.dedupedKeys.length = 0;
 });
 
 // ============================================================================
@@ -380,7 +414,7 @@ describe("planAllocations (net matching)", () => {
     expect((await getDonation(t, donationId))?.allocationPayoutId).toBe("po_earlier");
   });
 
-  test("re-planning the same payout returns the same still-pending items and re-stamps nothing", async () => {
+  test("THE RACE: a second pass over the same payout cannot also take an item the first is still holding", async () => {
     const t = convexTest(schema, modules);
     const { communityId, fundAId } = await seedAllocFixture(t);
 
@@ -398,17 +432,53 @@ describe("planAllocations (net matching)", () => {
       charges: [{ paymentIntentId: "pi_replan", netCents: 4_825 }],
     };
     const first = await t.mutation(internal.functions.finance.jobs.planAllocations, args);
+    // Second pass while the first is still mid-transfer (a redelivered
+    // payout.paid, or the :45 retry cron). Before the lease, BOTH would have
+    // been handed this donation and both would have issued
+    // `alloc:{donationId}` concurrently.
     const second = await t.mutation(internal.functions.finance.jobs.planAllocations, args);
 
     expect(first.alreadyClaimed).toBe(false);
+    expect(first.plan.map((p) => p.donationId)).toEqual([donationId]);
+
     expect(second.alreadyClaimed).toBe(true);
-    expect(second.plan.map((p) => p.donationId)).toEqual([donationId]);
-    expect(second.plan[0].amountCents).toBe(4_825);
+    expect(second.plan).toHaveLength(0);
+    expect(second.leasedElsewhere).toBe(1);
 
     const payoutRows = await t.run((ctx) =>
       ctx.db.query("processedStripePayouts").collect(),
     );
     expect(payoutRows).toHaveLength(1);
+  });
+
+  test("an expired lease is reclaimable — a pass that died mid-transfer can't strand an item forever", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_expired_lease",
+      amountCents: 5_000,
+      createdAt: 1_000,
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(donationId, {
+        allocationPayoutId: "po_expired",
+        payoutNetCents: 4_825,
+        // Claimed by a pass that never came back. TTL is 15 minutes.
+        allocationTransferStartedAt: Date.now() - 60 * 60 * 1000,
+      });
+    });
+
+    const result = await t.mutation(internal.functions.finance.jobs.planAllocations, {
+      communityId,
+      payoutCents: 4_825,
+      stripePayoutId: "po_expired",
+      charges: [{ paymentIntentId: "pi_expired_lease", netCents: 4_825 }],
+    });
+
+    expect(result.plan.map((p) => p.donationId)).toEqual([donationId]);
+    expect(result.leasedElsewhere).toBe(0);
   });
 
   test("a nonsense net from Stripe is ignored rather than allocated", async () => {
@@ -894,5 +964,660 @@ describe("reconcile on the net basis", () => {
         pendingAllocationCents: 2_650,
       }),
     ).toEqual({ ok: true, driftCents: 0 });
+  });
+});
+
+// ============================================================================
+// Refunds — the P0. A gift the donor already got back must never reach a
+// group's spendable Increase Account.
+// ============================================================================
+
+/** Drive the real webhook mutation, not a hand-patched row: the refund's
+ * effect on allocation is the thing under test. */
+async function refundDonation(
+  t: ReturnType<typeof convexTest>,
+  args: { paymentIntentId: string; chargeId: string; amountRefundedCents: number },
+) {
+  await t.mutation(internal.functions.finance.giving.recordDonationRefund, args);
+}
+
+describe("refunds and allocation", () => {
+  test("THE P0: a donation refunded BEFORE its payout transfers nothing and leaves no negative balance", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    // $100 gift. Ledger +10000.
+    const refundedId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_refunded",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    // A healthy gift in the same payout, to prove the refund doesn't take
+    // the rest of the batch down with it.
+    const healthyId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_healthy",
+      amountCents: 5_000,
+      createdAt: 2_000,
+      creditLedger: true,
+    });
+
+    // Donor is refunded in full the next day, before the T+2 payout.
+    await refundDonation(t, {
+      paymentIntentId: "pi_refunded",
+      chargeId: "ch_refunded",
+      amountRefundedCents: 10_000,
+    });
+    expect((await getDonation(t, refundedId))?.allocationStatus).toBe("refunded");
+    expect((await t.run((ctx) => ctx.db.get(fundAId)))?.balanceCents).toBe(5_000);
+
+    // The payout carries the charge (+9680) AND the refund (−10000). Netted,
+    // that PaymentIntent contributed nothing, so Stripe reports it as
+    // reversed and it is not a fundable charge.
+    stubs.payouts.set("po_with_refund", {
+      charges: [{ paymentIntentId: "pi_healthy", netCents: 4_825 }],
+      reversedPaymentIntentIds: ["pi_refunded"],
+    });
+
+    const result = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_with_refund",
+      payoutCents: 4_825,
+    });
+
+    expect(result).toEqual({ allocated: 1, failed: 0 });
+    // The ONLY transfer is the healthy gift. Not one cent of the refunded
+    // gift reached the group's Account.
+    expect(stubs.transferCalls).toEqual([
+      {
+        toAccountId: "account_fund_a",
+        amountCents: 4_825,
+        idempotencyKey: `alloc:${healthyId}`,
+      },
+    ]);
+
+    const refunded = await getDonation(t, refundedId);
+    expect(refunded?.allocationStatus).toBe("refunded");
+    expect(refunded?.allocationPayoutId).toBeUndefined();
+    expect((await getDonation(t, healthyId))?.allocationStatus).toBe("allocated");
+
+    // Ledger: +10000 −10000 (refund) +5000 −175 (fee on the healthy gift).
+    // Never negative, and exactly what the bank now holds.
+    const fund = await t.run((ctx) => ctx.db.get(fundAId));
+    expect(fund?.balanceCents).toBe(4_825);
+    expect(fund!.balanceCents).toBeGreaterThanOrEqual(0);
+
+    // And the invariant closes: bank 4825, nothing pending.
+    const pending = await t.mutation(
+      internal.functions.finance.jobs.computePendingAllocationCents,
+      { communityId },
+    );
+    expect(pending.find((p) => p.fundId === fundAId)?.pendingCents).toBe(0);
+    expect(
+      await t.mutation(internal.functions.finance.jobs.recordReconcileResult, {
+        fundId: fundAId,
+        communityId,
+        ledgerBalanceCents: fund!.balanceCents,
+        bankBalanceCents: 4_825,
+        pendingAllocationCents: 0,
+      }),
+    ).toEqual({ ok: true, driftCents: 0 });
+
+    // No fee was ever charged for the refunded gift.
+    const entries = await t.run((ctx) =>
+      ctx.db
+        .query("ledgerEntries")
+        .withIndex("by_fund", (q) => q.eq("fundId", fundAId))
+        .collect(),
+    );
+    expect(entries.filter((e) => e.kind === "fee")).toHaveLength(1);
+  });
+
+  test("a PARTIAL refund before the payout allocates only the remainder, and the refund isn't double-debited", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_partial",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+
+    await refundDonation(t, {
+      paymentIntentId: "pi_partial",
+      chargeId: "ch_partial",
+      amountRefundedCents: 3_000,
+    });
+
+    // Still allocatable — the donor kept $70 of the gift with the group.
+    const afterRefund = await getDonation(t, donationId);
+    expect(afterRefund?.allocationStatus).toBe("pending");
+    expect(afterRefund?.refundedCents).toBe(3_000);
+    // Pending is the remainder, not the gross — otherwise the nightly
+    // invariant drifts by the refunded amount forever.
+    expect(
+      (
+        await t.mutation(
+          internal.functions.finance.jobs.computePendingAllocationCents,
+          { communityId },
+        )
+      ).find((p) => p.fundId === fundAId)?.pendingCents,
+    ).toBe(7_000);
+
+    // The payout delivers 10000 − 320 fee − 3000 refund = 6680 for this PI.
+    stubs.payouts.set("po_partial_refund", {
+      charges: [{ paymentIntentId: "pi_partial", netCents: 6_680 }],
+    });
+
+    const result = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_partial_refund",
+      payoutCents: 6_680,
+    });
+    expect(result).toEqual({ allocated: 1, failed: 0 });
+    expect(stubs.transferCalls[0].amountCents).toBe(6_680);
+
+    // The fee debit is 320 — Stripe's actual fee — NOT 3320. Charging
+    // `gross − net` here would debit the 3000 refund a second time on top of
+    // the refund entry that already exists.
+    const entries = await t.run((ctx) =>
+      ctx.db
+        .query("ledgerEntries")
+        .withIndex("by_fund", (q) => q.eq("fundId", fundAId))
+        .collect(),
+    );
+    const fee = entries.find((e) => e.kind === "fee");
+    expect(fee).toMatchObject({ direction: "debit", amountCents: 320 });
+
+    // 10000 − 3000 − 320 = 6680, exactly what the group Account holds.
+    const fund = await t.run((ctx) => ctx.db.get(fundAId));
+    expect(fund?.balanceCents).toBe(6_680);
+    expect(
+      await t.mutation(internal.functions.finance.jobs.recordReconcileResult, {
+        fundId: fundAId,
+        communityId,
+        ledgerBalanceCents: fund!.balanceCents,
+        bankBalanceCents: 6_680,
+        pendingAllocationCents: 0,
+      }),
+    ).toEqual({ ok: true, driftCents: 0 });
+  });
+
+  test("a full refund AFTER allocation reverses the fee instead of leaving the fund negative", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_late_refund",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    stubs.payouts.set("po_late", {
+      charges: [{ paymentIntentId: "pi_late_refund", netCents: 9_680 }],
+    });
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_late",
+      payoutCents: 9_680,
+    });
+    expect((await t.run((ctx) => ctx.db.get(fundAId)))?.balanceCents).toBe(9_680);
+
+    // Donor refunded a week later. Without the fee reversal this lands at
+    // −320 (10000 credit − 320 fee − 10000 refund) and renders to members.
+    await refundDonation(t, {
+      paymentIntentId: "pi_late_refund",
+      chargeId: "ch_late",
+      amountRefundedCents: 10_000,
+    });
+
+    const fund = await t.run((ctx) => ctx.db.get(fundAId));
+    expect(fund?.balanceCents).toBe(0);
+    expect(fund!.balanceCents).toBeGreaterThanOrEqual(0);
+
+    // Append-only: the fee debit is still there, cancelled by a credit.
+    const entries = await t.run((ctx) =>
+      ctx.db
+        .query("ledgerEntries")
+        .withIndex("by_fund", (q) => q.eq("fundId", fundAId))
+        .collect(),
+    );
+    const feeEntries = entries.filter((e) => e.kind === "fee");
+    expect(feeEntries).toHaveLength(2);
+    expect(feeEntries.map((e) => e.direction).sort()).toEqual(["credit", "debit"]);
+
+    // Replaying the same cumulative refund reverses nothing twice.
+    await refundDonation(t, {
+      paymentIntentId: "pi_late_refund",
+      chargeId: "ch_late",
+      amountRefundedCents: 10_000,
+    });
+    expect((await t.run((ctx) => ctx.db.get(fundAId)))?.balanceCents).toBe(0);
+  });
+
+  test("a partial refund that stays under the net does NOT reverse the fee", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_small_late_refund",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    stubs.payouts.set("po_small_late", {
+      charges: [{ paymentIntentId: "pi_small_late_refund", netCents: 9_680 }],
+    });
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_small_late",
+      payoutCents: 9_680,
+    });
+
+    await refundDonation(t, {
+      paymentIntentId: "pi_small_late_refund",
+      chargeId: "ch_small_late",
+      amountRefundedCents: 1_000,
+    });
+
+    // 10000 − 320 − 1000 = 8680: non-negative on its own, so the fee stands.
+    // Stripe really did keep it on the $90 the fund retained.
+    const fund = await t.run((ctx) => ctx.db.get(fundAId));
+    expect(fund?.balanceCents).toBe(8_680);
+    const entries = await t.run((ctx) =>
+      ctx.db
+        .query("ledgerEntries")
+        .withIndex("by_fund", (q) => q.eq("fundId", fundAId))
+        .collect(),
+    );
+    expect(entries.filter((e) => e.kind === "fee")).toHaveLength(1);
+  });
+
+  test("a partial refund landing after a payout bound the gift keeps the pending sum honest", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_bound_partial",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    // Bound at the full net — the payout couldn't have known about a refund
+    // that hadn't happened yet.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(donationId, {
+        allocationPayoutId: "po_bound_partial",
+        payoutNetCents: 9_680,
+      });
+    });
+
+    await refundDonation(t, {
+      paymentIntentId: "pi_bound_partial",
+      chargeId: "ch_bound_partial",
+      amountRefundedCents: 3_000,
+    });
+
+    // Ledger is 7000. Counting the stale 9680 net as pending would drift by
+    // the refunded 3000 every night and never close.
+    const fund = await t.run((ctx) => ctx.db.get(fundAId));
+    expect(fund?.balanceCents).toBe(7_000);
+    const pending = await t.mutation(
+      internal.functions.finance.jobs.computePendingAllocationCents,
+      { communityId },
+    );
+    expect(pending.find((p) => p.fundId === fundAId)?.pendingCents).toBe(7_000);
+    expect(
+      await t.mutation(internal.functions.finance.jobs.recordReconcileResult, {
+        fundId: fundAId,
+        communityId,
+        ledgerBalanceCents: fund!.balanceCents,
+        bankBalanceCents: 0,
+        pendingAllocationCents: 7_000,
+      }),
+    ).toEqual({ ok: true, driftCents: 0 });
+  });
+
+  test("a gift refunded while bound to a payout is dropped by the retry cron, not transferred", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_bound_then_refunded",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    // A pass bound it to a payout but its transfer never landed.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(donationId, {
+        allocationPayoutId: "po_bound",
+        payoutNetCents: 9_680,
+      });
+    });
+
+    await refundDonation(t, {
+      paymentIntentId: "pi_bound_then_refunded",
+      chargeId: "ch_bound",
+      amountRefundedCents: 10_000,
+    });
+
+    await t.action(internal.functions.finance.jobs.retryStaleAllocations, {});
+
+    expect(stubs.transferCalls).toHaveLength(0);
+    expect((await getDonation(t, donationId))?.allocationStatus).toBe("refunded");
+    expect((await t.run((ctx) => ctx.db.get(fundAId)))?.balanceCents).toBe(0);
+  });
+});
+
+// ============================================================================
+// Failure-mode separation and observability
+// ============================================================================
+
+describe("transfer vs. record failure", () => {
+  test("transfer LANDS but recording throws: audited as record_failed, and the retry re-uses the same transfer", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_record_fail",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    stubs.payouts.set("po_record_fail", {
+      charges: [{ paymentIntentId: "pi_record_fail", netCents: 9_680 }],
+    });
+
+    // `postLedgerEntry` throws on a closed fund — a real way for the
+    // recording half to fail after the money has already moved.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(fundAId, { status: "closed" });
+    });
+
+    const first = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_record_fail",
+      payoutCents: 9_680,
+    });
+    expect(first).toEqual({ allocated: 0, failed: 1 });
+
+    // The money DID move.
+    expect(stubs.transferCalls).toEqual([
+      {
+        toAccountId: "account_fund_a",
+        amountCents: 9_680,
+        idempotencyKey: `alloc:${donationId}`,
+      },
+    ]);
+    // And the audit says so, instead of claiming the transfer failed.
+    const actions = await auditActions(t, communityId);
+    expect(actions).toContain("allocation.record_failed");
+    expect(actions).not.toContain("allocation.transfer_failed");
+
+    const failureRow = await t.run((ctx) =>
+      ctx.db
+        .query("financeAuditEvents")
+        .withIndex("by_community", (q) => q.eq("communityId", communityId))
+        .collect(),
+    );
+    const recordFailed = failureRow.find((r) => r.action === "allocation.record_failed");
+    expect(JSON.parse(recordFailed!.detailsJson!)).toMatchObject({
+      donationId,
+      increaseTransferId: `at_alloc:${donationId}`,
+    });
+
+    // The item is released, not left leased.
+    expect(
+      (await getDonation(t, donationId))?.allocationTransferStartedAt,
+    ).toBeUndefined();
+
+    // --- The retry, once the fund is usable again. ---
+    await t.run(async (ctx) => {
+      await ctx.db.patch(fundAId, { status: "active" });
+    });
+    stubs.transferCalls.length = 0;
+
+    const second = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_record_fail",
+      payoutCents: 9_680,
+    });
+    expect(second).toEqual({ allocated: 1, failed: 0 });
+
+    // Increase collapsed the replay into the SAME transfer — money moved once.
+    expect(stubs.dedupedKeys).toEqual([`alloc:${donationId}`]);
+    expect(stubs.transfersByKey.size).toBe(1);
+
+    // One fee entry, one donation.allocated audit row.
+    const entries = await t.run((ctx) =>
+      ctx.db
+        .query("ledgerEntries")
+        .withIndex("by_fund", (q) => q.eq("fundId", fundAId))
+        .collect(),
+    );
+    expect(entries.filter((e) => e.kind === "fee")).toHaveLength(1);
+    expect(
+      (await auditActions(t, communityId)).filter((a) => a === "donation.allocated"),
+    ).toHaveLength(1);
+    expect((await t.run((ctx) => ctx.db.get(fundAId)))?.balanceCents).toBe(9_680);
+  });
+
+  test("a transfer that never happens is still audited as transfer_failed, with no transfer id", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_transfer_fail",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    stubs.payouts.set("po_transfer_fail", {
+      charges: [{ paymentIntentId: "pi_transfer_fail", netCents: 9_680 }],
+    });
+    stubs.failTransferKeys.add(`alloc:${donationId}`);
+
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_transfer_fail",
+      payoutCents: 9_680,
+    });
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("financeAuditEvents")
+        .withIndex("by_community", (q) => q.eq("communityId", communityId))
+        .collect(),
+    );
+    const failed = rows.find((r) => r.action === "allocation.transfer_failed");
+    expect(failed).toBeDefined();
+    expect(JSON.parse(failed!.detailsJson!).increaseTransferId).toBeUndefined();
+    // Released so the next pass can pick it up without waiting out the TTL.
+    expect(
+      (await getDonation(t, donationId))?.allocationTransferStartedAt,
+    ).toBeUndefined();
+  });
+});
+
+describe("unmatched payouts are observable", () => {
+  test("a payout that matches NOTHING alarms instead of returning zero quietly", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_unrelated",
+      amountCents: 4_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    // Stripe reports nothing for the payout — reconciliation lag, a manual
+    // payout, or a broken account. There is no automatic recovery from here,
+    // so it MUST be loud.
+    stubs.payouts.set("po_empty", { charges: [] });
+
+    const result = await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_empty",
+      payoutCents: 9_680,
+    });
+
+    expect(result).toEqual({ allocated: 0, failed: 0 });
+    expect(stubs.transferCalls).toHaveLength(0);
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("financeAuditEvents")
+        .withIndex("by_community", (q) => q.eq("communityId", communityId))
+        .collect(),
+    );
+    const unmatched = rows.find((r) => r.action === "allocation.payout_unmatched");
+    expect(unmatched).toBeDefined();
+    expect(JSON.parse(unmatched!.detailsJson!)).toMatchObject({
+      stripePayoutId: "po_empty",
+      payoutCents: 9_680,
+      leftoverCents: 9_680,
+      matchedCount: 0,
+      chargeCount: 0,
+    });
+  });
+
+  test("a material unmatched remainder alarms even when some donations did allocate", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_known",
+      amountCents: 1_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    // The payout is 50000 but only 941 of it maps to a donation we know —
+    // the rest is money we cannot attribute to anyone.
+    stubs.payouts.set("po_mostly_unmatched", {
+      charges: [{ paymentIntentId: "pi_known", netCents: 941 }],
+    });
+
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_mostly_unmatched",
+      payoutCents: 50_000,
+    });
+
+    expect(await auditActions(t, communityId)).toContain("allocation.payout_unmatched");
+  });
+
+  test("a fully matched payout does not alarm", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_exact",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    stubs.payouts.set("po_exact", {
+      charges: [{ paymentIntentId: "pi_exact", netCents: 9_680 }],
+    });
+
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_exact",
+      payoutCents: 9_680,
+    });
+
+    expect(await auditActions(t, communityId)).not.toContain(
+      "allocation.payout_unmatched",
+    );
+  });
+});
+
+describe("payout.failed", () => {
+  test("unbinds the donations a paid-then-failed payout claimed, so the retry cron stops chasing them", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_failed_payout",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    stubs.payouts.set("po_will_fail", {
+      charges: [{ paymentIntentId: "pi_failed_payout", netCents: 9_680 }],
+    });
+    stubs.failTransferKeys.add(`alloc:${donationId}`);
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_will_fail",
+      payoutCents: 9_680,
+    });
+    expect((await getDonation(t, donationId))?.allocationPayoutId).toBe("po_will_fail");
+
+    // The bank rejects the payout. The money never reached the receiving
+    // Account, so nothing may be transferred out of it.
+    const { unbound } = await t.mutation(
+      internal.functions.finance.jobs.unbindFailedPayout,
+      { communityId, stripePayoutId: "po_will_fail" },
+    );
+    expect(unbound).toBe(1);
+
+    const donation = await getDonation(t, donationId);
+    expect(donation?.allocationPayoutId).toBeUndefined();
+    expect(donation?.payoutNetCents).toBeUndefined();
+    expect(donation?.allocationStatus).toBe("pending");
+
+    // The hourly retry now finds nothing resumable — no transfer against an
+    // Account that never received the money.
+    stubs.failTransferKeys.clear();
+    stubs.transferCalls.length = 0;
+    await t.action(internal.functions.finance.jobs.retryStaleAllocations, {});
+    expect(stubs.transferCalls).toHaveLength(0);
+    expect(await auditActions(t, communityId)).toContain("allocation.payout_failed");
+  });
+
+  test("leaves an already-allocated donation alone — a completed transfer is a clawback, not a rollback", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, fundAId } = await seedAllocFixture(t);
+
+    const donationId = await seedDonation(t, {
+      fundId: fundAId,
+      paymentIntentId: "pi_already_done",
+      amountCents: 10_000,
+      createdAt: 1_000,
+      creditLedger: true,
+    });
+    stubs.payouts.set("po_paid_then_failed", {
+      charges: [{ paymentIntentId: "pi_already_done", netCents: 9_680 }],
+    });
+    await t.action(internal.functions.finance.jobs.runAllocation, {
+      communityId,
+      stripePayoutId: "po_paid_then_failed",
+      payoutCents: 9_680,
+    });
+
+    const { unbound } = await t.mutation(
+      internal.functions.finance.jobs.unbindFailedPayout,
+      { communityId, stripePayoutId: "po_paid_then_failed" },
+    );
+    expect(unbound).toBe(0);
+    const donation = await getDonation(t, donationId);
+    expect(donation?.allocationStatus).toBe("allocated");
+    expect(donation?.allocationPayoutId).toBe("po_paid_then_failed");
   });
 });

--- a/apps/convex/__tests__/finance-flag.test.ts
+++ b/apps/convex/__tests__/finance-flag.test.ts
@@ -209,22 +209,27 @@ describe("splitDonationAmounts (fee-cover double-count fix)", () => {
   });
 });
 
-describe("claimPayout (payout.paid replay protection)", () => {
-  test("second claim of the same stripePayoutId returns false", async () => {
+describe("planAllocations (payout.paid replay protection)", () => {
+  test("re-planning the same payout records it once and reports alreadyClaimed", async () => {
     const t = convexTest(schema, modules);
     const s = await seedWithoutFlag(t);
 
-    const first = await t.mutation(internal.functions.finance.jobs.claimPayout, {
+    // Settlement paths are deliberately NOT flag-gated (see this file's
+    // header): a payout that arrives while the flag is off must still
+    // allocate, and must still be replay-safe.
+    const args = {
       communityId: s.communityId,
       stripePayoutId: "po_replay_test",
       payoutCents: 12345,
-    });
-    const second = await t.mutation(internal.functions.finance.jobs.claimPayout, {
-      communityId: s.communityId,
-      stripePayoutId: "po_replay_test",
-      payoutCents: 12345,
-    });
-    expect(first).toBe(true);
-    expect(second).toBe(false);
+      charges: [],
+    };
+    const first = await t.mutation(internal.functions.finance.jobs.planAllocations, args);
+    const second = await t.mutation(internal.functions.finance.jobs.planAllocations, args);
+
+    expect(first.alreadyClaimed).toBe(false);
+    expect(second.alreadyClaimed).toBe(true);
+    expect(
+      await t.run((ctx) => ctx.db.query("processedStripePayouts").collect()),
+    ).toHaveLength(1);
   });
 });

--- a/apps/convex/__tests__/finance-giving.test.ts
+++ b/apps/convex/__tests__/finance-giving.test.ts
@@ -232,6 +232,28 @@ describe("getFundOverview", () => {
         actorUserId: s.donorUserId,
         createdAt: withinYearNotMonthTs,
       });
+      // Within this month: the Stripe processing fee allocation realises for
+      // the donation above. A debit, but NOT something the group spent — it
+      // must never inflate the member-facing "… spent" figure.
+      await ctx.db.insert("ledgerEntries", {
+        fundId: s.fundId,
+        communityId: s.communityId,
+        direction: "debit",
+        amountCents: 175,
+        kind: "fee",
+        idempotencyKey: "alloc-fee:donation_month",
+        createdAt: withinMonthTs,
+      });
+      // Within this month: a refund. Also a debit, also not spending.
+      await ctx.db.insert("ledgerEntries", {
+        fundId: s.fundId,
+        communityId: s.communityId,
+        direction: "debit",
+        amountCents: 400,
+        kind: "refund",
+        idempotencyKey: "refund:ch_month:400",
+        createdAt: withinMonthTs,
+      });
       // Before this year: excluded from both MTD and YTD entirely.
       await ctx.db.insert("ledgerEntries", {
         fundId: s.fundId,
@@ -252,14 +274,21 @@ describe("getFundOverview", () => {
 
     expect(memberResult).not.toBeNull();
     expect(memberResult!.balanceCents).toBe(10_000); // fund's cached balance, unaffected by these direct-insert entries
+    // "spent" is 300 — the card capture — and NOT 875. Bucketing the fee and
+    // the refund into spend would have a group that spent $3 report $8.75,
+    // on the one screen whose purpose is telling members where the money went.
     expect(memberResult!.monthToDate).toEqual({
       donationsCents: 5000,
       spentCents: 300,
+      feesCents: 175,
+      refundedCents: 400,
       donationCount: 1,
     });
     expect(memberResult!.yearToDate).toEqual({
       donationsCents: 5000 + 9999,
       spentCents: 300,
+      feesCents: 175,
+      refundedCents: 400,
       donationCount: 2,
     });
     expect(memberResult!.viewerCanSeeDonorNames).toBe(false);
@@ -1079,7 +1108,7 @@ async function seedJobsFixture(t: ReturnType<typeof convexTest>): Promise<JobsFi
 // reconcile.
 
 describe("recordAllocation", () => {
-  test("flips allocationStatus and audit-logs without changing the fund's balanceCents", async () => {
+  test("a donation with no recorded payout NET posts no fee entry, so the balance is untouched", async () => {
     const t = convexTest(schema, modules);
     const { fundAId } = await seedJobsFixture(t);
 
@@ -1106,7 +1135,19 @@ describe("recordAllocation", () => {
     expect(donation?.allocationStatus).toBe("allocated");
 
     const balanceAfter = await t.run(async (ctx) => (await ctx.db.get(fundAId))?.balanceCents);
-    expect(balanceAfter).toBe(balanceBefore); // no ledger entry posted — see jobs.ts's design-decision comment
+    // Unchanged specifically because this fixture donation carries no
+    // `payoutNetCents` — a legacy row allocated before net matching shipped,
+    // where there is no realised fee to post. Allocation of a NET-matched
+    // donation DOES post a `fee` debit and does move the balance; that side
+    // is covered in finance-allocation.test.ts.
+    expect(balanceAfter).toBe(balanceBefore);
+    const feeEntries = await t.run((ctx) =>
+      ctx.db
+        .query("ledgerEntries")
+        .withIndex("by_fund", (q) => q.eq("fundId", fundAId))
+        .collect(),
+    );
+    expect(feeEntries.filter((e) => e.kind === "fee")).toHaveLength(0);
 
     const auditEvents = await t.run((ctx) =>
       ctx.db

--- a/apps/convex/__tests__/finance-giving.test.ts
+++ b/apps/convex/__tests__/finance-giving.test.ts
@@ -4,8 +4,9 @@
  *
  * Covers functions/finance/giving.ts (getFundOverview aggregates + donor-name
  * gating, getGivingContext live-gating, recordDonationSucceeded idempotency)
- * functions/finance/jobs.ts (planAllocations, recordAllocation,
- * computePendingAllocationCents, recordReconcileResult), and
+ * functions/finance/jobs.ts (recordAllocation, computePendingAllocationCents,
+ * recordReconcileResult — payout matching and the allocation action itself
+ * are covered in __tests__/finance-allocation.test.ts), and
  * lib/finance/receipts.ts (buildDonationReceiptEmail content). The live
  * Stripe/Resend/Increase paths (createDonationIntent, sendDonationReceipt's
  * actual send, runAllocation/runNightlyReconcile's provider calls) are
@@ -1071,94 +1072,11 @@ async function seedJobsFixture(t: ReturnType<typeof convexTest>): Promise<JobsFi
   });
 }
 
-describe("planAllocations", () => {
-  test("selects pending donations oldest-first across the whole community, whole donations only, with leftover", async () => {
-    const t = convexTest(schema, modules);
-    const { communityId, fundAId, fundBId } = await seedJobsFixture(t);
-
-    await t.run(async (ctx) => {
-      // Oldest, on fund A: total 1000.
-      await ctx.db.insert("donations", {
-        fundId: fundAId,
-        amountCents: 1000,
-        feeCoverCents: 0,
-        stripePaymentIntentId: "pi_1",
-        allocationStatus: "pending",
-        receiptEmailStatus: "sent",
-        createdAt: 1_000,
-      });
-      // Second oldest, on fund B: total 2100.
-      await ctx.db.insert("donations", {
-        fundId: fundBId,
-        amountCents: 2000,
-        feeCoverCents: 100,
-        stripePaymentIntentId: "pi_2",
-        allocationStatus: "pending",
-        receiptEmailStatus: "sent",
-        createdAt: 2_000,
-      });
-      // Newest, on fund A: total 5000 — doesn't fit in a 3100-cent payout.
-      await ctx.db.insert("donations", {
-        fundId: fundAId,
-        amountCents: 5000,
-        feeCoverCents: 0,
-        stripePaymentIntentId: "pi_3",
-        allocationStatus: "pending",
-        receiptEmailStatus: "sent",
-        createdAt: 3_000,
-      });
-      // Already allocated — must never be selected, even though it's oldest.
-      await ctx.db.insert("donations", {
-        fundId: fundAId,
-        amountCents: 999,
-        feeCoverCents: 0,
-        stripePaymentIntentId: "pi_0_already_allocated",
-        allocationStatus: "allocated",
-        receiptEmailStatus: "sent",
-        createdAt: 500,
-      });
-    });
-
-    const result = await t.mutation(internal.functions.finance.jobs.planAllocations, {
-      communityId,
-      payoutCents: 3100,
-      stripePayoutId: "po_test_1",
-    });
-
-    expect(result.plan).toHaveLength(2);
-    expect(result.plan[0]).toMatchObject({ fundId: fundAId, amountCents: 1000 });
-    expect(result.plan[1]).toMatchObject({ fundId: fundBId, amountCents: 2100 });
-    expect(result.leftoverCents).toBe(0);
-  });
-
-  test("leftoverCents reflects a payout that doesn't exactly cover whole donations", async () => {
-    const t = convexTest(schema, modules);
-    const { communityId, fundAId } = await seedJobsFixture(t);
-
-    await t.run((ctx) =>
-      ctx.db.insert("donations", {
-        fundId: fundAId,
-        amountCents: 1000,
-        feeCoverCents: 0,
-        stripePaymentIntentId: "pi_solo",
-        allocationStatus: "pending",
-        receiptEmailStatus: "sent",
-        createdAt: 1_000,
-      }),
-    );
-
-    // Payout is $9.90 more than the one donation — e.g. Stripe's processing
-    // fee taken out of the gross payout, never matching a whole donation.
-    const result = await t.mutation(internal.functions.finance.jobs.planAllocations, {
-      communityId,
-      payoutCents: 1990,
-      stripePayoutId: "po_test_2",
-    });
-
-    expect(result.plan).toHaveLength(1);
-    expect(result.leftoverCents).toBe(990);
-  });
-});
+// `planAllocations` selection (NET matching, skip-don't-stall, per-donation
+// replay protection) lives in __tests__/finance-allocation.test.ts alongside
+// the `runAllocation` action it feeds — this file keeps the two pieces that
+// stand alone from a payout: recordAllocation and the pending-sum used by
+// reconcile.
 
 describe("recordAllocation", () => {
   test("flips allocationStatus and audit-logs without changing the fund's balanceCents", async () => {

--- a/apps/convex/__tests__/finance-payout-nets.test.ts
+++ b/apps/convex/__tests__/finance-payout-nets.test.ts
@@ -66,14 +66,20 @@ function refundTxn(id: string, paymentIntentId: string, net: number) {
   };
 }
 
-async function composition(payoutId = "po_1") {
+/**
+ * `payoutCents` is not decoration: a payout IS the sum of the nets Stripe
+ * attributed to it (excluding the payout's own leg), and `getPayoutComposition`
+ * refuses a composition that doesn't add up to it. Every case below therefore
+ * states the arithmetic total of the rows it feeds in.
+ */
+async function composition(payoutId: string, payoutCents: number) {
   const { getPayoutComposition } = await import("../lib/finance/stripeConnect");
-  return await getPayoutComposition("acct_connected", payoutId);
+  return await getPayoutComposition("acct_connected", payoutId, payoutCents);
 }
 
 /** The charges half, which is what allocation actually plans against. */
-async function listNets(payoutId = "po_1") {
-  return (await composition(payoutId)).charges;
+async function listNets(payoutId: string, payoutCents: number) {
+  return (await composition(payoutId, payoutCents)).charges;
 }
 
 describe("getPayoutComposition", () => {
@@ -83,7 +89,7 @@ describe("getPayoutComposition", () => {
       has_more: false,
     });
 
-    expect(await listNets("po_abc")).toEqual([
+    expect(await listNets("po_abc", 14_505)).toEqual([
       { paymentIntentId: "pi_1", netCents: 9_680 },
       { paymentIntentId: "pi_2", netCents: 4_825 },
     ]);
@@ -108,7 +114,9 @@ describe("getPayoutComposition", () => {
       has_more: false,
     });
 
-    expect(await listNets()).toEqual([{ paymentIntentId: "pi_1", netCents: 9_680 }]);
+    expect(await listNets("po_bookkeeping", 9_630)).toEqual([
+      { paymentIntentId: "pi_1", netCents: 9_680 },
+    ]);
   });
 
   test("THE P0: a refund is netted against its charge, never discarded — a fully refunded gift yields NO fundable charge", async () => {
@@ -128,12 +136,12 @@ describe("getPayoutComposition", () => {
       has_more: false,
     });
 
-    const result = await composition("po_refund");
+    const result = await composition("po_refund", 4_505);
     expect(result.charges).toEqual([
       { paymentIntentId: "pi_healthy", netCents: 4_825 },
     ]);
     expect(result.reversedPaymentIntentIds).toEqual(["pi_refunded"]);
-    expect(result.unattributedReversalCents).toBe(0);
+    expect(result.unattributedNetCents).toBe(0);
   });
 
   test("a PARTIAL refund reduces its charge's net rather than removing it", async () => {
@@ -145,7 +153,7 @@ describe("getPayoutComposition", () => {
       has_more: false,
     });
 
-    const result = await composition("po_partial_refund");
+    const result = await composition("po_partial_refund", 6_680);
     expect(result.charges).toEqual([
       { paymentIntentId: "pi_partial", netCents: 6_680 },
     ]);
@@ -162,12 +170,14 @@ describe("getPayoutComposition", () => {
           net: -11_500, // gift back plus Stripe's dispute fee
           source: { id: "dp_1", payment_intent: "pi_disputed" },
         },
+        chargeTxn("txn_other", "pi_other", 20_000),
       ],
       has_more: false,
     });
 
-    const result = await composition("po_disputed");
-    expect(result.charges).toEqual([]);
+    // 9680 - 11500 + 20000 = 18180.
+    const result = await composition("po_disputed", 18_180);
+    expect(result.charges).toEqual([{ paymentIntentId: "pi_other", netCents: 20_000 }]);
     expect(result.reversedPaymentIntentIds).toEqual(["pi_disputed"]);
   });
 
@@ -182,9 +192,9 @@ describe("getPayoutComposition", () => {
       has_more: false,
     });
 
-    const result = await composition("po_orphan_refund");
+    const result = await composition("po_orphan_refund", 8_680);
     expect(result.charges).toEqual([{ paymentIntentId: "pi_1", netCents: 9_680 }]);
-    expect(result.unattributedReversalCents).toBe(-1_000);
+    expect(result.unattributedNetCents).toBe(-1_000);
   });
 
   test("a failed refund puts the money back, so it nets positively", async () => {
@@ -202,7 +212,9 @@ describe("getPayoutComposition", () => {
       has_more: false,
     });
 
-    expect(await listNets()).toEqual([{ paymentIntentId: "pi_1", netCents: 9_680 }]);
+    expect(await listNets("po_refund_failed", 9_680)).toEqual([
+      { paymentIntentId: "pi_1", netCents: 9_680 },
+    ]);
   });
 
   test("includes ACH-debit charges, which Stripe types as 'payment'", async () => {
@@ -218,7 +230,7 @@ describe("getPayoutComposition", () => {
       has_more: false,
     });
 
-    expect(await listNets()).toEqual([
+    expect(await listNets("po_ach", 49_600)).toEqual([
       { paymentIntentId: "pi_ach", netCents: 49_600 },
     ]);
   });
@@ -229,7 +241,7 @@ describe("getPayoutComposition", () => {
       { data: [chargeTxn("txn_2", "pi_2", 200)], has_more: false },
     );
 
-    expect(await listNets()).toEqual([
+    expect(await listNets("po_paged", 300)).toEqual([
       { paymentIntentId: "pi_1", netCents: 100 },
       { paymentIntentId: "pi_2", netCents: 200 },
     ]);
@@ -241,11 +253,20 @@ describe("getPayoutComposition", () => {
   test("nets a charge and its refund across DIFFERENT pages", async () => {
     stubs.pages.push(
       { data: [chargeTxn("txn_1", "pi_split", 9_680)], has_more: true },
-      { data: [refundTxn("txn_2", "pi_split", -10_000)], has_more: false },
+      {
+        data: [
+          refundTxn("txn_2", "pi_split", -10_000),
+          chargeTxn("txn_3", "pi_healthy", 10_000),
+        ],
+        has_more: false,
+      },
     );
 
-    const result = await composition("po_split_pages");
-    expect(result.charges).toEqual([]);
+    // 9680 - 10000 + 10000 = 9680.
+    const result = await composition("po_split_pages", 9_680);
+    expect(result.charges).toEqual([
+      { paymentIntentId: "pi_healthy", netCents: 10_000 },
+    ]);
     expect(result.reversedPaymentIntentIds).toEqual(["pi_split"]);
   });
 
@@ -260,7 +281,7 @@ describe("getPayoutComposition", () => {
       });
     }
 
-    await expect(composition("po_huge")).rejects.toThrow(
+    await expect(composition("po_huge", 12_000)).rejects.toThrow(
       /refusing to allocate on a truncated view/,
     );
   });
@@ -276,7 +297,9 @@ describe("getPayoutComposition", () => {
       has_more: false,
     });
 
-    expect(await listNets()).toEqual([{ paymentIntentId: "pi_ok", netCents: 700 }]);
+    expect(await listNets("po_unmappable", 1_800)).toEqual([
+      { paymentIntentId: "pi_ok", netCents: 700 },
+    ]);
   });
 
   test("accepts an expanded payment_intent object, not just an id", async () => {
@@ -292,22 +315,119 @@ describe("getPayoutComposition", () => {
       has_more: false,
     });
 
-    expect(await listNets()).toEqual([
+    expect(await listNets("po_expanded", 800)).toEqual([
       { paymentIntentId: "pi_expanded", netCents: 800 },
     ]);
   });
 
-  test("drops non-integer or non-positive charge nets — never allocates a fractional cent", async () => {
+  test("drops zero and non-positive charge nets — only a gift that delivered something is fundable", async () => {
     stubs.pages.push({
       data: [
-        chargeTxn("txn_1", "pi_float", 100.5),
         chargeTxn("txn_2", "pi_zero", 0),
+        // Nonsense from Stripe. Netted signed rather than dropped (dropping
+        // it would put the payout total out of balance), which can only push
+        // this PaymentIntent below zero and OUT of the fundable set.
         chargeTxn("txn_3", "pi_negative", -400),
         chargeTxn("txn_4", "pi_good", 400),
       ],
       has_more: false,
     });
 
-    expect(await listNets()).toEqual([{ paymentIntentId: "pi_good", netCents: 400 }]);
+    const result = await composition("po_nonsense", 0);
+    expect(result.charges).toEqual([{ paymentIntentId: "pi_good", netCents: 400 }]);
+    expect(result.reversedPaymentIntentIds).toEqual(["pi_negative"]);
+  });
+
+  test("REFUSES a fractional net rather than dropping the row and allocating the rest", async () => {
+    stubs.pages.push({
+      data: [chargeTxn("txn_1", "pi_float", 100.5), chargeTxn("txn_2", "pi_ok", 400)],
+      has_more: false,
+    });
+
+    await expect(composition("po_float", 500)).rejects.toThrow(
+      /non-integer net/,
+    );
+  });
+
+  // ==========================================================================
+  // P1-6: membership is decided by `payment_intent`, not by `type`
+  // ==========================================================================
+
+  test("THE MISS: `payment_reversal` — a real type the old allowlist omitted — nets against its payment", async () => {
+    // Two $500 ACH gifts; the bank reverses one after Stripe had already
+    // credited it. `payment_reversal` was not in the reversal allowlist (which
+    // instead listed `payment_refund_failure`, a type Stripe does not emit),
+    // so the reversed gift kept its full net and got FUNDED, while the
+    // residual-budget check absorbed the shortfall by stranding the healthy
+    // one — with leftoverCents at 0, so nothing alarmed.
+    stubs.pages.push({
+      data: [
+        { id: "txn_a", type: "payment", net: 49_600, source: { id: "py_a", payment_intent: "pi_healthy" } },
+        { id: "txn_b", type: "payment", net: 49_600, source: { id: "py_b", payment_intent: "pi_reversed" } },
+        {
+          id: "txn_rev",
+          type: "payment_reversal",
+          net: -49_600,
+          source: { id: "pyr_b", payment_intent: "pi_reversed" },
+        },
+        { id: "txn_payout", type: "payout", net: -49_600, source: "po_rev" },
+      ],
+      has_more: false,
+    });
+
+    const result = await composition("po_rev", 49_600);
+    expect(result.charges).toEqual([
+      { paymentIntentId: "pi_healthy", netCents: 49_600 },
+    ]);
+    expect(result.reversedPaymentIntentIds).toEqual(["pi_reversed"]);
+    expect(result.unattributedNetCents).toBe(0);
+  });
+
+  test("a type invented after this code was written still nets, because only `payment_intent` decides", async () => {
+    stubs.pages.push({
+      data: [
+        chargeTxn("txn_1", "pi_1", 9_680),
+        {
+          id: "txn_future",
+          type: "some_future_reversal_type_stripe_adds_in_2027",
+          net: -9_680,
+          source: { id: "xx_1", payment_intent: "pi_1" },
+        },
+        chargeTxn("txn_2", "pi_2", 4_825),
+      ],
+      has_more: false,
+    });
+
+    const result = await composition("po_future", 4_825);
+    expect(result.charges).toEqual([{ paymentIntentId: "pi_2", netCents: 4_825 }]);
+    expect(result.reversedPaymentIntentIds).toEqual(["pi_1"]);
+  });
+
+  test("REFUSES a composition whose nets don't add up to the payout — a partial read is not a payout", async () => {
+    // Stripe attributes balance transactions asynchronously, so a query at
+    // `payout.paid` can come back with only some of them. Allocating against
+    // that view allocates against money that may not be there.
+    stubs.pages.push({
+      data: [chargeTxn("txn_1", "pi_1", 9_680)],
+      has_more: false,
+    });
+
+    await expect(composition("po_partial_read", 19_360)).rejects.toThrow(
+      /balance transactions net to 9680 cents but the payout is 19360/,
+    );
+  });
+
+  test("the payout's own leg is excluded from the total rather than double-counted", async () => {
+    stubs.pages.push({
+      data: [
+        chargeTxn("txn_1", "pi_1", 9_680),
+        { id: "txn_payout", type: "payout", net: -9_680, source: "po_leg" },
+      ],
+      has_more: false,
+    });
+
+    expect(await listNets("po_leg", 9_680)).toEqual([
+      { paymentIntentId: "pi_1", netCents: 9_680 },
+    ]);
   });
 });

--- a/apps/convex/__tests__/finance-payout-nets.test.ts
+++ b/apps/convex/__tests__/finance-payout-nets.test.ts
@@ -1,14 +1,14 @@
 /**
- * `listPayoutChargeNets` (lib/finance/stripeConnect.ts) — the Stripe
+ * `getPayoutComposition` (lib/finance/stripeConnect.ts) — the Stripe
  * balance-transaction lookup that ADR-032 Phase-2 requirement 6 makes
  * allocation depend on.
  *
  * Lives in its own file because it mocks the `stripe` SDK itself, which the
  * rest of the finance suites deliberately never load. Everything asserted
  * here is about turning a payout's balance transactions into the per-charge
- * NET amounts allocation can actually fund: paging, non-charge rows, and the
- * PaymentIntent mapping that connects a balance transaction to a `donations`
- * row.
+ * NET amounts allocation can actually fund: paging, netting reversals against
+ * their charge, and the PaymentIntent mapping that connects a balance
+ * transaction to a `donations` row.
  *
  * Run with: cd apps/convex && pnpm test __tests__/finance-payout-nets.test.ts
  */
@@ -54,12 +54,29 @@ function chargeTxn(id: string, paymentIntentId: string, net: number) {
   };
 }
 
-async function listNets(payoutId = "po_1") {
-  const { listPayoutChargeNets } = await import("../lib/finance/stripeConnect");
-  return await listPayoutChargeNets("acct_connected", payoutId);
+/** A refund-type balance transaction. Its expanded `source` is a Refund,
+ * which carries `payment_intent` just like a Charge does — and its `net` is
+ * already negative. */
+function refundTxn(id: string, paymentIntentId: string, net: number) {
+  return {
+    id,
+    type: "refund",
+    net,
+    source: { id: `re_${id}`, payment_intent: paymentIntentId },
+  };
 }
 
-describe("listPayoutChargeNets", () => {
+async function composition(payoutId = "po_1") {
+  const { getPayoutComposition } = await import("../lib/finance/stripeConnect");
+  return await getPayoutComposition("acct_connected", payoutId);
+}
+
+/** The charges half, which is what allocation actually plans against. */
+async function listNets(payoutId = "po_1") {
+  return (await composition(payoutId)).charges;
+}
+
+describe("getPayoutComposition", () => {
   test("returns the NET per charge, keyed by PaymentIntent, scoped to the connected account", async () => {
     stubs.pages.push({
       data: [chargeTxn("txn_1", "pi_1", 9_680), chargeTxn("txn_2", "pi_2", 4_825)],
@@ -81,13 +98,106 @@ describe("listPayoutChargeNets", () => {
     expect(stubs.calls[0].options).toEqual({ stripeAccount: "acct_connected" });
   });
 
-  test("skips fee/payout/refund rows — they are the payout's leftover, not donor money", async () => {
+  test("skips pure bookkeeping rows — Stripe's own fee and the payout leg are not donor money", async () => {
     stubs.pages.push({
       data: [
         chargeTxn("txn_1", "pi_1", 9_680),
         { id: "txn_fee", type: "stripe_fee", net: -50, source: null },
         { id: "txn_payout", type: "payout", net: -9_630, source: "po_abc" },
-        { id: "txn_refund", type: "refund", net: -1_000, source: { id: "re_1" } },
+      ],
+      has_more: false,
+    });
+
+    expect(await listNets()).toEqual([{ paymentIntentId: "pi_1", netCents: 9_680 }]);
+  });
+
+  test("THE P0: a refund is netted against its charge, never discarded — a fully refunded gift yields NO fundable charge", async () => {
+    // $100 gift, refunded in full before the payout settled. Stripe pays out
+    // the charge's net (9680) and takes the refund (10000) out of the same
+    // payout. Dropping the refund row (as this used to) left 9680 looking
+    // like a fundable gift, and the donation is still `pending` because
+    // nothing about a refund used to touch allocationStatus — so real money
+    // the donor already got back was transferred into a group's spendable
+    // Increase Account.
+    stubs.pages.push({
+      data: [
+        chargeTxn("txn_1", "pi_refunded", 9_680),
+        refundTxn("txn_2", "pi_refunded", -10_000),
+        chargeTxn("txn_3", "pi_healthy", 4_825),
+      ],
+      has_more: false,
+    });
+
+    const result = await composition("po_refund");
+    expect(result.charges).toEqual([
+      { paymentIntentId: "pi_healthy", netCents: 4_825 },
+    ]);
+    expect(result.reversedPaymentIntentIds).toEqual(["pi_refunded"]);
+    expect(result.unattributedReversalCents).toBe(0);
+  });
+
+  test("a PARTIAL refund reduces its charge's net rather than removing it", async () => {
+    stubs.pages.push({
+      data: [
+        chargeTxn("txn_1", "pi_partial", 9_680),
+        refundTxn("txn_2", "pi_partial", -3_000),
+      ],
+      has_more: false,
+    });
+
+    const result = await composition("po_partial_refund");
+    expect(result.charges).toEqual([
+      { paymentIntentId: "pi_partial", netCents: 6_680 },
+    ]);
+    expect(result.reversedPaymentIntentIds).toEqual([]);
+  });
+
+  test("a chargeback posts as an `adjustment` and nets out the same way", async () => {
+    stubs.pages.push({
+      data: [
+        chargeTxn("txn_1", "pi_disputed", 9_680),
+        {
+          id: "txn_dispute",
+          type: "adjustment",
+          net: -11_500, // gift back plus Stripe's dispute fee
+          source: { id: "dp_1", payment_intent: "pi_disputed" },
+        },
+      ],
+      has_more: false,
+    });
+
+    const result = await composition("po_disputed");
+    expect(result.charges).toEqual([]);
+    expect(result.reversedPaymentIntentIds).toEqual(["pi_disputed"]);
+  });
+
+  test("a refund whose PaymentIntent can't be resolved is reported, not silently swallowed", async () => {
+    stubs.pages.push({
+      data: [
+        chargeTxn("txn_1", "pi_1", 9_680),
+        // Unexpanded source: we cannot tell which charge this reversed, so
+        // the payout is short by 1000 cents we can't subtract from anything.
+        { id: "txn_orphan", type: "refund", net: -1_000, source: "re_unexpanded" },
+      ],
+      has_more: false,
+    });
+
+    const result = await composition("po_orphan_refund");
+    expect(result.charges).toEqual([{ paymentIntentId: "pi_1", netCents: 9_680 }]);
+    expect(result.unattributedReversalCents).toBe(-1_000);
+  });
+
+  test("a failed refund puts the money back, so it nets positively", async () => {
+    stubs.pages.push({
+      data: [
+        chargeTxn("txn_1", "pi_1", 9_680),
+        refundTxn("txn_2", "pi_1", -9_680),
+        {
+          id: "txn_refund_failed",
+          type: "refund_failure",
+          net: 9_680,
+          source: { id: "re_1", payment_intent: "pi_1" },
+        },
       ],
       has_more: false,
     });
@@ -128,6 +238,33 @@ describe("listPayoutChargeNets", () => {
     expect(stubs.calls[1].params.starting_after).toBe("txn_1");
   });
 
+  test("nets a charge and its refund across DIFFERENT pages", async () => {
+    stubs.pages.push(
+      { data: [chargeTxn("txn_1", "pi_split", 9_680)], has_more: true },
+      { data: [refundTxn("txn_2", "pi_split", -10_000)], has_more: false },
+    );
+
+    const result = await composition("po_split_pages");
+    expect(result.charges).toEqual([]);
+    expect(result.reversedPaymentIntentIds).toEqual(["pi_split"]);
+  });
+
+  test("REFUSES to allocate on a truncated view rather than returning the prefix", async () => {
+    // 100 pages that all still say has_more: the cap is hit while Stripe
+    // insists there is more. Returning the prefix would look like a complete
+    // payout, and every retry would read the same first 100 pages.
+    for (let i = 0; i < 120; i++) {
+      stubs.pages.push({
+        data: [chargeTxn(`txn_${i}`, `pi_${i}`, 100)],
+        has_more: true,
+      });
+    }
+
+    await expect(composition("po_huge")).rejects.toThrow(
+      /refusing to allocate on a truncated view/,
+    );
+  });
+
   test("drops a charge with no resolvable payment_intent rather than guessing", async () => {
     stubs.pages.push({
       data: [
@@ -160,7 +297,7 @@ describe("listPayoutChargeNets", () => {
     ]);
   });
 
-  test("drops non-integer or non-positive nets — never allocates a fractional cent", async () => {
+  test("drops non-integer or non-positive charge nets — never allocates a fractional cent", async () => {
     stubs.pages.push({
       data: [
         chargeTxn("txn_1", "pi_float", 100.5),

--- a/apps/convex/__tests__/finance-payout-nets.test.ts
+++ b/apps/convex/__tests__/finance-payout-nets.test.ts
@@ -1,0 +1,176 @@
+/**
+ * `listPayoutChargeNets` (lib/finance/stripeConnect.ts) — the Stripe
+ * balance-transaction lookup that ADR-032 Phase-2 requirement 6 makes
+ * allocation depend on.
+ *
+ * Lives in its own file because it mocks the `stripe` SDK itself, which the
+ * rest of the finance suites deliberately never load. Everything asserted
+ * here is about turning a payout's balance transactions into the per-charge
+ * NET amounts allocation can actually fund: paging, non-charge rows, and the
+ * PaymentIntent mapping that connects a balance transaction to a `donations`
+ * row.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/finance-payout-nets.test.ts
+ */
+
+import { expect, test, describe, vi, beforeEach } from "vitest";
+
+const stubs = vi.hoisted(() => ({
+  /** Pages returned in order by balanceTransactions.list. */
+  pages: [] as Array<{ data: unknown[]; has_more: boolean }>,
+  /** Every list() call's params, for asserting paging + connected account. */
+  calls: [] as Array<{ params: Record<string, unknown>; options: unknown }>,
+}));
+
+vi.mock("stripe", () => {
+  class FakeStripe {
+    balanceTransactions = {
+      list: async (params: Record<string, unknown>, options: unknown) => {
+        stubs.calls.push({ params, options });
+        return (
+          stubs.pages[stubs.calls.length - 1] ?? { data: [], has_more: false }
+        );
+      },
+    };
+  }
+  return { default: FakeStripe };
+});
+
+process.env.STRIPE_SECRET_KEY = "sk_test_payout_nets";
+
+beforeEach(() => {
+  stubs.pages.length = 0;
+  stubs.calls.length = 0;
+});
+
+/** A charge-type balance transaction with `source` expanded, as Stripe
+ * returns it when `expand: ["data.source"]` is sent. */
+function chargeTxn(id: string, paymentIntentId: string, net: number) {
+  return {
+    id,
+    type: "charge",
+    net,
+    source: { id: `ch_${id}`, payment_intent: paymentIntentId },
+  };
+}
+
+async function listNets(payoutId = "po_1") {
+  const { listPayoutChargeNets } = await import("../lib/finance/stripeConnect");
+  return await listPayoutChargeNets("acct_connected", payoutId);
+}
+
+describe("listPayoutChargeNets", () => {
+  test("returns the NET per charge, keyed by PaymentIntent, scoped to the connected account", async () => {
+    stubs.pages.push({
+      data: [chargeTxn("txn_1", "pi_1", 9_680), chargeTxn("txn_2", "pi_2", 4_825)],
+      has_more: false,
+    });
+
+    expect(await listNets("po_abc")).toEqual([
+      { paymentIntentId: "pi_1", netCents: 9_680 },
+      { paymentIntentId: "pi_2", netCents: 4_825 },
+    ]);
+
+    expect(stubs.calls).toHaveLength(1);
+    expect(stubs.calls[0].params).toMatchObject({
+      payout: "po_abc",
+      expand: ["data.source"],
+    });
+    // Payouts and their charges live on the CONNECTED account, not the
+    // platform account.
+    expect(stubs.calls[0].options).toEqual({ stripeAccount: "acct_connected" });
+  });
+
+  test("skips fee/payout/refund rows — they are the payout's leftover, not donor money", async () => {
+    stubs.pages.push({
+      data: [
+        chargeTxn("txn_1", "pi_1", 9_680),
+        { id: "txn_fee", type: "stripe_fee", net: -50, source: null },
+        { id: "txn_payout", type: "payout", net: -9_630, source: "po_abc" },
+        { id: "txn_refund", type: "refund", net: -1_000, source: { id: "re_1" } },
+      ],
+      has_more: false,
+    });
+
+    expect(await listNets()).toEqual([{ paymentIntentId: "pi_1", netCents: 9_680 }]);
+  });
+
+  test("includes ACH-debit charges, which Stripe types as 'payment'", async () => {
+    stubs.pages.push({
+      data: [
+        {
+          id: "txn_ach",
+          type: "payment",
+          net: 49_600,
+          source: { id: "py_1", payment_intent: "pi_ach" },
+        },
+      ],
+      has_more: false,
+    });
+
+    expect(await listNets()).toEqual([
+      { paymentIntentId: "pi_ach", netCents: 49_600 },
+    ]);
+  });
+
+  test("pages until has_more is false, carrying starting_after", async () => {
+    stubs.pages.push(
+      { data: [chargeTxn("txn_1", "pi_1", 100)], has_more: true },
+      { data: [chargeTxn("txn_2", "pi_2", 200)], has_more: false },
+    );
+
+    expect(await listNets()).toEqual([
+      { paymentIntentId: "pi_1", netCents: 100 },
+      { paymentIntentId: "pi_2", netCents: 200 },
+    ]);
+    expect(stubs.calls).toHaveLength(2);
+    expect(stubs.calls[0].params.starting_after).toBeUndefined();
+    expect(stubs.calls[1].params.starting_after).toBe("txn_1");
+  });
+
+  test("drops a charge with no resolvable payment_intent rather than guessing", async () => {
+    stubs.pages.push({
+      data: [
+        // Unexpanded source: just the charge id, no way back to a donation.
+        { id: "txn_1", type: "charge", net: 500, source: "ch_unexpanded" },
+        { id: "txn_2", type: "charge", net: 600, source: { id: "ch_2" } },
+        chargeTxn("txn_3", "pi_ok", 700),
+      ],
+      has_more: false,
+    });
+
+    expect(await listNets()).toEqual([{ paymentIntentId: "pi_ok", netCents: 700 }]);
+  });
+
+  test("accepts an expanded payment_intent object, not just an id", async () => {
+    stubs.pages.push({
+      data: [
+        {
+          id: "txn_1",
+          type: "charge",
+          net: 800,
+          source: { id: "ch_1", payment_intent: { id: "pi_expanded" } },
+        },
+      ],
+      has_more: false,
+    });
+
+    expect(await listNets()).toEqual([
+      { paymentIntentId: "pi_expanded", netCents: 800 },
+    ]);
+  });
+
+  test("drops non-integer or non-positive nets — never allocates a fractional cent", async () => {
+    stubs.pages.push({
+      data: [
+        chargeTxn("txn_1", "pi_float", 100.5),
+        chargeTxn("txn_2", "pi_zero", 0),
+        chargeTxn("txn_3", "pi_negative", -400),
+        chargeTxn("txn_4", "pi_good", 400),
+      ],
+      has_more: false,
+    });
+
+    expect(await listNets()).toEqual([{ paymentIntentId: "pi_good", netCents: 400 }]);
+  });
+});

--- a/apps/convex/functions/finance/ARCHITECTURE.md
+++ b/apps/convex/functions/finance/ARCHITECTURE.md
@@ -4,15 +4,15 @@
 
 **functions/finance/onboarding.ts** — Community-level intake and status machine. Exports `startOnboarding` (mutation: one-time intake form — legalName, EIN, address, website, statementDescriptor — triggering `provisionProviders`), `getOnboardingStatus` (read-side for the mobile admin checklist), `enableGroupGiving` (per-group fund provisioning + leader role grants), `applyStripeAccountStatus` (Stripe webhook-driven status machine), `recordProvisioned` (internal: stores provider ids after external provisioning succeeds), `recordProvisioningFailure` (internal: marks `stripe_blocked`/`increase_blocked` with a stored `provisioningError` when `provisionProviders` itself throws — there is no webhook at that stage to explain a stall, so the checklist surfaces the provider error directly), `retryProvisioning` (mutation: admin re-runs a failed provisioning; safe because every provider call is idempotency-keyed on the community id; refuses once all provider ids exist so it can't clobber a webhook-set blocked state), `freezeFundForArchivedGroup` (internal: freezes a group's fund on archive — ADR-032 §3, freeze half only), and `isValidEin` (pure validator for EIN format).
 
-**functions/finance/giving.ts** — Donation lifecycle and transparency screen. Exports `getGivingContext` (assembly of donation UI: fund list, suggested amounts, fee-cover toggle), `createDonationIntent` (creates Stripe PaymentIntent on the connected account, with an optional client nonce folded into Stripe's own request idempotency key to prevent a double-tap double-charge), `recordDonationSucceeded` (internal: Stripe webhook handler — writes donation + ledger credit + schedules receipt), `recordDonationRefund` (internal: Stripe `charge.refunded` handler — posts a "refund" ledger debit, replay-safe against Stripe's cumulative `amount_refunded`), `recordDonationDisputed` (internal: Stripe `charge.dispute.created` handler — audit-only), `getFundOverview` (transparency screen with donor-name visibility gating for non-finance roles), and `updateDonationReceipt` (internal: Resend email callback handler).
+**functions/finance/giving.ts** — Donation lifecycle and transparency screen. Exports `getGivingContext` (assembly of donation UI: fund list, suggested amounts, fee-cover toggle), `createDonationIntent` (creates Stripe PaymentIntent on the connected account, with an optional client nonce folded into Stripe's own request idempotency key to prevent a double-tap double-charge), `recordDonationSucceeded` (internal: Stripe webhook handler — writes donation + ledger credit + schedules receipt), `recordDonationRefund` (internal: Stripe `charge.refunded` handler — posts a "refund" ledger debit, replay-safe against Stripe's cumulative `amount_refunded`; also stamps `donations.refundedCents`, flips a fully-refunded pending gift to the terminal `"refunded"` allocation status so it can never be transferred, and reverses the realised allocation fee when refunds exceed the net the fund received, so a fund balance can't go negative), `recordDonationDisputed` (internal: Stripe `charge.dispute.created` handler — audit-only), `getFundOverview` (transparency screen with donor-name visibility gating for non-finance roles; period totals split spend from `feesCents`/`refundedCents`), and `updateDonationReceipt` (internal: Resend email callback handler).
 
 **functions/finance/expenses.ts** — Member reimbursement submission, approval, and payout. Exports `submitExpense` (mutation: member-submitted reimbursement request; rejects on a non-active fund), `approveExpense` (mutation: first or second approval, respecting the $200 threshold; rejects on a non-active fund), `denyExpense` (mutation: explicit rejection — allowed regardless of fund status), `payReimbursement` (internal action: ACH transfer via Increase, gated on `fund.status === "active"` BEFORE the transfer call — currently a no-op stub for the transfer itself awaiting payout-destination linking), and `recordReimbursementPaid` (internal: called post-transfer or by manual entry).
 
 **functions/finance/roles.ts** — Fund role (finance_admin / manager / cardholder) lifecycle. Exports `grantFundRole` (mutation: community-admin-only role assignment), `revokeFundRole` (mutation: soft-delete via revokedAt), and `getFundRoles` (query: list active roles on a fund).
 
-**functions/finance/jobs.ts** — Allocation, reconciliation, and payout-retry background jobs. Exports `planAllocations` (internal: binds a payout's donations to it, matching Stripe balance-transaction per-charge NET amounts by PaymentIntent id and stamping `donations.allocationPayoutId` / `payoutNetCents`; skips — never `break`s on — an item it can't fit), `recordAllocation` (internal: flips donation.allocationStatus, posts the realised Stripe fee as a `fee` ledger debit, audit-logs the transfer id), `recordAllocationFailure` (internal: audits `allocation.transfer_failed` for one item that didn't transfer, leaving it pending and retryable), `runAllocation` (internal action: reads the payout's composition from Stripe, plans, then transfers item-by-item with per-item error isolation), `listResumableAllocations` (internal: payout-bound donations whose transfer never landed), `runNightlyReconcileAllCommunities` (cron: nightly invariant check per community), `retryStaleAllocations` (cron: resumes stranded payout-bound allocations, alerts on donations no payout has covered yet), `retryStuckReimbursements` (cron: re-schedules `payReimbursement` for reimbursements stuck "approved" > 6h with no transfer — a backstop for a crashed/interrupted payout, safe because `createAchTransfer`'s idempotency key collapses a retry to the same transfer), and `registerFinanceCrons` (registers all three crons — reconcile daily at 07:00 UTC, allocation-retry hourly at :45, stuck-reimbursement-retry hourly at :20).
+**functions/finance/jobs.ts** — Allocation, reconciliation, and payout-retry background jobs. Exports `planAllocations` (internal: binds a payout's donations to it, matching Stripe balance-transaction per-PaymentIntent NET amounts and stamping `donations.allocationPayoutId` / `payoutNetCents` / the transfer lease; skips — never `break`s on — an item it can't fit or that another pass holds), `recordAllocation` (internal: flips donation.allocationStatus, posts the realised Stripe fee as a `fee` ledger debit, releases the lease, audit-logs the transfer id), `recordAllocationFailure` (internal: releases the lease and audits `allocation.transfer_failed` or `allocation.record_failed` depending on which half failed, leaving the item pending and retryable), `runAllocation` (internal action: reads the payout's composition from Stripe, plans, then transfers item-by-item with per-item error isolation; alarms on an unmatched payout), `recordUnmatchedPayout` (internal: the `allocation.payout_unmatched` alarm), `unbindFailedPayout` (internal: `payout.failed` handler — releases the bindings a `payout.paid` made), `listResumableAllocations` (internal: payout-bound donations whose transfer never landed, leased as they're handed out), `runNightlyReconcileAllCommunities` (cron: nightly invariant check per community), `retryStaleAllocations` (cron: resumes stranded payout-bound allocations, alerts on donations no payout has covered yet), `retryStuckReimbursements` (cron: re-schedules `payReimbursement` for reimbursements stuck "approved" > 6h with no transfer — a backstop for a crashed/interrupted payout, safe because `createAchTransfer`'s idempotency key collapses a retry to the same transfer), and `registerFinanceCrons` (registers all three crons — reconcile daily at 07:00 UTC, allocation-retry hourly at :45, stuck-reimbursement-retry hourly at :20).
 
-**functions/finance/webhooks.ts** — Stripe payment/payout/refund/dispute and Increase event dispatch + signature verification. Handles Stripe routing to `recordDonationSucceeded` (payment_intent.succeeded, with a server-side connected-account cross-check against the fund's own `communityFinance` before crediting — see `getFundFinanceForWebhook`), `recordDonationRefund` (charge.refunded, same account cross-check via `getDonationFundForWebhook`), `recordDonationDisputed` (charge.dispute.created, audit-only), `runAllocation` (payout.paid), Increase Entity/Account status updates (entity.created, account.created), `recordCardSettlement` (transaction.created with `source.category === "card_settlement"` — turns a card swipe into a `card_charge` expense + ledger debit, see cards.ts below), and webhook signature verification via Increase's idempotency behavior (documented in lib/finance/increase.ts).
+**functions/finance/webhooks.ts** — Stripe payment/payout/refund/dispute and Increase event dispatch + signature verification. Handles Stripe routing to `recordDonationSucceeded` (payment_intent.succeeded, with a server-side connected-account cross-check against the fund's own `communityFinance` before crediting — see `getFundFinanceForWebhook`), `recordDonationRefund` (charge.refunded, same account cross-check via `getDonationFundForWebhook`), `recordDonationDisputed` (charge.dispute.created, audit-only), `runAllocation` (payout.paid **and** payout.reconciliation_completed — Stripe attributes balance transactions asynchronously, so the paid event alone can read a partial or empty composition), `unbindFailedPayout` (payout.failed), Increase Entity/Account status updates (entity.created, account.created), `recordCardSettlement` (transaction.created with `source.category === "card_settlement"` — turns a card swipe into a `card_charge` expense + ledger debit, see cards.ts below), and webhook signature verification via Increase's idempotency behavior (documented in lib/finance/increase.ts).
 
 **functions/finance/cards.ts** — Group-fund virtual cards (ADR-032 §3 Phase 3). Exports `listFundCards` / `getCardDetail` (cardholder+/leader/admin-gated reads; `getCardDetail` includes the card's last 20 `card_charge` expenses), `createFundCard` (mutation: finance_admin issues a card to a cardholder+ holder — rejects a non-`active` fund, a fund with no `increaseAccountId`, or a community whose `communityFinance.onboardingStatus` isn't `"live"`; inserts a `"pending"` row, audits `card.created`, then schedules `provisionCard`, an internalAction that calls Increase's `createCard` and records the result via `recordCardProvisioned`/`recordCardProvisionFailed` — same provider-write-then-record shape as onboarding.ts's `provisionProviders`), `setCardFrozen` (mutation: the holder can self-freeze, but only a finance_admin can unfreeze — a compromised holder must not be able to re-enable their own frozen card), and `cancelCard` (mutation: finance_admin-only, irreversible). Both lifecycle mutations schedule the shared `applyCardStatus` internalAction (`updateCardStatus` at Increase, then `recordCardStatus` persists whatever status Increase actually confirmed). `spendLimitCents`/`limitPeriod` are **advisory only** — Increase enforces no automatic period reset tied to them; real per-swipe enforcement needs Increase's real-time-authorization webhook, out of scope here (Phase 2 follow-up, see "Known Seams & TODOs"). The settlement side — turning a confirmed card swipe into an expense — is `webhooks.ts`'s `recordCardSettlement`, not this file.
 
@@ -23,10 +23,12 @@
 1. `createDonationIntent` (Stripe PaymentIntent on connected account) → donor card charged
 2. Stripe webhook: `payment_intent.succeeded` → `recordDonationSucceeded` (writes donations row + credit to ledger + schedules receipt email)
 3. Stripe bulk payout (T+2) arrives at Increase receiving Account — **net** of Stripe's processing fees
-4. Webhook: `payout.paid` → `runAllocation`: read the payout's per-charge NET amounts from Stripe (`listPayoutChargeNets`) → `planAllocations` binds each matching donation to the payout → one Increase AccountTransfer per group-fund donation, at its NET, each isolated from the others → `recordAllocation` flips allocationStatus and posts the `gross − net` difference as a `fee` ledger debit
+4. Webhook: `payout.paid` (and `payout.reconciliation_completed`) → `runAllocation`: read the payout's per-PaymentIntent NET composition from Stripe (`getPayoutComposition`) → `planAllocations` binds each matching donation to the payout and leases it → one Increase AccountTransfer per group-fund donation, at its NET, each isolated from the others → `recordAllocation` flips allocationStatus and posts the `gross − refunded − net` difference as a `fee` ledger debit
 5. Nightly cron: `runNightlyReconcileAllCommunities` → invariant check (ledger balance == bank balance + pending, pending summed on the same NET basis step 4 transfers)
 
 **Why NET, not gross (ADR-032 Phase-2 requirement 6).** A payout delivers the sum of its charges' nets. Matching donations by gross — what the donor was charged and what the ledger was credited — could never fit a donation inside the payout carrying it, which deterministically stalled allocation on the ordinary one-donation-per-payout case. Stripe's balance transactions for a payout also say exactly *which* charges it contained, so membership is read rather than inferred from a running total, and a donation is matched by PaymentIntent identity.
+
+**Refunds are netted, never dropped.** A payout's balance transactions include reversals (`refund`, `payment_refund`, `adjustment` for a chargeback, and the `*_failure` rows that put money back). `getPayoutComposition` sums each PaymentIntent's rows — a Refund's expanded `source` carries `payment_intent` just like a Charge's does — and emits only PaymentIntents whose total is strictly positive; the rest come back as `reversedPaymentIntentIds`. Discarding reversal rows (as the first cut of this job did) was a P0: a donation refunded before its payout is still `allocationStatus: "pending"`, so the surviving charge row looked like a fundable gift and the job transferred money the donor had already been given back into a group's spendable Increase Account. Belt and braces on the other side: `recordDonationRefund` stamps `donations.refundedCents` and flips a fully-refunded pending gift to the terminal `"refunded"` status, which every allocation query (planner, retry cron, pending sum) excludes.
 
 **Reimbursement → Approve → Pay**
 
@@ -50,8 +52,12 @@
   - `role.revoked` — Finance role soft-deleted
   - `donation.recorded` — Stripe donation succeeded; webhook-driven
   - `donation.allocated` — Increase AccountTransfer completed; details carry the transfer id, the payout id, and the net/gross/fee breakdown of the balance change
-  - `allocation.transfer_failed` — One item of an allocation pass didn't transfer; the donation stays `pending` with its payout binding, so the next pass (webhook redelivery or the hourly retry) picks up exactly it
-  - `allocation.stale_pending` — Donations pending allocation for > 3 days; details include how many stranded items that run managed to resume
+  - `allocation.transfer_failed` — One item of an allocation pass didn't transfer; **no money moved**. The donation stays `pending` with its payout binding and its lease released, so the next pass (webhook redelivery or the hourly retry) picks up exactly it
+  - `allocation.record_failed` — The Increase transfer **landed** (its id is in the details) but the bookkeeping mutation threw, so real money is in the group's Account with nothing in the ledger saying so. Distinct from `transfer_failed` on purpose: the retry re-issues the same `alloc:{donationId}` key, which Increase collapses into the same transfer, then re-attempts the recording
+  - `allocation.refunded_in_flight` — A refund landed while that donation's transfer was in flight, so money moved for a gift the donor already got back. The donation stays `"refunded"` and the misplaced money surfaces as reconcile drift
+  - `allocation.payout_unmatched` — A payout matched no donation at all, or a material slice of it couldn't be attributed. The one allocation failure with no automatic recovery (the `processedStripePayouts` row is written and the webhook 200s, so Stripe never redelivers), hence the alarm
+  - `allocation.payout_failed` — `payout.failed` arrived; donations that a `payout.paid` for the same payout had bound were unbound so the retry cron stops trying to move money out of an Account that never received it
+  - `allocation.stale_pending` — Donations pending allocation for > 3 days; the amount is the **>3-day slice only**, not the community's whole pending balance. Details include how many stranded items that run managed to resume
   - `reconcile.drift` — Nightly invariant failed (ledger ≠ bank + pending)
   - `expense.submitted` — Member reimbursement created
   - `expense.approved` — First or second approval
@@ -82,6 +88,7 @@ Every external write (Stripe, Increase API calls) is idempotency-keyed to safely
 - **`alloc-fee:{donationId}`** — The `fee` ledger debit for the Stripe processing fee realised when that donation's allocation lands (jobs.ts recordAllocation + postLedgerEntry)
 - **`reimb:{expenseId}`** — Reimbursement ledger debit + ACH initiation (expenses.ts payReimbursement + postLedgerEntry)
 - **`refund:{chargeId}:{cumulativeAmountRefundedCents}`** — Refund ledger debit (giving.ts recordDonationRefund + postLedgerEntry). The CUMULATIVE amount (Stripe's own running total, not a per-event delta) is part of the key, so a redelivered `charge.refunded` webhook with the same cumulative amount dedupes to one entry, while a later refund step (e.g. partial → full) gets its own key and posts its own entry.
+- **`alloc-fee-reversal:{donationId}`** — The compensating `fee` CREDIT that cancels an `alloc-fee:{donationId}` debit once refunds exceed the net the fund actually received (giving.ts recordDonationRefund). Keyed per donation, not per refund step, so the reversal happens at most once however many refund events arrive.
 - **`donation-intent:{fundId}:{idempotencyNonce}`** — Stripe's own REQUEST-level idempotency key on `paymentIntents.create` (giving.ts createDonationIntent), not a ledger key — prevents a double-tap on the give sheet from creating two PaymentIntents. Only sent when the client provides `idempotencyNonce`.
 - **`finance:card:{cardId}`** — Increase card creation (cards.ts provisionCard + createCard)
 - **`card-settlement:{increaseTransactionId}`** — Card-charge ledger debit (webhooks.ts recordCardSettlement + postLedgerEntry); the expense row itself is deduped separately via `expenses.by_increaseTransactionId` before either write happens.
@@ -121,8 +128,8 @@ Finance test files in `apps/convex/__tests__/`:
 - **finance-onboarding.test.ts** — Tests `startOnboarding` (form validation — EIN format, address shape), status machine transitions, idempotency of external provisioning calls
 - **finance-expenses.test.ts** — Tests `submitExpense`, `approveExpense`, `denyExpense`, two-approver $200 threshold, policy violations (non-members can't submit, expired roles can't approve)
 - **finance-giving.test.ts** — Tests the donation lifecycle (`recordDonationSucceeded`/`Refund`/`Disputed`, transparency reads), plus `recordAllocation` semantics, `computePendingAllocationCents`, and reconcile drift detection; exercises them directly without the Increase provider (lazy-imported in actions so these tests never load it)
-- **finance-allocation.test.ts** — Tests the payout seam end to end: NET matching (including the exact stall — a lone donation whose gross exceeds its payout's net), skip-don't-stall selection, per-donation replay protection, partial-failure isolation and resume (transfer 2 of 3 fails → 1 and 3 land, a redelivery finishes 2 and re-transfers nothing), no-op replay of a completed payout, `retryStaleAllocations` recovery vs. alert-only, and drift on a stranded allocation. Unlike the other suites this one drives the `runAllocation` **action**, with `listPayoutChargeNets` and `createAccountTransfer` mocked at the module boundary — and deliberately no suite-wide fake timers, so an awaited action can't silently no-op
-- **finance-payout-nets.test.ts** — Tests `listPayoutChargeNets` against a mocked `stripe` SDK: NET extraction, PaymentIntent mapping via the expanded `source`, paging, and the skipping of fee/payout/refund rows and malformed nets
+- **finance-allocation.test.ts** — Tests the payout seam end to end: NET matching (including the exact stall — a lone donation whose gross exceeds its payout's net), skip-don't-stall selection, per-donation replay protection, the concurrency lease (a second pass over a live-leased item gets nothing; an expired lease is reclaimable), partial-failure isolation and resume (transfer 2 of 3 fails → 1 and 3 land, a redelivery finishes 2 and re-transfers nothing), transfer-landed-record-failed as a distinct audited outcome, no-op replay of a completed payout, the full refund sequences (before payout → nothing transfers and no negative balance; partial before payout; full after allocation → fee reversed; refunded while bound → retry cron drops it), unmatched/empty payouts alarming, `payout.failed` unbinding, `retryStaleAllocations` recovery vs. alert-only, and drift on a stranded allocation. Unlike the other suites this one drives the `runAllocation` **action**, with `getPayoutComposition` and `createAccountTransfer` mocked at the module boundary — the Increase mock models idempotency-key dedupe, so the "same key returns the same transfer" lock is genuinely exercised — and deliberately no suite-wide fake timers, so an awaited action can't silently no-op
+- **finance-payout-nets.test.ts** — Tests `getPayoutComposition` against a mocked `stripe` SDK: NET extraction, PaymentIntent mapping via the expanded `source`, paging (including a charge and its refund landing on different pages), netting refunds/chargebacks/failed-refunds against their charge, reporting reversals that can't be attributed, refusing a truncated view, and skipping pure bookkeeping rows and malformed nets
 - **finance-cards.test.ts** — Tests `createFundCard` (pending row + audit, holder-role gate, caller gate, fund-readiness gates), `listFundCards`/`getCardDetail` viewer gating, `setCardFrozen` permissions (self-freeze vs. finance_admin-only unfreeze), `cancelCard` (finance_admin-only), and `recordCardSettlement` (idempotency, account-mismatch rejection, missing-card log-not-throw)
 
 ## Known Seams & TODOs
@@ -137,7 +144,7 @@ Finance test files in `apps/convex/__tests__/`:
 
 - **Net-amount allocation — DONE** (ADR-032 Phase-2 requirement 6, was a hard
   go-live prerequisite). Allocation matches Stripe balance-transaction
-  per-charge NET amounts (`listPayoutChargeNets` in lib/finance/stripeConnect.ts,
+  per-PaymentIntent NET amounts (`getPayoutComposition` in lib/finance/stripeConnect.ts,
   `GET /v1/balance_transactions?payout=…&expand[]=data.source` on the
   connected account, paged), not gross donation totals. The old gross matcher
   compared a gross donation against a fee-reduced payout, so the common
@@ -146,25 +153,59 @@ Finance test files in `apps/convex/__tests__/`:
   the same way. Selection now skips (`continue`) rather than stopping, and
   membership comes from Stripe rather than a running total.
 
-  **Partial-failure recovery semantics.** Each Increase transfer in a pass is
-  wrapped individually: one failure costs that donation only, is audited as
-  `allocation.transfer_failed`, and leaves the donation `pending` with its
-  `allocationPayoutId` / `payoutNetCents` stamp intact. Replay protection is
-  therefore per-**(payout, donation)**, not per payout: a redelivered
-  `payout.paid` re-derives the same donation set from Stripe, drops the ones
-  already flipped to `"allocated"`, and finishes only the tail. Exactly-once
-  rests on two independent locks — `recordAllocation` no-ops on an
-  already-allocated donation, and the `alloc:{donationId}` Increase
-  idempotency key collapses the genuinely ambiguous case (transfer landed,
-  action died before recording) into the same transfer instead of a second
-  movement of money. `processedStripePayouts` is now only the bookkeeping
-  record of a pass, not the gate. Stripe is queried *before* anything is
-  written, so an unreachable Stripe leaves the payout wholly untouched for the
-  next attempt. `retryStaleAllocations` (hourly) resumes stranded
-  payout-bound donations for real now — the payout id and the exact delivered
-  net are on the row, so nothing has to be guessed — and stays alert-only for
-  donations no payout has covered yet (fabricating a payout amount there would
-  still be wrong; Codex review, PR #653).
+  **Partial-failure recovery semantics.** The transfer and the recording are
+  wrapped in SEPARATE try blocks per item: one failure costs that donation
+  only, and the two halves are audited differently
+  (`allocation.transfer_failed` = no money moved; `allocation.record_failed` =
+  money moved and isn't booked yet) because they need different responses from
+  whoever reads the log. Either way the donation stays `pending` with its
+  `allocationPayoutId` / `payoutNetCents` stamp intact and its lease released.
+  Replay protection is per-**(payout, donation)**, not per payout: a
+  redelivered `payout.paid` re-derives the same donation set from Stripe,
+  drops the ones already flipped to `"allocated"`, and finishes only the tail.
+  `processedStripePayouts` is now only the bookkeeping record of the first
+  pass, not the gate. Stripe is queried *before* anything is written, so an
+  unreachable Stripe leaves the payout wholly untouched for the next attempt.
+  `retryStaleAllocations` (hourly) resumes stranded payout-bound donations for
+  real now — the payout id and the exact delivered net are on the row, so
+  nothing has to be guessed — and stays alert-only for donations no payout has
+  covered yet (fabricating a payout amount there would still be wrong; Codex
+  review, PR #653).
+
+  **Exactly-once rests on three locks, in this order.**
+  1. **A per-donation transfer LEASE** (`donations.allocationTransferStartedAt`,
+     15-minute TTL). Taken inside the selection *mutation* — `planAllocations`
+     and `listResumableAllocations` both claim every item they hand out and
+     skip anything another pass still holds — so acquiring the claim and
+     returning the item are one serializable transaction and Convex's OCC
+     picks the winner. This is what closes the window that opened when the
+     whole-payout `claimPayout` was removed: the payout stamp alone is a
+     *marker*, and two passes (a redelivered webhook, or the `:45` retry cron
+     firing mid-`runAllocation`) could both be handed the same bound donation
+     and both issue `alloc:{donationId}` *concurrently*, before either had
+     recorded anything. Increase documents "at most one object per key" but
+     says nothing about two in-flight requests sharing one, which is not a
+     property to rest a money guarantee on. Failures release the lease
+     immediately, so the normal retry path never waits for expiry; the TTL
+     only bounds a pass that died mid-transfer.
+  2. **`recordAllocation` no-ops** on an already-`"allocated"` donation, so a
+     finished item is never re-recorded.
+  3. **The `alloc:{donationId}` Increase idempotency key** collapses the
+     genuinely ambiguous case (transfer landed, recording didn't) into the
+     same transfer instead of a second movement of money.
+
+  **Unmatched payouts alarm.** An empty plan used to `return` silently while
+  the `processedStripePayouts` row was already written and the webhook 200'd —
+  no redelivery, and the retry cron only resumes *bound* donations, so nothing
+  would ever re-plan that payout. `runAllocation` now audits
+  `allocation.payout_unmatched` for an empty plan or a material unattributed
+  remainder (>$1, or >1% of the payout). `payout.reconciliation_completed` is
+  routed alongside `payout.paid` because Stripe attributes balance
+  transactions to a payout asynchronously, so a query at `payout.paid` can
+  legitimately come back partial or empty; and `getPayoutComposition` throws
+  rather than returning a truncated prefix if the 100-page cap is hit while
+  Stripe still reports `has_more`. `payout.failed` unbinds whatever a
+  preceding `payout.paid` bound.
 
   **Ledger consequence: allocation posts a `fee` debit.** The donation credit
   is gross, the bank only ever holds net, so ADR-032's invariant
@@ -182,6 +223,44 @@ Finance test files in `apps/convex/__tests__/`:
   is in `FROZEN_ALLOWED_KINDS` for the same in-flight reason as refunds: Stripe
   already kept the money, so a fund frozen between gift and allocation must
   still record it.
+
+  The fee is **not** member-facing "spend". `summarizePeriod` (giving.ts)
+  buckets only what a group chose to spend — card swipes, reimbursements,
+  transfers, sweeps — into `spentCents`, and reports `feesCents` /
+  `refundedCents` separately. Counting the fee as spend would have a group
+  that spent nothing report spending 2.9% + 30¢ of every gift on the one
+  screen whose purpose is telling members where their money went; hiding it
+  entirely would leave "given" minus "spent" not reconciling against the
+  balance. Both surfaces render the separate line: `FundScreenView`'s MTD/YTD
+  cards and `GivingHubView`'s "SPENT THIS MONTH" tile.
+
+  **Refund states (the fourth and fifth rows of that table).**
+  `recordDonationRefund` stamps `donations.refundedCents` and, on a full
+  refund of a still-pending gift, flips it to the terminal `"refunded"`
+  status. So:
+  refunded before its payout `ledger 0 / bank 0 / pending 0` → ok;
+  partially refunded, not paid out `ledger gross−refund / bank 0 /
+  pending gross−refund` → ok;
+  refunded AFTER allocation `ledger gross−fee−refund / bank NET / pending 0`
+  → **drift**, deliberately. Stripe takes the refund out of the community's
+  Stripe balance (shrinking a later payout) while the gift's money already
+  sits in the group's own Increase Account; retrieving it is a bank-side
+  clawback ADR-032 hasn't designed, so the nightly reconcile alarms on
+  exactly that amount until it's handled by hand. What is guaranteed is that
+  a fund balance never renders NEGATIVE from a refund: once refunds exceed
+  the net the fund actually received, the realised `fee` debit is cancelled
+  by a compensating credit (`alloc-fee-reversal:{donationId}`) instead of
+  being left as an overdraft. Partial refunds that stay under the net leave
+  the fee alone — Stripe genuinely kept it on the portion the fund retained.
+  `recordAllocation` charges its fee on `gross − refunded − net`, not
+  `gross − net`, so a partial refund settling inside the same payout isn't
+  debited twice.
+
+  DISPUTES remain audit-only and known-drifting (see "Dispute lifecycle"
+  below), but the money path is safe without a dispute state machine: Stripe
+  posts a chargeback as an `adjustment` balance transaction, which
+  `getPayoutComposition` nets against the charge exactly like a refund, so a
+  disputed gift is never transferred out of the receiving Account.
 
   **Still open (pre-existing, unchanged here):** general-fund donations are
   recorded as allocated without any transfer, because `recordProvisioned`

--- a/apps/convex/functions/finance/ARCHITECTURE.md
+++ b/apps/convex/functions/finance/ARCHITECTURE.md
@@ -10,9 +10,9 @@
 
 **functions/finance/roles.ts** — Fund role (finance_admin / manager / cardholder) lifecycle. Exports `grantFundRole` (mutation: community-admin-only role assignment), `revokeFundRole` (mutation: soft-delete via revokedAt), and `getFundRoles` (query: list active roles on a fund).
 
-**functions/finance/jobs.ts** — Allocation, reconciliation, and payout-retry background jobs. Exports `planAllocations` (internal: decides which pending donations a payout covers — oldest-first, whole-only), `recordAllocation` (internal: flips donation.allocationStatus + audit log), `runAllocation` (internal action: pairs planAllocations with Increase transfers), `runNightlyReconcileAllCommunities` (cron: nightly invariant check per community), `retryStuckReimbursements` (cron: re-schedules `payReimbursement` for reimbursements stuck "approved" > 6h with no transfer — a backstop for a crashed/interrupted payout, safe because `createAchTransfer`'s idempotency key collapses a retry to the same transfer), and `registerFinanceCrons` (registers all three crons — reconcile daily at 07:00 UTC, allocation-retry hourly at :45, stuck-reimbursement-retry hourly at :20).
+**functions/finance/jobs.ts** — Allocation, reconciliation, and payout-retry background jobs. Exports `planAllocations` (internal: binds a payout's donations to it, matching Stripe balance-transaction per-charge NET amounts by PaymentIntent id and stamping `donations.allocationPayoutId` / `payoutNetCents`; skips — never `break`s on — an item it can't fit), `recordAllocation` (internal: flips donation.allocationStatus, posts the realised Stripe fee as a `fee` ledger debit, audit-logs the transfer id), `recordAllocationFailure` (internal: audits `allocation.transfer_failed` for one item that didn't transfer, leaving it pending and retryable), `runAllocation` (internal action: reads the payout's composition from Stripe, plans, then transfers item-by-item with per-item error isolation), `listResumableAllocations` (internal: payout-bound donations whose transfer never landed), `runNightlyReconcileAllCommunities` (cron: nightly invariant check per community), `retryStaleAllocations` (cron: resumes stranded payout-bound allocations, alerts on donations no payout has covered yet), `retryStuckReimbursements` (cron: re-schedules `payReimbursement` for reimbursements stuck "approved" > 6h with no transfer — a backstop for a crashed/interrupted payout, safe because `createAchTransfer`'s idempotency key collapses a retry to the same transfer), and `registerFinanceCrons` (registers all three crons — reconcile daily at 07:00 UTC, allocation-retry hourly at :45, stuck-reimbursement-retry hourly at :20).
 
-**functions/finance/webhooks.ts** — Stripe payment/payout/refund/dispute and Increase event dispatch + signature verification. Handles Stripe routing to `recordDonationSucceeded` (payment_intent.succeeded, with a server-side connected-account cross-check against the fund's own `communityFinance` before crediting — see `getFundFinanceForWebhook`), `recordDonationRefund` (charge.refunded, same account cross-check via `getDonationFundForWebhook`), `recordDonationDisputed` (charge.dispute.created, audit-only), `planAllocations` (payout.paid), Increase Entity/Account status updates (entity.created, account.created), `recordCardSettlement` (transaction.created with `source.category === "card_settlement"` — turns a card swipe into a `card_charge` expense + ledger debit, see cards.ts below), and webhook signature verification via Increase's idempotency behavior (documented in lib/finance/increase.ts).
+**functions/finance/webhooks.ts** — Stripe payment/payout/refund/dispute and Increase event dispatch + signature verification. Handles Stripe routing to `recordDonationSucceeded` (payment_intent.succeeded, with a server-side connected-account cross-check against the fund's own `communityFinance` before crediting — see `getFundFinanceForWebhook`), `recordDonationRefund` (charge.refunded, same account cross-check via `getDonationFundForWebhook`), `recordDonationDisputed` (charge.dispute.created, audit-only), `runAllocation` (payout.paid), Increase Entity/Account status updates (entity.created, account.created), `recordCardSettlement` (transaction.created with `source.category === "card_settlement"` — turns a card swipe into a `card_charge` expense + ledger debit, see cards.ts below), and webhook signature verification via Increase's idempotency behavior (documented in lib/finance/increase.ts).
 
 **functions/finance/cards.ts** — Group-fund virtual cards (ADR-032 §3 Phase 3). Exports `listFundCards` / `getCardDetail` (cardholder+/leader/admin-gated reads; `getCardDetail` includes the card's last 20 `card_charge` expenses), `createFundCard` (mutation: finance_admin issues a card to a cardholder+ holder — rejects a non-`active` fund, a fund with no `increaseAccountId`, or a community whose `communityFinance.onboardingStatus` isn't `"live"`; inserts a `"pending"` row, audits `card.created`, then schedules `provisionCard`, an internalAction that calls Increase's `createCard` and records the result via `recordCardProvisioned`/`recordCardProvisionFailed` — same provider-write-then-record shape as onboarding.ts's `provisionProviders`), `setCardFrozen` (mutation: the holder can self-freeze, but only a finance_admin can unfreeze — a compromised holder must not be able to re-enable their own frozen card), and `cancelCard` (mutation: finance_admin-only, irreversible). Both lifecycle mutations schedule the shared `applyCardStatus` internalAction (`updateCardStatus` at Increase, then `recordCardStatus` persists whatever status Increase actually confirmed). `spendLimitCents`/`limitPeriod` are **advisory only** — Increase enforces no automatic period reset tied to them; real per-swipe enforcement needs Increase's real-time-authorization webhook, out of scope here (Phase 2 follow-up, see "Known Seams & TODOs"). The settlement side — turning a confirmed card swipe into an expense — is `webhooks.ts`'s `recordCardSettlement`, not this file.
 
@@ -22,9 +22,11 @@
 
 1. `createDonationIntent` (Stripe PaymentIntent on connected account) → donor card charged
 2. Stripe webhook: `payment_intent.succeeded` → `recordDonationSucceeded` (writes donations row + credit to ledger + schedules receipt email)
-3. Stripe bulk payout (T+2) arrives at Increase receiving Account
-4. Webhook: `payout.paid` → `planAllocations` + `runAllocation` (Increase AccountTransfer to group Account + flip allocationStatus)
-5. Nightly cron: `runNightlyReconcileAllCommunities` → invariant check (ledger balance == bank balance + pending)
+3. Stripe bulk payout (T+2) arrives at Increase receiving Account — **net** of Stripe's processing fees
+4. Webhook: `payout.paid` → `runAllocation`: read the payout's per-charge NET amounts from Stripe (`listPayoutChargeNets`) → `planAllocations` binds each matching donation to the payout → one Increase AccountTransfer per group-fund donation, at its NET, each isolated from the others → `recordAllocation` flips allocationStatus and posts the `gross − net` difference as a `fee` ledger debit
+5. Nightly cron: `runNightlyReconcileAllCommunities` → invariant check (ledger balance == bank balance + pending, pending summed on the same NET basis step 4 transfers)
+
+**Why NET, not gross (ADR-032 Phase-2 requirement 6).** A payout delivers the sum of its charges' nets. Matching donations by gross — what the donor was charged and what the ledger was credited — could never fit a donation inside the payout carrying it, which deterministically stalled allocation on the ordinary one-donation-per-payout case. Stripe's balance transactions for a payout also say exactly *which* charges it contained, so membership is read rather than inferred from a running total, and a donation is matched by PaymentIntent identity.
 
 **Reimbursement → Approve → Pay**
 
@@ -47,7 +49,9 @@
   - `role.granted` — Finance role assigned to a user
   - `role.revoked` — Finance role soft-deleted
   - `donation.recorded` — Stripe donation succeeded; webhook-driven
-  - `donation.allocated` — Increase AccountTransfer completed; includes transfer id in details
+  - `donation.allocated` — Increase AccountTransfer completed; details carry the transfer id, the payout id, and the net/gross/fee breakdown of the balance change
+  - `allocation.transfer_failed` — One item of an allocation pass didn't transfer; the donation stays `pending` with its payout binding, so the next pass (webhook redelivery or the hourly retry) picks up exactly it
+  - `allocation.stale_pending` — Donations pending allocation for > 3 days; details include how many stranded items that run managed to resume
   - `reconcile.drift` — Nightly invariant failed (ledger ≠ bank + pending)
   - `expense.submitted` — Member reimbursement created
   - `expense.approved` — First or second approval
@@ -74,7 +78,8 @@ Every external write (Stripe, Increase API calls) is idempotency-keyed to safely
 - **`finance:stripe-account:{communityId}`** — Community Stripe connected account creation (used in onboarding.ts createConnectedAccount)
 - **`finance:entity:{communityId}`** — Increase Entity creation (communityFinance.increaseEntityId — used in increase.ts createEntity)
 - **`donation:{paymentIntentId}`** — Donation ledger credit (giving.ts recordDonationSucceeded + ledger posting)
-- **`alloc:{donationId}`** — Allocation ledger entry for the AccountTransfer (jobs.ts recordAllocation + postLedgerEntry)
+- **`alloc:{donationId}`** — Increase AccountTransfer for one allocated donation (jobs.ts `executeAllocationItems` → `createAccountTransfer`). Doing double duty as replay protection: if a transfer succeeded but the action died before recording it, the retry resolves to the SAME transfer at Increase instead of moving money twice.
+- **`alloc-fee:{donationId}`** — The `fee` ledger debit for the Stripe processing fee realised when that donation's allocation lands (jobs.ts recordAllocation + postLedgerEntry)
 - **`reimb:{expenseId}`** — Reimbursement ledger debit + ACH initiation (expenses.ts payReimbursement + postLedgerEntry)
 - **`refund:{chargeId}:{cumulativeAmountRefundedCents}`** — Refund ledger debit (giving.ts recordDonationRefund + postLedgerEntry). The CUMULATIVE amount (Stripe's own running total, not a per-event delta) is part of the key, so a redelivered `charge.refunded` webhook with the same cumulative amount dedupes to one entry, while a later refund step (e.g. partial → full) gets its own key and posts its own entry.
 - **`donation-intent:{fundId}:{idempotencyNonce}`** — Stripe's own REQUEST-level idempotency key on `paymentIntents.create` (giving.ts createDonationIntent), not a ledger key — prevents a double-tap on the give sheet from creating two PaymentIntents. Only sent when the client provides `idempotencyNonce`.
@@ -110,12 +115,14 @@ Ledger posting adds `:debit` or `:credit` suffix to distinguish the paired trans
 
 ## Testing
 
-Four finance test files in `apps/convex/__tests__/`:
+Finance test files in `apps/convex/__tests__/`:
 
 - **finance-ledger.test.ts** — Tests `postLedgerEntry`, `deriveBalance`, `checkInvariant`, paired-transfer semantics; validates dedup by idempotencyKey and the append-only invariant
 - **finance-onboarding.test.ts** — Tests `startOnboarding` (form validation — EIN format, address shape), status machine transitions, idempotency of external provisioning calls
 - **finance-expenses.test.ts** — Tests `submitExpense`, `approveExpense`, `denyExpense`, two-approver $200 threshold, policy violations (non-members can't submit, expired roles can't approve)
-- **finance-giving.test.ts** — Tests `planAllocations` (oldest-first, whole-only selection), `recordAllocation` semantics, reconcile drift detection; exercises allocation/reconcile directly without Increase provider (lazy-imported in actions so tests never load it)
+- **finance-giving.test.ts** — Tests the donation lifecycle (`recordDonationSucceeded`/`Refund`/`Disputed`, transparency reads), plus `recordAllocation` semantics, `computePendingAllocationCents`, and reconcile drift detection; exercises them directly without the Increase provider (lazy-imported in actions so these tests never load it)
+- **finance-allocation.test.ts** — Tests the payout seam end to end: NET matching (including the exact stall — a lone donation whose gross exceeds its payout's net), skip-don't-stall selection, per-donation replay protection, partial-failure isolation and resume (transfer 2 of 3 fails → 1 and 3 land, a redelivery finishes 2 and re-transfers nothing), no-op replay of a completed payout, `retryStaleAllocations` recovery vs. alert-only, and drift on a stranded allocation. Unlike the other suites this one drives the `runAllocation` **action**, with `listPayoutChargeNets` and `createAccountTransfer` mocked at the module boundary — and deliberately no suite-wide fake timers, so an awaited action can't silently no-op
+- **finance-payout-nets.test.ts** — Tests `listPayoutChargeNets` against a mocked `stripe` SDK: NET extraction, PaymentIntent mapping via the expanded `source`, paging, and the skipping of fee/payout/refund rows and malformed nets
 - **finance-cards.test.ts** — Tests `createFundCard` (pending row + audit, holder-role gate, caller gate, fund-readiness gates), `listFundCards`/`getCardDetail` viewer gating, `setCardFrozen` permissions (self-freeze vs. finance_admin-only unfreeze), `cancelCard` (finance_admin-only), and `recordCardSettlement` (idempotency, account-mismatch rejection, missing-card log-not-throw)
 
 ## Known Seams & TODOs
@@ -128,16 +135,62 @@ Four finance test files in `apps/convex/__tests__/`:
   away from the managed Increase account via the Express Dashboard) must be
   detected and surfaced.
 
-- **Allocation matches GROSS donation amounts against a NET payout.** A Stripe
-  payout is net of processing fees, while `planAllocations` sums gross
-  donation totals — so a payout will under-cover its own donations by roughly
-  the fee amount, leaving a tail of donations pending (surfaced by the
-  `allocation.stale_pending` alert; no money moves incorrectly because the
-  stale backstop is alert-only and payout replays are blocked by
-  `processedStripePayouts`). Before Phase-2 go-live, allocation must switch to
-  balance-transaction-based per-charge NET amounts (`stripe.balanceTransactions`
-  for the payout) instead of gross donation totals. Tracked from the Codex
-  review on PR #653.
+- **Net-amount allocation — DONE** (ADR-032 Phase-2 requirement 6, was a hard
+  go-live prerequisite). Allocation matches Stripe balance-transaction
+  per-charge NET amounts (`listPayoutChargeNets` in lib/finance/stripeConnect.ts,
+  `GET /v1/balance_transactions?payout=…&expand[]=data.source` on the
+  connected account, paged), not gross donation totals. The old gross matcher
+  compared a gross donation against a fee-reduced payout, so the common
+  one-donation-per-payout case never fit — and it `break`ed on the first
+  non-fitting item, so the queue never advanced and every later payout stalled
+  the same way. Selection now skips (`continue`) rather than stopping, and
+  membership comes from Stripe rather than a running total.
+
+  **Partial-failure recovery semantics.** Each Increase transfer in a pass is
+  wrapped individually: one failure costs that donation only, is audited as
+  `allocation.transfer_failed`, and leaves the donation `pending` with its
+  `allocationPayoutId` / `payoutNetCents` stamp intact. Replay protection is
+  therefore per-**(payout, donation)**, not per payout: a redelivered
+  `payout.paid` re-derives the same donation set from Stripe, drops the ones
+  already flipped to `"allocated"`, and finishes only the tail. Exactly-once
+  rests on two independent locks — `recordAllocation` no-ops on an
+  already-allocated donation, and the `alloc:{donationId}` Increase
+  idempotency key collapses the genuinely ambiguous case (transfer landed,
+  action died before recording) into the same transfer instead of a second
+  movement of money. `processedStripePayouts` is now only the bookkeeping
+  record of a pass, not the gate. Stripe is queried *before* anything is
+  written, so an unreachable Stripe leaves the payout wholly untouched for the
+  next attempt. `retryStaleAllocations` (hourly) resumes stranded
+  payout-bound donations for real now — the payout id and the exact delivered
+  net are on the row, so nothing has to be guessed — and stays alert-only for
+  donations no payout has covered yet (fabricating a payout amount there would
+  still be wrong; Codex review, PR #653).
+
+  **Ledger consequence: allocation posts a `fee` debit.** The donation credit
+  is gross, the bank only ever holds net, so ADR-032's invariant
+  (`funds.balanceCents === Increase balance + pending allocations`) is only
+  satisfiable if the fee is realised somewhere. `recordAllocation` posts it
+  (`gross − net`, key `alloc-fee:{donationId}`) when the transfer lands — and
+  that timing is deliberate. `computePendingAllocationCents` counts a donation
+  at gross while it's still in the Stripe pipeline and at net once a payout
+  has bound it, so the three states read:
+  in-pipeline `ledger gross / bank 0 / pending gross` → ok;
+  bound but stalled `ledger gross / bank 0 / pending net` → **drift = fee**;
+  allocated `ledger net / bank net / pending 0` → ok. Summing pending at gross
+  throughout (as it used to) made a stalled allocation self-consistent, which
+  is why the deterministic stall was invisible to the nightly alarm. `"fee"`
+  is in `FROZEN_ALLOWED_KINDS` for the same in-flight reason as refunds: Stripe
+  already kept the money, so a fund frozen between gift and allocation must
+  still record it.
+
+  **Still open (pre-existing, unchanged here):** general-fund donations are
+  recorded as allocated without any transfer, because `recordProvisioned`
+  never provisions a separate General Increase Account (ADR-032 §1's topology
+  says there is one) — unearmarked money simply stays in the receiving
+  Account. The General fund has no `increaseAccountId`, so
+  `getFundsWithIncreaseAccount` excludes it from reconcile and nothing
+  alarms; it just means the General fund's ledger balance isn't backed by a
+  bank account of its own yet. Provisioning that Account is Phase-2 work.
 
 **Member payout destination stub** (expenses.ts `getPayoutDestination`) — Phase 2 follow-up. Currently returns `null` (every expense blocks at "no destination found"). Awaiting linking flow to ship; structure is in place (`payReimbursement` action + `recordReimbursementPaid` mutation + Increase ACH client calls). Replace the stub with a real lookup once the UI for members to link their bank account lands.
 

--- a/apps/convex/functions/finance/ARCHITECTURE.md
+++ b/apps/convex/functions/finance/ARCHITECTURE.md
@@ -28,7 +28,7 @@
 
 **Why NET, not gross (ADR-032 Phase-2 requirement 6).** A payout delivers the sum of its charges' nets. Matching donations by gross — what the donor was charged and what the ledger was credited — could never fit a donation inside the payout carrying it, which deterministically stalled allocation on the ordinary one-donation-per-payout case. Stripe's balance transactions for a payout also say exactly *which* charges it contained, so membership is read rather than inferred from a running total, and a donation is matched by PaymentIntent identity.
 
-**Refunds are netted, never dropped.** A payout's balance transactions include reversals (`refund`, `payment_refund`, `adjustment` for a chargeback, and the `*_failure` rows that put money back). `getPayoutComposition` sums each PaymentIntent's rows — a Refund's expanded `source` carries `payment_intent` just like a Charge's does — and emits only PaymentIntents whose total is strictly positive; the rest come back as `reversedPaymentIntentIds`. Discarding reversal rows (as the first cut of this job did) was a P0: a donation refunded before its payout is still `allocationStatus: "pending"`, so the surviving charge row looked like a fundable gift and the job transferred money the donor had already been given back into a group's spendable Increase Account. Belt and braces on the other side: `recordDonationRefund` stamps `donations.refundedCents` and flips a fully-refunded pending gift to the terminal `"refunded"` status, which every allocation query (planner, retry cron, pending sum) excludes.
+**Refunds are netted, never dropped, and `payment_intent` — not `type` — decides what counts.** A payout's balance transactions include reversals (`refund`, `payment_refund`, `adjustment` for a chargeback, `payment_reversal` for a bank-side reversal of an ACH `payment`, and the `*_failure` rows that put money back). `getPayoutComposition` sums each PaymentIntent's rows — a Refund's expanded `source` carries `payment_intent` just like a Charge's does — and emits only PaymentIntents whose total is strictly positive; the rest come back as `reversedPaymentIntentIds`. Membership deliberately is **not** an allowlist of reversal types: every omission from such a list fails *open* (the charge row survives alone and looks fundable), and the first cut proved it by listing `payment_refund_failure`, which Stripe does not emit, while omitting `payment_reversal`, which it does. Two structural guards back this up: the nets of every row (excluding the payout's own `payout` leg) must sum **exactly** to `payout.amount` or `getPayoutComposition` throws, and anything it could not tie to a PaymentIntent lands in `unattributedNetCents`, whose negative direction `runAllocation` refuses outright. Discarding reversal rows (as the first cut of this job did) was a P0: a donation refunded before its payout is still `allocationStatus: "pending"`, so the surviving charge row looked like a fundable gift and the job transferred money the donor had already been given back into a group's spendable Increase Account. Belt and braces on the other side: `recordDonationRefund` stamps `donations.refundedCents` and flips a fully-refunded pending gift to the terminal `"refunded"` status, which every allocation query (planner, retry cron, pending sum) excludes.
 
 **Reimbursement → Approve → Pay**
 
@@ -129,7 +129,7 @@ Finance test files in `apps/convex/__tests__/`:
 - **finance-expenses.test.ts** — Tests `submitExpense`, `approveExpense`, `denyExpense`, two-approver $200 threshold, policy violations (non-members can't submit, expired roles can't approve)
 - **finance-giving.test.ts** — Tests the donation lifecycle (`recordDonationSucceeded`/`Refund`/`Disputed`, transparency reads), plus `recordAllocation` semantics, `computePendingAllocationCents`, and reconcile drift detection; exercises them directly without the Increase provider (lazy-imported in actions so these tests never load it)
 - **finance-allocation.test.ts** — Tests the payout seam end to end: NET matching (including the exact stall — a lone donation whose gross exceeds its payout's net), skip-don't-stall selection, per-donation replay protection, the concurrency lease (a second pass over a live-leased item gets nothing; an expired lease is reclaimable), partial-failure isolation and resume (transfer 2 of 3 fails → 1 and 3 land, a redelivery finishes 2 and re-transfers nothing), transfer-landed-record-failed as a distinct audited outcome, no-op replay of a completed payout, the full refund sequences (before payout → nothing transfers and no negative balance; partial before payout; full after allocation → fee reversed; refunded while bound → retry cron drops it), unmatched/empty payouts alarming, `payout.failed` unbinding, `retryStaleAllocations` recovery vs. alert-only, and drift on a stranded allocation. Unlike the other suites this one drives the `runAllocation` **action**, with `getPayoutComposition` and `createAccountTransfer` mocked at the module boundary — the Increase mock models idempotency-key dedupe, so the "same key returns the same transfer" lock is genuinely exercised — and deliberately no suite-wide fake timers, so an awaited action can't silently no-op
-- **finance-payout-nets.test.ts** — Tests `getPayoutComposition` against a mocked `stripe` SDK: NET extraction, PaymentIntent mapping via the expanded `source`, paging (including a charge and its refund landing on different pages), netting refunds/chargebacks/failed-refunds against their charge, reporting reversals that can't be attributed, refusing a truncated view, and skipping pure bookkeeping rows and malformed nets
+- **finance-payout-nets.test.ts** — Tests `getPayoutComposition` against a mocked `stripe` SDK: NET extraction, PaymentIntent mapping via the expanded `source`, paging (including a charge and its refund landing on different pages), netting refunds/chargebacks/failed-refunds against their charge, reporting reversals that can't be attributed, refusing a truncated view, refusing a fractional net, refusing a composition whose nets don't sum to the payout, excluding the payout's own leg, and netting types the code has never heard of (`payment_reversal`, and a made-up future type) purely off `payment_intent`
 - **finance-cards.test.ts** — Tests `createFundCard` (pending row + audit, holder-role gate, caller gate, fund-readiness gates), `listFundCards`/`getCardDetail` viewer gating, `setCardFrozen` permissions (self-freeze vs. finance_admin-only unfreeze), `cancelCard` (finance_admin-only), and `recordCardSettlement` (idempotency, account-mismatch rejection, missing-card log-not-throw)
 
 ## Known Seams & TODOs
@@ -198,8 +198,15 @@ Finance test files in `apps/convex/__tests__/`:
   the `processedStripePayouts` row was already written and the webhook 200'd —
   no redelivery, and the retry cron only resumes *bound* donations, so nothing
   would ever re-plan that payout. `runAllocation` now audits
-  `allocation.payout_unmatched` for an empty plan or a material unattributed
-  remainder (>$1, or >1% of the payout). `payout.reconciliation_completed` is
+  `allocation.payout_unmatched` when a pass got nothing *done* (an empty plan
+  with nothing already allocated out of this payout), when a material slice
+  is unattributed (>$1, or >1% of the payout), when the residual-budget check
+  had to strand a gift, or when the pass refused the payout outright. It
+  deliberately stays quiet for a payout with nothing left to do: Stripe emits
+  `payout.reconciliation_completed` after every healthy payout and webhooks.ts
+  routes it to the same handler, so an empty plan on that second pass is the
+  success condition — treating it as "matched nothing" fired a full-payout
+  alarm on every payout and made the signal useless. `payout.reconciliation_completed` is
   routed alongside `payout.paid` because Stripe attributes balance
   transactions to a payout asynchronously, so a query at `payout.paid` can
   legitimately come back partial or empty; and `getPayoutComposition` throws
@@ -234,6 +241,13 @@ Finance test files in `apps/convex/__tests__/`:
   balance. Both surfaces render the separate line: `FundScreenView`'s MTD/YTD
   cards and `GivingHubView`'s "SPENT THIS MONTH" tile.
 
+  **Known gap:** `refundedCents` is computed and typed through to
+  `member/types.ts` but rendered nowhere, so the same "given minus spent must
+  reconcile" argument that put fees on-screen is not yet satisfied for a fund
+  that has taken a refund. Deliberately left for a copy/layout pass rather
+  than bolted on here — refunds on group funds are rare, and the wrong words
+  for them are worse than none.
+
   **Refund states (the fourth and fifth rows of that table).**
   `recordDonationRefund` stamps `donations.refundedCents` and, on a full
   refund of a still-pending gift, flips it to the terminal `"refunded"`
@@ -257,10 +271,16 @@ Finance test files in `apps/convex/__tests__/`:
   debited twice.
 
   DISPUTES remain audit-only and known-drifting (see "Dispute lifecycle"
-  below), but the money path is safe without a dispute state machine: Stripe
-  posts a chargeback as an `adjustment` balance transaction, which
-  `getPayoutComposition` nets against the charge exactly like a refund, so a
-  disputed gift is never transferred out of the receiving Account.
+  below), and the money path is safe **only when the chargeback settles in
+  the same payout as the charge**: Stripe posts it as an `adjustment` balance
+  transaction, which `getPayoutComposition` nets against the charge exactly
+  like a refund, so that gift is not transferred out of the receiving
+  Account. Disputes typically arrive weeks after the payout, by which point
+  the gift is already allocated — and a dispute filed *before* the payout but
+  settling in a later one funds the gift in full, because unlike
+  `recordDonationRefund` the dispute path sets no `refundedCents` and no
+  status. Both cases surface as nightly reconcile drift, not as a blocked
+  transfer.
 
   **Still open (pre-existing, unchanged here):** general-fund donations are
   recorded as allocated without any transfer, because `recordProvisioned`

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -189,6 +189,15 @@ interface ActivityPeriodTotals {
  * one screen whose entire purpose is telling members where their money went.
  * They get their own totals instead of disappearing — a fee that is invisible
  * is exactly as dishonest as a fee mislabelled as spend.
+ *
+ * TODO: Investigate — `refundedCents` is computed here and typed all the way
+ * through to `member/types.ts`, but no surface renders it, so on a fund with
+ * a refund "given" minus "spent" minus "fees" does not reconcile. That is the
+ * same argument that put fees on their own line. Left as-is deliberately for
+ * now: it is a copy/layout decision on the member transparency screen rather
+ * than a correctness one, and this pass is scoped to money movement. Refunds
+ * on group funds are rare enough that shipping the wrong words for them is
+ * worse than shipping nothing yet.
  */
 function summarizePeriod(
   entries: Array<Pick<Doc<"ledgerEntries">, "direction" | "amountCents" | "kind">>,

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -170,25 +170,49 @@ function donorDisplayName(donor: Doc<"users"> | null): string {
 interface ActivityPeriodTotals {
   donationsCents: number;
   spentCents: number;
+  /** Stripe's processing fees, realised as "fee" ledger entries. */
+  feesCents: number;
+  /** Gifts handed back to donors, as "refund" ledger entries. */
+  refundedCents: number;
   donationCount: number;
 }
 
-/** Sums a set of ledger entries into the aggregates the transparency screen shows. */
+/**
+ * Sums a set of ledger entries into the aggregates the transparency screen
+ * shows.
+ *
+ * "Spent" means the group CHOSE to spend it — card swipes, reimbursements,
+ * transfers, sweeps. Processing fees and refunds are debits too, but neither
+ * is the group spending anything: allocation posts a `fee` debit for every
+ * gift (jobs.ts recordAllocation), so bucketing fees into "spent" would have
+ * a group that spent nothing report spending 2.9% + 30¢ of every gift on the
+ * one screen whose entire purpose is telling members where their money went.
+ * They get their own totals instead of disappearing — a fee that is invisible
+ * is exactly as dishonest as a fee mislabelled as spend.
+ */
 function summarizePeriod(
   entries: Array<Pick<Doc<"ledgerEntries">, "direction" | "amountCents" | "kind">>,
 ): ActivityPeriodTotals {
   let donationsCents = 0;
   let spentCents = 0;
+  let feesCents = 0;
+  let refundedCents = 0;
   let donationCount = 0;
   for (const entry of entries) {
     if (entry.direction === "credit" && entry.kind === "donation") {
       donationsCents += entry.amountCents;
       donationCount += 1;
+    } else if (entry.kind === "fee") {
+      // Signed: a fee reversal (a refunded gift's fee, see
+      // recordDonationRefund) is a credit that cancels an earlier debit.
+      feesCents += entry.direction === "debit" ? entry.amountCents : -entry.amountCents;
+    } else if (entry.kind === "refund") {
+      refundedCents += entry.direction === "debit" ? entry.amountCents : -entry.amountCents;
     } else if (entry.direction === "debit") {
       spentCents += entry.amountCents;
     }
   }
-  return { donationsCents, spentCents, donationCount };
+  return { donationsCents, spentCents, feesCents, refundedCents, donationCount };
 }
 
 export const getFundOverview = query({
@@ -743,6 +767,29 @@ export const recordDonationSucceeded = internalMutation({
  * FROZEN_ALLOWED_KINDS) — a fund frozen mid-flight (e.g. its group just
  * archived) must still be able to settle a refund already in progress at
  * Stripe.
+ *
+ * ALLOCATION CONSEQUENCES (ADR-032 §3; the refund states in jobs.ts's
+ * invariant table). A refund is not just a ledger debit — it changes what
+ * allocation is allowed to move:
+ *
+ *  - The cumulative refund is stamped on the donation (`refundedCents`), so
+ *    the planner and the nightly pending sum only ever count what is left of
+ *    the gift, and `recordAllocation` charges a fee on that remainder rather
+ *    than on the original gross.
+ *  - A FULLY refunded gift flips to `allocationStatus: "refunded"`, which is
+ *    terminal. Every allocation query selects `"pending"`, so this is what
+ *    guarantees a returned gift can never be transferred into a group's
+ *    spendable Increase Account — belt and braces with the netting in
+ *    `getPayoutComposition`, which already removes it from the payout's
+ *    composition when the refund settles in the same payout.
+ *  - Refunding a gift that was ALREADY allocated can leave the fund's ledger
+ *    negative, because the allocation posted a `fee` debit and the refund
+ *    now debits the full gross on top of it. Once the donor has been given
+ *    back more than the fund ever received, that fee is not recoverable from
+ *    this gift, so the entry is reversed with a compensating credit
+ *    (`alloc-fee-reversal:{donationId}`) rather than driving a member-visible
+ *    fund balance below zero. The ledger stays append-only; nothing is
+ *    patched.
  */
 export const recordDonationRefund = internalMutation({
   args: {
@@ -804,6 +851,49 @@ export const recordDonationRefund = internalMutation({
       stripeObjectId: args.chargeId,
     });
 
+    // --- Keep allocation from moving money the donor already got back. ---
+    const grossCents = donation.amountCents + donation.feeCoverCents;
+    const refundedCents = args.amountRefundedCents;
+    const fullyRefunded = refundedCents >= grossCents;
+    const donationPatch: {
+      refundedCents: number;
+      allocationStatus?: "refunded";
+      allocationTransferStartedAt?: undefined;
+    } = { refundedCents };
+    if (fullyRefunded && donation.allocationStatus === "pending") {
+      // Terminal: no payout will ever fund this gift. Releasing the lease too
+      // means a pass that had claimed it doesn't hold a dead reservation.
+      donationPatch.allocationStatus = "refunded";
+      donationPatch.allocationTransferStartedAt = undefined;
+    }
+    await ctx.db.patch(donation._id, donationPatch);
+
+    // --- Don't let an already-realised fee drive the fund below zero. ---
+    // The `fee` debit exists only to reconcile the GROSS ledger credit
+    // against the NET the bank actually holds. Once the refunds exceed that
+    // net (gross − fee), the credit it was offsetting is gone and the debit
+    // is pure overdraft, so reverse it. Below that line the arithmetic still
+    // works out non-negative and the fee stays where it is: Stripe really did
+    // keep it on the portion the fund retained.
+    const allocationFeeEntry = fundEntries.find(
+      (e) => e.idempotencyKey === `alloc-fee:${donation._id}`,
+    );
+    const allocationFeeCents = allocationFeeEntry?.amountCents ?? 0;
+    const feeReversedCents =
+      allocationFeeCents > 0 && refundedCents > grossCents - allocationFeeCents
+        ? allocationFeeCents
+        : 0;
+    if (feeReversedCents > 0) {
+      await postLedgerEntry(ctx, {
+        fundId: fund._id,
+        direction: "credit",
+        amountCents: allocationFeeCents,
+        kind: "fee",
+        idempotencyKey: `alloc-fee-reversal:${donation._id}`,
+        stripeObjectId: args.chargeId,
+      });
+    }
+
     await logFinanceAudit(ctx, {
       communityId: fund.communityId,
       fundId: fund._id,
@@ -812,7 +902,12 @@ export const recordDonationRefund = internalMutation({
         paymentIntentId: args.paymentIntentId,
         chargeId: args.chargeId,
         deltaCents,
-        cumulativeCents: args.amountRefundedCents,
+        cumulativeCents: refundedCents,
+        donationId: donation._id,
+        // Spelled out so the audit row alone explains why (or why not) this
+        // gift dropped out of the allocation queue.
+        allocationStatus: donationPatch.allocationStatus ?? donation.allocationStatus,
+        feeReversedCents,
       },
     });
   },

--- a/apps/convex/functions/finance/jobs.ts
+++ b/apps/convex/functions/finance/jobs.ts
@@ -5,11 +5,21 @@
  * Two background jobs live here:
  *
  *   1. ALLOCATION — Stripe pays a community out in bulk (T+2) to its
- *      Increase receiving Account. `planAllocations` decides, per donation,
- *      whether this payout covers it (oldest pending donation first, whole
- *      donations only — never split across payouts); `runAllocation` then
- *      moves each covered donation's money from the receiving Account to
- *      its group's Account via Increase and flips `donations.allocationStatus`.
+ *      Increase receiving Account. `runAllocation` asks Stripe which charges
+ *      composed that payout and at what NET (gross minus the processing fee
+ *      Stripe already took), `planAllocations` binds each of those charges'
+ *      donations to the payout, and each bound donation's net is then moved
+ *      from the receiving Account to its group's Account via Increase,
+ *      flipping `donations.allocationStatus`.
+ *
+ *      NET, not gross (ADR-032 Phase-2 requirement 6): a payout physically
+ *      delivers the sum of its charges' NETS. Matching donations by their
+ *      gross total — what the donor was charged, and what the ledger was
+ *      credited — can never fit inside the payout that carries them, which
+ *      previously stalled allocation permanently on the very common
+ *      one-donation-per-payout case. Stripe's balance transactions for the
+ *      payout also tell us exactly WHICH donations it contained, so
+ *      membership is now read, not inferred from a running total.
  *
  *   2. NIGHTLY RECONCILE — per fund, compares our ledger's cached balance
  *      against the Increase Account balance (adjusted for donations still
@@ -18,31 +28,40 @@
  *
  *        funds.balanceCents === Increase Account balance + pendingAllocationCents
  *
- * DESIGN DECISION — allocation does NOT post a second ledger entry:
- * `recordDonationSucceeded` (functions/finance/giving.ts) already credits
- * the fund's ledger balance in full the moment the donation succeeds — that
- * credit represents money Togather has *attributed* to the fund, not money
- * physically sitting in the fund's Increase Account yet (it's still in the
- * Stripe→receiving-Account pipeline). Allocation is purely a BANK-side move
- * of already-attributed money from the receiving Account to the group's
- * Account; crediting the ledger again here would double-count the fund's
- * balance. Instead, allocation only (a) flips `donations.allocationStatus`
- * to "allocated" and (b) writes a `financeAuditEvents` row
- * ("donation.allocated") carrying the Increase transfer id — the control-
- * plane record of the bank-side move, not a second balance-affecting entry.
- * The nightly-reconcile invariant is exactly what accounts for the gap this
- * creates: `pendingAllocationCents` (donations not yet allocated) is added
- * to the bank balance before comparing against the ledger balance, so a
- * fund whose donations are still "in transit" through Stripe's payout cycle
- * doesn't look like a drift.
+ * DESIGN DECISION — allocation posts no allocation CREDIT, only the fee
+ * DEBIT: `recordDonationSucceeded` (functions/finance/giving.ts) already
+ * credits the fund's ledger balance in full the moment the donation succeeds
+ * — that credit represents money Togather has *attributed* to the fund, not
+ * money physically sitting in the fund's Increase Account yet (it's still in
+ * the Stripe→receiving-Account pipeline). Allocation is purely a BANK-side
+ * move of already-attributed money from the receiving Account to the group's
+ * Account; crediting the ledger again would double-count the fund's balance.
+ * So allocation (a) flips `donations.allocationStatus` to "allocated",
+ * (b) writes a `financeAuditEvents` row ("donation.allocated") carrying the
+ * Increase transfer id, and (c) posts ONE balance-affecting entry: a "fee"
+ * debit for `gross - net`, the processing fee Stripe kept.
  *
- * The Increase client (lib/finance/increase.ts) is being built concurrently
- * by another agent. Every call into it is a lazy `await import(...)` inside
- * an action body — never a top-level import — so this file's unit tests
- * never load it (see __tests__/finance-giving.test.ts, which exercises
- * `planAllocations` / `recordAllocation` / `recordReconcileResult` directly
- * with synthetic inputs and never touches `runAllocation` /
- * `runNightlyReconcile`'s provider calls).
+ * That fee debit is what makes the ADR-032 invariant satisfiable at all. The
+ * donation credit is gross; the bank will only ever hold net; without
+ * realising the fee the ledger permanently overstates every fund by its
+ * Stripe fees. It is posted when the transfer LANDS (not when the payout is
+ * matched) on purpose — that timing is what turns a stalled allocation into
+ * observable drift instead of a silently self-consistent lie:
+ *
+ *   in the pipeline, not paid out : ledger gross, bank 0,   pending gross → ok
+ *   matched to a payout, transfer stalled
+ *                                 : ledger gross, bank 0,   pending NET   → DRIFT = fee
+ *   allocated                     : ledger net,   bank net, pending 0     → ok
+ *
+ * (`pendingAllocationCents` switches from gross to net the moment a donation
+ * is bound to a payout — see `allocationAmountCents` — because from that
+ * point on, net is all that will ever arrive.)
+ *
+ * Every provider call (lib/finance/increase.ts, lib/finance/stripeConnect.ts)
+ * is a lazy `await import(...)` inside an action body — never a top-level
+ * import — so the mutation-level unit tests never load them (see
+ * __tests__/finance-giving.test.ts). __tests__/finance-allocation.test.ts
+ * does exercise `runAllocation` end to end, with both providers mocked.
  */
 
 import { v } from "convex/values";
@@ -51,16 +70,38 @@ import {
   internalMutation,
   internalAction,
   internalQuery,
+  type ActionCtx,
 } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
-import { checkInvariant } from "../../lib/finance/ledger";
+import { checkInvariant, postLedgerEntry } from "../../lib/finance/ledger";
 import { logFinanceAudit } from "../../lib/finance/audit";
 import { now } from "../../lib/utils";
 
-/** A donation never splits across payouts — this backstops that read. */
+/**
+ * GROSS: what the donor was charged and what the ledger was credited at
+ * donation time. A donation never splits across payouts — this backstops
+ * that read.
+ */
 function donationTotalCents(donation: Pick<Doc<"donations">, "amountCents" | "feeCoverCents">): number {
   return donation.amountCents + donation.feeCoverCents;
+}
+
+/**
+ * What allocation will actually move for a donation, in integer cents.
+ *
+ * Once a donation is bound to a payout we know its NET — the only amount the
+ * receiving Account ever got for it, and therefore the only amount that can
+ * be transferred on. Before that, gross is the honest estimate: the fee
+ * hasn't been taken yet as far as anything we can observe is concerned, and
+ * gross is what the ledger credited. Both the allocation plan and the
+ * nightly reconcile read the amount through here so they can never disagree
+ * about what "pending" is worth.
+ */
+function allocationAmountCents(
+  donation: Pick<Doc<"donations">, "amountCents" | "feeCoverCents" | "payoutNetCents">,
+): number {
+  return donation.payoutNetCents ?? donationTotalCents(donation);
 }
 
 // ============================================================================
@@ -71,28 +112,85 @@ export interface AllocationPlanItem {
   donationId: Id<"donations">;
   fundId: Id<"funds">;
   fundType: "group" | "general";
+  /** NET cents — what the payout actually delivered for this donation. */
   amountCents: number;
 }
 
+export interface AllocationPlan {
+  plan: AllocationPlanItem[];
+  /** Payout cents not matched to any donation — the Stripe processing fees. */
+  leftoverCents: number;
+  /** True when this payout had already been planned (a redelivered webhook). */
+  alreadyClaimed: boolean;
+}
+
 /**
- * Decides which pending donations a payout of `payoutCents` covers, without
- * moving any money. Oldest-first, whole donations only: walks the
- * community's pending donations in `createdAt` order and keeps adding while
- * the running total still fits under `payoutCents`; stops at the first
- * donation that would push it over (rather than skipping ahead to a
- * smaller later one) — a real Stripe payout is the sum of a contiguous
- * block of the oldest charges collected since the last payout, so this
- * mirrors how the money actually arrived. `leftoverCents` is almost always
- * the Stripe processing fees taken out of the payout — money that will
- * never match a whole donation and is expected to sit as leftover.
+ * Binds a payout's donations to that payout and returns the ones still
+ * needing a transfer. No money moves here.
+ *
+ * `charges` is the payout's composition straight from Stripe
+ * (`listPayoutChargeNets` in lib/finance/stripeConnect.ts): one entry per
+ * charge the payout contained, keyed by PaymentIntent id, valued at the NET
+ * cents that charge contributed. Membership is therefore read off Stripe,
+ * not guessed from a running total, and a donation is matched by identity —
+ * which is what makes this safe to re-run.
+ *
+ * REPLAY PROTECTION lives on the donation rows, not on the payout. A matched
+ * donation is stamped `allocationPayoutId` + `payoutNetCents` in the same
+ * transaction that selects it, and a donation already stamped for a
+ * DIFFERENT payout is never re-selected. So a redelivered `payout.paid`
+ * re-derives exactly the same donation set, minus the ones already flipped
+ * to "allocated" — i.e. it resumes the unfinished tail and can never
+ * double-transfer a finished item or reach forward into a later payout's
+ * money (which is what the old payout-level `processedStripePayouts` gate
+ * existed to prevent, at the cost of making partial failures unrecoverable).
+ *
+ * `leftoverCents` is the payout minus every matched net: the Stripe
+ * processing fees, plus anything in the payout we couldn't map to a donation.
  */
 export const planAllocations = internalMutation({
   args: {
     communityId: v.id("communities"),
     payoutCents: v.number(),
     stripePayoutId: v.string(),
+    charges: v.array(
+      v.object({
+        paymentIntentId: v.string(),
+        netCents: v.number(),
+      }),
+    ),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<AllocationPlan> => {
+    const existingClaim = await ctx.db
+      .query("processedStripePayouts")
+      .withIndex("by_payout", (q) => q.eq("stripePayoutId", args.stripePayoutId))
+      .first();
+    if (!existingClaim) {
+      await ctx.db.insert("processedStripePayouts", {
+        communityId: args.communityId,
+        stripePayoutId: args.stripePayoutId,
+        payoutCents: args.payoutCents,
+        processedAt: now(),
+      });
+    }
+
+    const netByPaymentIntent = new Map<string, number>();
+    for (const charge of args.charges) {
+      if (!Number.isInteger(charge.netCents) || charge.netCents <= 0) {
+        console.error(
+          `[finance] planAllocations: payout ${args.stripePayoutId} charge ${charge.paymentIntentId} has a non-positive/non-integer net (${charge.netCents}) — ignoring it`,
+        );
+        continue;
+      }
+      // One PaymentIntent producing two charges in one payout isn't a shape
+      // Stripe produces for our flow, but summing is the only non-lossy
+      // reading if it ever does.
+      netByPaymentIntent.set(
+        charge.paymentIntentId,
+        (netByPaymentIntent.get(charge.paymentIntentId) ?? 0) + charge.netCents,
+      );
+    }
+
     const funds = await ctx.db
       .query("funds")
       .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
@@ -109,25 +207,68 @@ export const planAllocations = internalMutation({
         pending.push({ ...donation, fundType: fund.type });
       }
     }
-    pending.sort((a, b) => a.createdAt - b.createdAt);
+    // Deterministic order: oldest gift first, tie-broken by id so two runs
+    // over the same data always plan the same sequence.
+    pending.sort((a, b) => a.createdAt - b.createdAt || a._id.localeCompare(b._id));
 
     const plan: AllocationPlanItem[] = [];
     let usedCents = 0;
     for (const donation of pending) {
-      const total = donationTotalCents(donation);
-      if (usedCents + total > args.payoutCents) {
-        break;
+      if (
+        donation.allocationPayoutId &&
+        donation.allocationPayoutId !== args.stripePayoutId
+      ) {
+        continue; // Belongs to another payout's pass.
       }
+
+      let netCents: number;
+      if (donation.allocationPayoutId === args.stripePayoutId) {
+        // Resume: an earlier pass over this payout matched this donation but
+        // its transfer never landed. Re-use the net already recorded rather
+        // than re-deriving it, so the retry moves the identical amount.
+        netCents = donation.payoutNetCents ?? 0;
+        if (netCents <= 0) {
+          console.error(
+            `[finance] planAllocations: donation ${donation._id} is bound to payout ${args.stripePayoutId} with no usable net — skipping`,
+          );
+          continue;
+        }
+      } else {
+        const matched = netByPaymentIntent.get(donation.stripePaymentIntentId);
+        if (matched === undefined) {
+          continue; // Not one of this payout's charges — a later payout owns it.
+        }
+        // Defensive only: the nets came out of this payout, so they sum to
+        // it by construction. `continue` (never `break`) so one oversized
+        // outlier can't wedge the queue behind it forever, which is exactly
+        // how the old gross matcher stalled.
+        if (usedCents + matched > args.payoutCents) {
+          console.error(
+            `[finance] planAllocations: donation ${donation._id} (net ${matched}) would overrun payout ${args.stripePayoutId} (${args.payoutCents}, ${usedCents} used) — skipping it, not the rest`,
+          );
+          continue;
+        }
+        netCents = matched;
+        await ctx.db.patch(donation._id, {
+          allocationPayoutId: args.stripePayoutId,
+          payoutNetCents: netCents,
+        });
+      }
+
       plan.push({
         donationId: donation._id,
         fundId: donation.fundId,
         fundType: donation.fundType,
-        amountCents: total,
+        amountCents: netCents,
       });
-      usedCents += total;
+      usedCents += netCents;
     }
 
-    return { plan, leftoverCents: args.payoutCents - usedCents };
+    return {
+      plan,
+      leftoverCents: args.payoutCents - usedCents,
+      alreadyClaimed: existingClaim !== null,
+    };
   },
 });
 
@@ -136,11 +277,15 @@ export const planAllocations = internalMutation({
 // ============================================================================
 
 /**
- * Flips a donation's `allocationStatus` to "allocated" and audit-logs the
- * Increase transfer id. Deliberately does NOT post a ledger entry — see the
- * file-level "DESIGN DECISION" comment above. Idempotent: a donation
- * already marked "allocated" is a no-op (safe if `runAllocation` retries
- * after a partial failure).
+ * Flips a donation's `allocationStatus` to "allocated", posts the Stripe
+ * processing fee as a "fee" debit, and audit-logs the Increase transfer id.
+ * The fee debit is the ONLY balance-affecting entry allocation writes — see
+ * the file-level "DESIGN DECISION" comment for why it exists and why it's
+ * posted here (on the transfer landing) rather than at match time.
+ *
+ * Idempotent on both halves: a donation already marked "allocated" returns
+ * immediately, and `postLedgerEntry` dedupes on `alloc-fee:{donationId}`
+ * anyway. Safe if `runAllocation` retries after a partial failure.
  */
 export const recordAllocation = internalMutation({
   args: {
@@ -163,6 +308,30 @@ export const recordAllocation = internalMutation({
 
     await ctx.db.patch(args.donationId, { allocationStatus: "allocated" });
 
+    const grossCents = donationTotalCents(donation);
+    const netCents = donation.payoutNetCents;
+    // Legacy rows (allocated before net matching shipped) carry no net, so
+    // there's no fee to realise for them — leave the ledger alone rather
+    // than inventing a number.
+    const feeCents = netCents === undefined ? 0 : grossCents - netCents;
+    if (feeCents < 0) {
+      // Net above gross is impossible from Stripe; refusing to post rather
+      // than crediting a fund for a number we don't understand.
+      console.error(
+        `[finance] recordAllocation: donation ${args.donationId} has net ${netCents} above gross ${grossCents} — not posting a fee entry`,
+      );
+    } else if (feeCents > 0) {
+      await postLedgerEntry(ctx, {
+        fundId: fund._id,
+        direction: "debit",
+        amountCents: feeCents,
+        kind: "fee",
+        idempotencyKey: `alloc-fee:${args.donationId}`,
+        stripeObjectId: donation.allocationPayoutId,
+        increaseObjectId: args.increaseTransferId,
+      });
+    }
+
     await logFinanceAudit(ctx, {
       communityId: fund.communityId,
       fundId: fund._id,
@@ -170,7 +339,47 @@ export const recordAllocation = internalMutation({
       details: {
         donationId: args.donationId,
         increaseTransferId: args.increaseTransferId,
-        amountCents: donationTotalCents(donation),
+        stripePayoutId: donation.allocationPayoutId,
+        // The net that moved; gross/fee spelled out so the audit row alone
+        // explains the balance change.
+        amountCents: netCents ?? grossCents,
+        grossCents,
+        feeCents,
+      },
+    });
+  },
+});
+
+/**
+ * Records that one item of an allocation pass failed to transfer, without
+ * failing the pass. The donation stays "pending" but keeps its
+ * `allocationPayoutId`/`payoutNetCents` stamp, so a redelivered webhook or
+ * the hourly retry cron picks up exactly this item again — see
+ * `executeAllocationItems`.
+ */
+export const recordAllocationFailure = internalMutation({
+  args: {
+    donationId: v.id("donations"),
+    fundId: v.id("funds"),
+    amountCents: v.number(),
+    reason: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const fund = await ctx.db.get(args.fundId);
+    if (!fund) {
+      console.error(
+        `[finance] recordAllocationFailure: fund ${args.fundId} not found`,
+      );
+      return;
+    }
+    await logFinanceAudit(ctx, {
+      communityId: fund.communityId,
+      fundId: args.fundId,
+      action: "allocation.transfer_failed",
+      details: {
+        donationId: args.donationId,
+        amountCents: args.amountCents,
+        reason: args.reason,
       },
     });
   },
@@ -180,116 +389,62 @@ export const recordAllocation = internalMutation({
 // runAllocation
 // ============================================================================
 
+export interface AllocationRunResult {
+  allocated: number;
+  failed: number;
+}
+
 /**
- * Executes an allocation plan: for each planned donation on a GROUP fund,
- * transfers the money from the community's receiving Account to the
- * fund's Increase Account, then records it. General-fund donations don't
- * need a transfer — the community's General Account is Increase's landing
- * spot for money that isn't earmarked to a specific group in the first
- * place — so those are recorded directly with no `increaseTransferId`.
+ * Moves one allocation plan's money, item by item, and reports how much of
+ * it landed. Shared by the payout webhook (`runAllocation`) and the hourly
+ * retry (`retryStaleAllocations`) so both recover identically.
  *
- * The Increase transfer's idempotency key (`alloc:${donationId}`) means a
- * re-run after a partial failure (e.g. the transfer succeeded but this
- * action crashed before calling `recordAllocation`) is safe: the next
- * `planAllocations` call re-selects the still-"pending" donation, and
- * Increase returns the same transfer for the same idempotency key instead
- * of moving the money twice.
+ * PER-ITEM ISOLATION is the whole point: each transfer is wrapped, so a
+ * single transient Increase failure costs exactly that donation instead of
+ * aborting the pass and stranding every item behind it. A failed item stays
+ * "pending" with its payout stamp intact, which is precisely what makes it
+ * re-selectable by the next pass.
+ *
+ * EXACTLY-ONCE across those retries comes from two independent locks:
+ *  - `recordAllocation` no-ops on an already-"allocated" donation, so a
+ *    finished item is never re-planned or re-recorded; and
+ *  - the Increase idempotency key `alloc:{donationId}` means that even the
+ *    genuinely ambiguous case — the transfer succeeded but this action died
+ *    before recording it — replays into the SAME transfer at Increase
+ *    rather than a second movement of money.
+ *
+ * General-fund donations need no transfer: the community's General Account
+ * is where money that isn't earmarked to a group belongs in the first place,
+ * so those are recorded directly with no `increaseTransferId`.
  */
-/**
- * Insert-if-absent claim on a Stripe payout id. Returns false when this
- * payout has already had an allocation pass — a redelivered `payout.paid`
- * webhook must NOT plan a second batch, because the first pass marked its
- * donations "allocated" and a re-plan would grab the NEXT pending donations
- * (money this payout never contained). Convex OCC makes the read+insert
- * transactional, so two concurrent deliveries can't both claim it.
- */
-export const claimPayout = internalMutation({
+async function executeAllocationItems(
+  ctx: ActionCtx,
   args: {
-    communityId: v.id("communities"),
-    stripePayoutId: v.string(),
-    payoutCents: v.number(),
+    receivingAccountId: string;
+    items: AllocationPlanItem[];
+    /** Job name for log lines, e.g. "runAllocation". */
+    context: string;
   },
-  handler: async (ctx, args): Promise<boolean> => {
-    const existing = await ctx.db
-      .query("processedStripePayouts")
-      .withIndex("by_payout", (q) => q.eq("stripePayoutId", args.stripePayoutId))
-      .first();
-    if (existing) {
-      return false;
-    }
-    await ctx.db.insert("processedStripePayouts", {
-      communityId: args.communityId,
-      stripePayoutId: args.stripePayoutId,
-      payoutCents: args.payoutCents,
-      processedAt: now(),
-    });
-    return true;
-  },
-});
+): Promise<AllocationRunResult> {
+  let allocated = 0;
+  let failed = 0;
 
-export const runAllocation = internalAction({
-  args: {
-    communityId: v.id("communities"),
-    stripePayoutId: v.string(),
-    payoutCents: v.number(),
-  },
-  handler: async (ctx, args) => {
-    const claimed = await ctx.runMutation(
-      internal.functions.finance.jobs.claimPayout,
-      {
-        communityId: args.communityId,
-        stripePayoutId: args.stripePayoutId,
-        payoutCents: args.payoutCents,
-      },
-    );
-    if (!claimed) {
-      console.log(
-        `[finance] runAllocation: payout ${args.stripePayoutId} already processed — replay ignored`,
-      );
-      return { allocated: 0 };
-    }
-
-    const { plan } = await ctx.runMutation(
-      internal.functions.finance.jobs.planAllocations,
-      {
-        communityId: args.communityId,
-        payoutCents: args.payoutCents,
-        stripePayoutId: args.stripePayoutId,
-      },
-    );
-
-    if (plan.length === 0) {
-      return { allocated: 0 };
-    }
-
-    const communityFinance = await ctx.runQuery(
-      internal.functions.finance.jobs.getCommunityFinanceForAllocation,
-      { communityId: args.communityId },
-    );
-    if (!communityFinance?.increaseReceivingAccountId) {
-      console.error(
-        `[finance] runAllocation: community ${args.communityId} has no receiving Account — skipping ${plan.length} planned item(s)`,
-      );
-      return { allocated: 0 };
-    }
-
-    let allocated = 0;
-    for (const item of plan) {
+  for (const item of args.items) {
+    try {
       if (item.fundType === "group") {
-        const fund = await ctx.runQuery(
+        const fund: Doc<"funds"> | null = await ctx.runQuery(
           internal.functions.finance.jobs.getFundForAllocation,
           { fundId: item.fundId },
         );
         if (!fund?.increaseAccountId) {
-          console.error(
-            `[finance] runAllocation: fund ${item.fundId} has no Increase Account — skipping donation ${item.donationId}`,
+          throw new Error(
+            `fund ${item.fundId} has no Increase Account to transfer into`,
           );
-          continue;
         }
 
         const { createAccountTransfer } = await import("../../lib/finance/increase");
         const transfer = await createAccountTransfer({
-          fromAccountId: communityFinance.increaseReceivingAccountId,
+          fromAccountId: args.receivingAccountId,
           toAccountId: fund.increaseAccountId,
           amountCents: item.amountCents,
           description: `Allocation: donation ${item.donationId}`,
@@ -306,9 +461,103 @@ export const runAllocation = internalAction({
         });
       }
       allocated += 1;
+    } catch (error) {
+      failed += 1;
+      const reason = error instanceof Error ? error.message : String(error);
+      console.error(
+        `[finance] ${args.context}: allocation failed for donation ${item.donationId} (${item.amountCents} cents) — it stays pending and will be retried`,
+        error,
+      );
+      try {
+        await ctx.runMutation(
+          internal.functions.finance.jobs.recordAllocationFailure,
+          {
+            donationId: item.donationId,
+            fundId: item.fundId,
+            amountCents: item.amountCents,
+            reason,
+          },
+        );
+      } catch (auditError) {
+        // Never let the bookkeeping of a failure become the thing that
+        // aborts the remaining transfers.
+        console.error(
+          `[finance] ${args.context}: could not audit the allocation failure for donation ${item.donationId}`,
+          auditError,
+        );
+      }
+    }
+  }
+
+  return { allocated, failed };
+}
+
+/**
+ * `payout.paid` entry point: allocate one Stripe payout into group Accounts.
+ *
+ * Order matters. Stripe is asked for the payout's composition BEFORE
+ * anything is written, so an unreachable Stripe leaves the payout completely
+ * untouched and the webhook redelivery (or the hourly retry) simply tries
+ * again — rather than claiming a payout we then can't match, which is how
+ * money used to get stranded. The action deliberately does not throw on a
+ * failed item: it reports counts, audits each failure, and leaves the item
+ * pending for the next pass.
+ */
+export const runAllocation = internalAction({
+  args: {
+    communityId: v.id("communities"),
+    stripePayoutId: v.string(),
+    payoutCents: v.number(),
+  },
+  handler: async (ctx, args): Promise<AllocationRunResult> => {
+    const communityFinance = await ctx.runQuery(
+      internal.functions.finance.jobs.getCommunityFinanceForAllocation,
+      { communityId: args.communityId },
+    );
+    if (!communityFinance?.stripeConnectedAccountId) {
+      console.error(
+        `[finance] runAllocation: community ${args.communityId} has no Stripe connected account — cannot resolve payout ${args.stripePayoutId}`,
+      );
+      return { allocated: 0, failed: 0 };
     }
 
-    return { allocated };
+    const { listPayoutChargeNets } = await import("../../lib/finance/stripeConnect");
+    const charges = await listPayoutChargeNets(
+      communityFinance.stripeConnectedAccountId,
+      args.stripePayoutId,
+    );
+
+    const { plan, alreadyClaimed } = await ctx.runMutation(
+      internal.functions.finance.jobs.planAllocations,
+      {
+        communityId: args.communityId,
+        payoutCents: args.payoutCents,
+        stripePayoutId: args.stripePayoutId,
+        charges,
+      },
+    );
+
+    if (alreadyClaimed) {
+      console.log(
+        `[finance] runAllocation: payout ${args.stripePayoutId} was already planned — resuming ${plan.length} unfinished item(s)`,
+      );
+    }
+    if (plan.length === 0) {
+      return { allocated: 0, failed: 0 };
+    }
+
+    if (!communityFinance.increaseReceivingAccountId) {
+      console.error(
+        `[finance] runAllocation: community ${args.communityId} has no receiving Account — ${plan.length} matched item(s) stay pending`,
+      );
+      return { allocated: 0, failed: plan.length };
+    }
+
+    return await executeAllocationItems(ctx, {
+      receivingAccountId: communityFinance.increaseReceivingAccountId,
+      items: plan,
+      context: "runAllocation",
+    });
   },
 });
 
@@ -339,8 +588,18 @@ export interface PendingAllocation {
 }
 
 /**
- * Sums pending (not-yet-allocated) donation totals per fund for a
- * community — the `pendingAllocationCents` term in the ADR-032 invariant.
+ * Sums pending (not-yet-allocated) donations per fund for a community — the
+ * `pendingAllocationCents` term in the ADR-032 invariant.
+ *
+ * Summed through `allocationAmountCents`, i.e. on exactly the basis the
+ * allocation job will transfer: NET once a donation is bound to a payout,
+ * gross while it's still in the Stripe pipeline. Summing gross throughout
+ * (as this used to) made the invariant self-consistent no matter what — a
+ * donation whose transfer never happened still "accounted" for its full
+ * gross, so a stalled allocation looked perfectly healthy. On the net basis
+ * a stall leaves the realised-but-unposted fee behind as drift, and the
+ * nightly alarm sees it.
+ *
  * Modeled as an internal mutation (rather than a query) so the nightly
  * reconcile action can call it with the same `ctx.runMutation` plumbing it
  * uses for `recordReconcileResult`, and so it's directly unit-testable the
@@ -362,7 +621,7 @@ export const computePendingAllocationCents = internalMutation({
         .filter((q) => q.eq(q.field("allocationStatus"), "pending"))
         .collect();
       const pendingCents = pendingDonations.reduce(
-        (sum, donation) => sum + donationTotalCents(donation),
+        (sum, donation) => sum + allocationAmountCents(donation),
         0,
       );
       results.push({ fundId: fund._id, pendingCents });
@@ -572,24 +831,156 @@ export const getCommunitiesWithStalePendingDonations = internalQuery({
 });
 
 /**
- * Cron entry point: ALERT-ONLY. Donations still pending after three days
- * mean a payout is delayed, held, or its webhook was missed — situations
- * where fabricating a synthetic payout amount and moving money against the
- * receiving Account would be wrong (the funds may simply not be there, or
- * belong to a different payout; Codex review, PR #653). This backstop only
- * surfaces the condition — an audit event per community for ops to
- * investigate. Recovery is the real payout webhook arriving, or a manual
- * runAllocation with the actual Stripe payout id and amount.
+ * Communities holding a donation that a payout pass matched but never
+ * transferred — with NO staleness window, unlike the alert path above.
+ *
+ * A bound donation isn't waiting on anything external: the payout has
+ * already landed in the receiving Account and the row records exactly how
+ * much of it belongs to this gift. Making it wait three days to be retried
+ * would leave real money sitting in the wrong Account for no reason (and
+ * Stripe stops redelivering `payout.paid` inside that window anyway).
+ */
+export const getCommunitiesWithStrandedAllocations = internalQuery({
+  args: {},
+  handler: async (ctx): Promise<Id<"communities">[]> => {
+    const pending = await ctx.db
+      .query("donations")
+      .withIndex("by_allocationStatus", (q) => q.eq("allocationStatus", "pending"))
+      .collect();
+
+    const communityIds = new Set<Id<"communities">>();
+    for (const donation of pending) {
+      if (!donation.allocationPayoutId) continue;
+      const fund = await ctx.db.get(donation.fundId);
+      if (fund) {
+        communityIds.add(fund.communityId);
+      }
+    }
+    return Array.from(communityIds);
+  },
+});
+
+/**
+ * Donations that a payout pass already matched (they carry
+ * `allocationPayoutId` + `payoutNetCents`) but never transferred — the
+ * residue of a partial failure. Everything needed to finish them is already
+ * on the row: the exact payout they belong to and the exact NET Stripe
+ * delivered for them. Nothing is inferred, so replaying them is safe.
+ *
+ * Modeled as an internal mutation, like `computePendingAllocationCents`
+ * above, so the retry action can call it with the same plumbing; it performs
+ * no writes.
+ */
+export const listResumableAllocations = internalMutation({
+  args: { communityId: v.id("communities") },
+  handler: async (ctx, args): Promise<AllocationPlanItem[]> => {
+    const funds = await ctx.db
+      .query("funds")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+
+    const rows: Array<{ item: AllocationPlanItem; createdAt: number }> = [];
+    for (const fund of funds) {
+      const pendingDonations = await ctx.db
+        .query("donations")
+        .withIndex("by_fund", (q) => q.eq("fundId", fund._id))
+        .filter((q) => q.eq(q.field("allocationStatus"), "pending"))
+        .collect();
+      for (const donation of pendingDonations) {
+        if (!donation.allocationPayoutId) continue;
+        const netCents = donation.payoutNetCents;
+        if (netCents === undefined || !Number.isInteger(netCents) || netCents <= 0) {
+          continue;
+        }
+        rows.push({
+          createdAt: donation.createdAt,
+          item: {
+            donationId: donation._id,
+            fundId: fund._id,
+            fundType: fund.type,
+            amountCents: netCents,
+          },
+        });
+      }
+    }
+    rows.sort(
+      (a, b) =>
+        a.createdAt - b.createdAt ||
+        a.item.donationId.localeCompare(b.item.donationId),
+    );
+    return rows.map((row) => row.item);
+  },
+});
+
+/**
+ * Cron entry point: recover what can be recovered, alert on the rest.
+ *
+ * A donation stuck "pending" is one of two very different things.
+ *
+ * (a) BOUND to a payout, transfer never landed. Recoverable immediately —
+ * no staleness window — because nothing has to be guessed: the row records
+ * which payout it belongs to and the exact NET that payout delivered for it,
+ * so the retry moves a known amount out of money known to have arrived, and
+ * the `alloc:{donationId}` idempotency key collapses a retry of a transfer
+ * that actually did land. Waiting three days here would leave real money in
+ * the wrong Account for no reason (and Stripe stops redelivering
+ * `payout.paid` inside that window anyway). Before net matching there was no
+ * such record, which is why this job could only ever alert.
+ *
+ * (b) NOT bound to any payout: delayed, held, or a missed webhook. Stays
+ * ALERT-ONLY past the three-day window, deliberately. Fabricating a
+ * synthetic payout amount and moving money against the receiving Account
+ * would be wrong — the funds may simply not be there, or belong to a
+ * different payout (Codex review, PR #653). Recovery there is the real
+ * payout webhook arriving, or a manual `runAllocation` with the actual
+ * Stripe payout id and amount.
  */
 export const retryStaleAllocations = internalAction({
   args: {},
   handler: async (ctx) => {
-    const communityIds = await ctx.runQuery(
+    // --- (a) Recover: finish the transfers a previous pass couldn't. ---
+    const resumedByCommunity = new Map<Id<"communities">, AllocationRunResult>();
+    const strandedCommunityIds: Id<"communities">[] = await ctx.runQuery(
+      internal.functions.finance.jobs.getCommunitiesWithStrandedAllocations,
+      {},
+    );
+
+    for (const communityId of strandedCommunityIds) {
+      const resumable: AllocationPlanItem[] = await ctx.runMutation(
+        internal.functions.finance.jobs.listResumableAllocations,
+        { communityId },
+      );
+      if (resumable.length === 0) continue;
+
+      const communityFinance = await ctx.runQuery(
+        internal.functions.finance.jobs.getCommunityFinanceForAllocation,
+        { communityId },
+      );
+      if (!communityFinance?.increaseReceivingAccountId) {
+        console.error(
+          `[finance] retryStaleAllocations: community ${communityId} has ${resumable.length} stranded allocation(s) but no receiving Account`,
+        );
+        continue;
+      }
+
+      const resumed = await executeAllocationItems(ctx, {
+        receivingAccountId: communityFinance.increaseReceivingAccountId,
+        items: resumable,
+        context: "retryStaleAllocations",
+      });
+      resumedByCommunity.set(communityId, resumed);
+      console.log(
+        `[finance] retryStaleAllocations: community ${communityId} resumed ${resumed.allocated}/${resumable.length} stranded allocation(s), ${resumed.failed} still failing`,
+      );
+    }
+
+    // --- (b) Alert: surface whatever is still pending past the window. ---
+    const staleCommunityIds = await ctx.runQuery(
       internal.functions.finance.jobs.getCommunitiesWithStalePendingDonations,
       { olderThanMs: THREE_DAYS_MS },
     );
 
-    for (const communityId of communityIds) {
+    for (const communityId of staleCommunityIds) {
       const pending = await ctx.runMutation(
         internal.functions.finance.jobs.computePendingAllocationCents,
         { communityId },
@@ -598,14 +989,20 @@ export const retryStaleAllocations = internalAction({
         (sum: number, p: PendingAllocation) => sum + p.pendingCents,
         0,
       );
-      if (stalePendingCents <= 0) continue;
+      if (stalePendingCents <= 0) continue; // Step (a) cleared it.
 
+      const resumed = resumedByCommunity.get(communityId);
       console.error(
         `[finance] allocation stale: community ${communityId} has ${stalePendingCents} cents of donations pending allocation for >3 days`,
       );
       await ctx.runMutation(
         internal.functions.finance.jobs.recordStaleAllocationAlert,
-        { communityId, stalePendingCents },
+        {
+          communityId,
+          stalePendingCents,
+          resumedCount: resumed?.allocated ?? 0,
+          failedCount: resumed?.failed ?? 0,
+        },
       );
     }
   },
@@ -615,6 +1012,9 @@ export const recordStaleAllocationAlert = internalMutation({
   args: {
     communityId: v.id("communities"),
     stalePendingCents: v.number(),
+    /** Stranded allocations this run managed to finish / still couldn't. */
+    resumedCount: v.optional(v.number()),
+    failedCount: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     await logFinanceAudit(ctx, {
@@ -623,6 +1023,8 @@ export const recordStaleAllocationAlert = internalMutation({
       details: {
         stalePendingCents: args.stalePendingCents,
         thresholdDays: 3,
+        resumedCount: args.resumedCount,
+        failedCount: args.failedCount,
       },
     });
   },

--- a/apps/convex/functions/finance/jobs.ts
+++ b/apps/convex/functions/finance/jobs.ts
@@ -7,7 +7,8 @@
  *   1. ALLOCATION — Stripe pays a community out in bulk (T+2) to its
  *      Increase receiving Account. `runAllocation` asks Stripe which charges
  *      composed that payout and at what NET (gross minus the processing fee
- *      Stripe already took), `planAllocations` binds each of those charges'
+ *      Stripe already took, minus any refund of the same charge that settled
+ *      in the same payout), `planAllocations` binds each of those charges'
  *      donations to the payout, and each bound donation's net is then moved
  *      from the receiving Account to its group's Account via Increase,
  *      flipping `donations.allocationStatus`.
@@ -57,6 +58,46 @@
  * is bound to a payout — see `allocationAmountCents` — because from that
  * point on, net is all that will ever arrive.)
  *
+ * REFUNDS AND DISPUTES — the fourth and fifth states, and the one place the
+ * model is deliberately incomplete:
+ *
+ *   refunded before its payout   : ledger 0,   bank 0,   pending 0     → ok
+ *   refunded in part, unpaid-out : ledger gross−refund, bank 0,
+ *                                  pending gross−refund               → ok
+ *   refunded in part after a payout bound it (but before the transfer):
+ *                                  ledger gross−refund, bank 0,
+ *                                  pending min(net, gross−refund)     → ok
+ *   refunded after allocation    : ledger gross−fee−refund (+fee back
+ *                                  once refunds exceed the net),
+ *                                  bank NET, pending 0   → DRIFT = the money
+ *                                  still sitting in the group's Account
+ *
+ * The first two close because `recordDonationRefund` (giving.ts) stamps
+ * `donations.refundedCents` and flips a fully-refunded pending gift to the
+ * terminal `"refunded"` status, so it leaves the pending sum at the same
+ * moment its ledger credit is reversed — and because
+ * `getPayoutComposition` nets refund rows against their charge, so a payout
+ * carrying both delivers nothing for that PaymentIntent and nothing is
+ * transferred.
+ *
+ * The third does NOT close, deliberately: Stripe takes the refund out of the
+ * community's Stripe balance (reducing a LATER payout), while the money for
+ * the original gift is already sitting in the group's own Increase Account.
+ * Pulling it back is a bank-side clawback transfer that ADR-032 has not
+ * designed yet, so the nightly reconcile alarms on exactly that amount until
+ * it is handled manually. What we do guarantee is that the fund's balance
+ * never renders NEGATIVE from a refund: once refunds exceed the net the fund
+ * actually received, the realised `fee` debit is reversed with a compensating
+ * credit rather than left as an overdraft (see `recordDonationRefund`).
+ *
+ * DISPUTES are the same shape and are known-drifting: `recordDonationDisputed`
+ * is audit-only (no provisional debit, no fund-status change), so a disputed
+ * gift's ledger credit stands until the nightly reconcile flags it. The money
+ * path is nonetheless safe, because Stripe posts a chargeback as an
+ * `adjustment` balance transaction, which `getPayoutComposition` nets against
+ * the charge just like a refund — a disputed gift is not transferred out of
+ * the receiving Account.
+ *
  * Every provider call (lib/finance/increase.ts, lib/finance/stripeConnect.ts)
  * is a lazy `await import(...)` inside an action body — never a top-level
  * import — so the mutation-level unit tests never load them (see
@@ -92,16 +133,68 @@ function donationTotalCents(donation: Pick<Doc<"donations">, "amountCents" | "fe
  *
  * Once a donation is bound to a payout we know its NET — the only amount the
  * receiving Account ever got for it, and therefore the only amount that can
- * be transferred on. Before that, gross is the honest estimate: the fee
- * hasn't been taken yet as far as anything we can observe is concerned, and
- * gross is what the ledger credited. Both the allocation plan and the
- * nightly reconcile read the amount through here so they can never disagree
- * about what "pending" is worth.
+ * be transferred on. Before that, gross MINUS whatever has already been
+ * refunded is the honest estimate: the fee hasn't been taken yet as far as
+ * anything we can observe is concerned, but a refund has already reversed
+ * its share of the ledger credit, so counting the full gross would drift by
+ * exactly the refunded amount every night and never close. Both the
+ * allocation plan and the nightly reconcile read the amount through here so
+ * they can never disagree about what "pending" is worth.
  */
 function allocationAmountCents(
-  donation: Pick<Doc<"donations">, "amountCents" | "feeCoverCents" | "payoutNetCents">,
+  donation: Pick<
+    Doc<"donations">,
+    "amountCents" | "feeCoverCents" | "payoutNetCents" | "refundedCents"
+  >,
 ): number {
-  return donation.payoutNetCents ?? donationTotalCents(donation);
+  const unrefundedGross = Math.max(
+    0,
+    donationTotalCents(donation) - (donation.refundedCents ?? 0),
+  );
+  if (donation.payoutNetCents !== undefined) {
+    // Normally the bound net is the smaller of the two and wins. The `min`
+    // matters for a refund that lands AFTER the payout bound the donation:
+    // `payoutNetCents` was fixed at bind time and can't know about it, while
+    // the ledger has already taken the refund debit. Counting the stale net
+    // would drift by the refunded amount every night and never close.
+    return Math.min(donation.payoutNetCents, unrefundedGross);
+  }
+  return unrefundedGross;
+}
+
+/**
+ * How long a donation stays claimed by the pass that selected it for a
+ * transfer.
+ *
+ * The lease exists because the per-donation payout stamp is a *marker*, not a
+ * reservation: two passes can legitimately select the same bound donation
+ * (a redelivered `payout.paid`, or the hourly retry cron firing while a
+ * `runAllocation` is mid-loop), and both would then issue the same
+ * `alloc:{donationId}` Increase transfer *concurrently* — before either has
+ * recorded anything, so `recordAllocation`'s already-allocated no-op cannot
+ * help. Increase documents "at most one object per idempotency key" but says
+ * nothing about two in-flight requests sharing one, and that is not a
+ * property to rest a money guarantee on.
+ *
+ * Claiming happens inside the selection MUTATION (`planAllocations` /
+ * `listResumableAllocations`), so acquiring the lease and returning the item
+ * are one serializable transaction and Convex's OCC decides the winner.
+ *
+ * The TTL bounds a pass that dies mid-transfer without releasing: 15 minutes
+ * comfortably exceeds an action's own lifetime, and the hourly retry cron
+ * picks the item up on its next tick. Failures release the lease immediately
+ * (`recordAllocationFailure`), so the normal partial-failure path never waits
+ * for expiry.
+ */
+const ALLOCATION_LEASE_TTL_MS = 15 * 60 * 1000;
+
+/** True while another pass still holds this donation's transfer claim. */
+function allocationLeaseHeld(
+  donation: Pick<Doc<"donations">, "allocationTransferStartedAt">,
+  nowMs: number,
+): boolean {
+  const startedAt = donation.allocationTransferStartedAt;
+  return startedAt !== undefined && nowMs - startedAt < ALLOCATION_LEASE_TTL_MS;
 }
 
 // ============================================================================
@@ -118,10 +211,17 @@ export interface AllocationPlanItem {
 
 export interface AllocationPlan {
   plan: AllocationPlanItem[];
-  /** Payout cents not matched to any donation — the Stripe processing fees. */
+  /**
+   * Payout cents this pass did not match to a donation it could act on.
+   * Expected to be ~0: a payout IS the sum of its rows' nets, so anything
+   * here is either a charge we couldn't map to a donation, or a gift another
+   * pass currently holds. `runAllocation` alarms when it gets large.
+   */
   leftoverCents: number;
   /** True when this payout had already been planned (a redelivered webhook). */
   alreadyClaimed: boolean;
+  /** Matched donations another in-flight pass currently holds the lease on. */
+  leasedElsewhere: number;
 }
 
 /**
@@ -129,9 +229,10 @@ export interface AllocationPlan {
  * needing a transfer. No money moves here.
  *
  * `charges` is the payout's composition straight from Stripe
- * (`listPayoutChargeNets` in lib/finance/stripeConnect.ts): one entry per
- * charge the payout contained, keyed by PaymentIntent id, valued at the NET
- * cents that charge contributed. Membership is therefore read off Stripe,
+ * (`getPayoutComposition` in lib/finance/stripeConnect.ts): one entry per
+ * PaymentIntent the payout contained, valued at the NET cents it actually
+ * contributed (its charge minus any refund of that same charge which settled
+ * in the same payout). Membership is therefore read off Stripe,
  * not guessed from a running total, and a donation is matched by identity —
  * which is what makes this safe to re-run.
  *
@@ -145,8 +246,21 @@ export interface AllocationPlan {
  * money (which is what the old payout-level `processedStripePayouts` gate
  * existed to prevent, at the cost of making partial failures unrecoverable).
  *
- * `leftoverCents` is the payout minus every matched net: the Stripe
- * processing fees, plus anything in the payout we couldn't map to a donation.
+ * CONCURRENCY is separate from replay, and needs a LEASE rather than a
+ * marker: this mutation stamps `allocationTransferStartedAt` on every item it
+ * returns and skips any item another pass still holds, all inside the one
+ * transaction, so two overlapping passes can never both be told to transfer
+ * the same donation. See `ALLOCATION_LEASE_TTL_MS`.
+ *
+ * REFUNDED gifts never reach here: a fully refunded donation is
+ * `allocationStatus: "refunded"` (giving.ts `recordDonationRefund`) and the
+ * selection below only ever reads `"pending"` rows, while a refund that
+ * settled inside this payout has already been netted out of `charges` by
+ * `getPayoutComposition`.
+ *
+ * `leftoverCents` is the payout minus every net this pass took responsibility
+ * for: charges we couldn't map to an actionable donation, plus anything held
+ * by another pass.
  */
 export const planAllocations = internalMutation({
   args: {
@@ -211,8 +325,10 @@ export const planAllocations = internalMutation({
     // over the same data always plan the same sequence.
     pending.sort((a, b) => a.createdAt - b.createdAt || a._id.localeCompare(b._id));
 
+    const nowMs = now();
     const plan: AllocationPlanItem[] = [];
     let usedCents = 0;
+    let leasedElsewhere = 0;
     for (const donation of pending) {
       if (
         donation.allocationPayoutId &&
@@ -249,11 +365,21 @@ export const planAllocations = internalMutation({
           continue;
         }
         netCents = matched;
-        await ctx.db.patch(donation._id, {
-          allocationPayoutId: args.stripePayoutId,
-          payoutNetCents: netCents,
-        });
       }
+
+      // Take the lease in the same transaction that hands the item out. A
+      // concurrent pass either loses the OCC race and re-reads this stamp, or
+      // wins and this pass re-reads theirs — either way exactly one of us
+      // gets to move the money.
+      if (allocationLeaseHeld(donation, nowMs)) {
+        leasedElsewhere += 1;
+        continue;
+      }
+      await ctx.db.patch(donation._id, {
+        allocationPayoutId: args.stripePayoutId,
+        payoutNetCents: netCents,
+        allocationTransferStartedAt: nowMs,
+      });
 
       plan.push({
         donationId: donation._id,
@@ -268,6 +394,7 @@ export const planAllocations = internalMutation({
       plan,
       leftoverCents: args.payoutCents - usedCents,
       alreadyClaimed: existingClaim !== null,
+      leasedElsewhere,
     };
   },
 });
@@ -306,19 +433,59 @@ export const recordAllocation = internalMutation({
       throw new Error(`recordAllocation: fund ${donation.fundId} not found`);
     }
 
-    await ctx.db.patch(args.donationId, { allocationStatus: "allocated" });
+    if (donation.allocationStatus === "refunded") {
+      // The refund webhook landed while this transfer was in flight, so real
+      // money moved into the group's Account for a gift the donor already got
+      // back. "refunded" is terminal and stays — overwriting it with
+      // "allocated" would hide the problem. The ledger is already correct
+      // (credit + full refund debit, no fee), so the money now sitting in the
+      // group Account shows up as reconcile drift, which is the signal an
+      // operator needs to claw it back.
+      console.error(
+        `[finance] recordAllocation: donation ${args.donationId} was refunded while its allocation transfer was in flight — ${args.increaseTransferId ?? "no transfer id"} moved money for a returned gift`,
+      );
+      await ctx.db.patch(args.donationId, { allocationTransferStartedAt: undefined });
+      await logFinanceAudit(ctx, {
+        communityId: fund.communityId,
+        fundId: fund._id,
+        action: "allocation.refunded_in_flight",
+        details: {
+          donationId: args.donationId,
+          increaseTransferId: args.increaseTransferId,
+          stripePayoutId: donation.allocationPayoutId,
+          amountCents: donation.payoutNetCents,
+          refundedCents: donation.refundedCents,
+        },
+      });
+      return;
+    }
+
+    await ctx.db.patch(args.donationId, {
+      allocationStatus: "allocated",
+      // Transfer resolved — drop the claim (schema: allocationTransferStartedAt).
+      allocationTransferStartedAt: undefined,
+    });
 
     const grossCents = donationTotalCents(donation);
+    const refundedCents = donation.refundedCents ?? 0;
     const netCents = donation.payoutNetCents;
+    // The fee is what Stripe kept out of the part of the gift the fund still
+    // has. Subtracting refunds first matters when a partial refund settled in
+    // the same payout: `payoutNetCents` is already net of it, so charging
+    // `gross − net` would debit the refund a SECOND time on top of the
+    // `refund` entry recordDonationRefund already posted.
     // Legacy rows (allocated before net matching shipped) carry no net, so
     // there's no fee to realise for them — leave the ledger alone rather
     // than inventing a number.
-    const feeCents = netCents === undefined ? 0 : grossCents - netCents;
+    const feeCents = netCents === undefined ? 0 : grossCents - refundedCents - netCents;
     if (feeCents < 0) {
-      // Net above gross is impossible from Stripe; refusing to post rather
-      // than crediting a fund for a number we don't understand.
+      // The net exceeds what's left of the gift. Either Stripe returned a net
+      // above gross (impossible) or a refund landed after this payout bound
+      // the donation, so `payoutNetCents` is larger than the remainder. Both
+      // mean we'd be CREDITING the fund for a number we don't understand;
+      // refuse, and let the nightly reconcile surface the difference.
       console.error(
-        `[finance] recordAllocation: donation ${args.donationId} has net ${netCents} above gross ${grossCents} — not posting a fee entry`,
+        `[finance] recordAllocation: donation ${args.donationId} has net ${netCents} above its unrefunded gross (${grossCents} gross − ${refundedCents} refunded) — not posting a fee entry`,
       );
     } else if (feeCents > 0) {
       await postLedgerEntry(ctx, {
@@ -351,11 +518,26 @@ export const recordAllocation = internalMutation({
 });
 
 /**
- * Records that one item of an allocation pass failed to transfer, without
- * failing the pass. The donation stays "pending" but keeps its
- * `allocationPayoutId`/`payoutNetCents` stamp, so a redelivered webhook or
- * the hourly retry cron picks up exactly this item again — see
- * `executeAllocationItems`.
+ * Records that one item of an allocation pass didn't complete, without
+ * failing the pass, and RELEASES that item's transfer lease so the next pass
+ * can pick it up immediately. The donation stays "pending" and keeps its
+ * `allocationPayoutId`/`payoutNetCents` stamp — see `executeAllocationItems`.
+ *
+ * `stage` is the distinction that matters at 3am, and the two failures are
+ * genuinely different events:
+ *
+ *  - `"transfer"` → the Increase call threw. No money moved. Retry freely.
+ *  - `"record"`   → the transfer LANDED (its id is in `increaseTransferId`)
+ *                   and the bookkeeping mutation threw — e.g. `postLedgerEntry`
+ *                   rejecting a fund that has since been closed, or OCC
+ *                   retries exhausting. Real money is now in the group's
+ *                   Account with nothing in our ledger saying so. The retry
+ *                   re-issues the same `alloc:{donationId}` key, which
+ *                   Increase collapses into the same transfer, and then
+ *                   re-attempts the recording. Auditing this as
+ *                   `allocation.transfer_failed` (which it used to be) is a
+ *                   lie that sends an operator looking for a transfer that
+ *                   is sitting right there.
  */
 export const recordAllocationFailure = internalMutation({
   args: {
@@ -363,8 +545,18 @@ export const recordAllocationFailure = internalMutation({
     fundId: v.id("funds"),
     amountCents: v.number(),
     reason: v.string(),
+    stage: v.union(v.literal("transfer"), v.literal("record")),
+    /** Set only for stage "record" — the transfer that already went through. */
+    increaseTransferId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    const donation = await ctx.db.get(args.donationId);
+    if (donation?.allocationTransferStartedAt !== undefined) {
+      await ctx.db.patch(args.donationId, {
+        allocationTransferStartedAt: undefined,
+      });
+    }
+
     const fund = await ctx.db.get(args.fundId);
     if (!fund) {
       console.error(
@@ -375,11 +567,15 @@ export const recordAllocationFailure = internalMutation({
     await logFinanceAudit(ctx, {
       communityId: fund.communityId,
       fundId: args.fundId,
-      action: "allocation.transfer_failed",
+      action:
+        args.stage === "record"
+          ? "allocation.record_failed"
+          : "allocation.transfer_failed",
       details: {
         donationId: args.donationId,
         amountCents: args.amountCents,
         reason: args.reason,
+        increaseTransferId: args.increaseTransferId,
       },
     });
   },
@@ -405,13 +601,21 @@ export interface AllocationRunResult {
  * "pending" with its payout stamp intact, which is precisely what makes it
  * re-selectable by the next pass.
  *
- * EXACTLY-ONCE across those retries comes from two independent locks:
+ * EXACTLY-ONCE across those retries comes from three independent locks:
+ *  - the per-donation transfer LEASE (`allocationTransferStartedAt`, taken by
+ *    the selection mutation) means two overlapping passes can never both be
+ *    holding this item at the same time;
  *  - `recordAllocation` no-ops on an already-"allocated" donation, so a
  *    finished item is never re-planned or re-recorded; and
  *  - the Increase idempotency key `alloc:{donationId}` means that even the
- *    genuinely ambiguous case — the transfer succeeded but this action died
- *    before recording it — replays into the SAME transfer at Increase
- *    rather than a second movement of money.
+ *    genuinely ambiguous case — the transfer succeeded but the recording
+ *    didn't — replays into the SAME transfer at Increase rather than a
+ *    second movement of money.
+ *
+ * The transfer and the recording are in SEPARATE try blocks on purpose. They
+ * fail in ways that need different responses, and collapsing them made
+ * "money moved but we never booked it" indistinguishable from "money never
+ * moved" in the audit trail.
  *
  * General-fund donations need no transfer: the community's General Account
  * is where money that isn't earmarked to a group belongs in the first place,
@@ -429,9 +633,38 @@ async function executeAllocationItems(
   let allocated = 0;
   let failed = 0;
 
-  for (const item of args.items) {
+  /** Audit + release the lease; never let this abort the remaining items. */
+  const noteFailure = async (
+    item: AllocationPlanItem,
+    stage: "transfer" | "record",
+    reason: string,
+    increaseTransferId?: string,
+  ) => {
     try {
-      if (item.fundType === "group") {
+      await ctx.runMutation(
+        internal.functions.finance.jobs.recordAllocationFailure,
+        {
+          donationId: item.donationId,
+          fundId: item.fundId,
+          amountCents: item.amountCents,
+          reason,
+          stage,
+          increaseTransferId,
+        },
+      );
+    } catch (auditError) {
+      console.error(
+        `[finance] ${args.context}: could not audit the allocation ${stage} failure for donation ${item.donationId}`,
+        auditError,
+      );
+    }
+  };
+
+  for (const item of args.items) {
+    // --- 1. Move the money (group funds only). ---
+    let increaseTransferId: string | undefined;
+    if (item.fundType === "group") {
+      try {
         const fund: Doc<"funds"> | null = await ctx.runQuery(
           internal.functions.finance.jobs.getFundForAllocation,
           { fundId: item.fundId },
@@ -450,46 +683,58 @@ async function executeAllocationItems(
           description: `Allocation: donation ${item.donationId}`,
           idempotencyKey: `alloc:${item.donationId}`,
         });
-
-        await ctx.runMutation(internal.functions.finance.jobs.recordAllocation, {
-          donationId: item.donationId,
-          increaseTransferId: transfer.id,
-        });
-      } else {
-        await ctx.runMutation(internal.functions.finance.jobs.recordAllocation, {
-          donationId: item.donationId,
-        });
+        increaseTransferId = transfer.id;
+      } catch (error) {
+        failed += 1;
+        const reason = error instanceof Error ? error.message : String(error);
+        console.error(
+          `[finance] ${args.context}: TRANSFER failed for donation ${item.donationId} (${item.amountCents} cents) — no money moved; it stays pending and will be retried`,
+          error,
+        );
+        await noteFailure(item, "transfer", reason);
+        continue;
       }
+    }
+
+    // --- 2. Book it. Money has already moved by this point. ---
+    try {
+      await ctx.runMutation(internal.functions.finance.jobs.recordAllocation, {
+        donationId: item.donationId,
+        increaseTransferId,
+      });
       allocated += 1;
     } catch (error) {
       failed += 1;
       const reason = error instanceof Error ? error.message : String(error);
       console.error(
-        `[finance] ${args.context}: allocation failed for donation ${item.donationId} (${item.amountCents} cents) — it stays pending and will be retried`,
+        `[finance] ${args.context}: RECORD failed for donation ${item.donationId} (${item.amountCents} cents) after transfer ${increaseTransferId ?? "n/a"} already landed — the money HAS moved and is not yet in the ledger`,
         error,
       );
-      try {
-        await ctx.runMutation(
-          internal.functions.finance.jobs.recordAllocationFailure,
-          {
-            donationId: item.donationId,
-            fundId: item.fundId,
-            amountCents: item.amountCents,
-            reason,
-          },
-        );
-      } catch (auditError) {
-        // Never let the bookkeeping of a failure become the thing that
-        // aborts the remaining transfers.
-        console.error(
-          `[finance] ${args.context}: could not audit the allocation failure for donation ${item.donationId}`,
-          auditError,
-        );
-      }
+      await noteFailure(item, "record", reason, increaseTransferId);
     }
   }
 
   return { allocated, failed };
+}
+
+/**
+ * How far a payout's unmatched remainder can stray before it is treated as a
+ * problem rather than rounding. A payout IS the sum of its balance
+ * transactions' nets, so a fully-matched pass leaves 0 — anything material
+ * means the payout carried money we could not attribute to a donation (or a
+ * refund we could not attribute to a charge, which shows up as a NEGATIVE
+ * remainder). $1, or 1% of the payout for large ones, is generous headroom
+ * for a single odd row while still catching a systematically broken match.
+ */
+const UNMATCHED_PAYOUT_FLOOR_CENTS = 100;
+const UNMATCHED_PAYOUT_FRACTION = 0.01;
+
+function unmatchedPayoutIsAlarming(leftoverCents: number, payoutCents: number): boolean {
+  const tolerance = Math.max(
+    UNMATCHED_PAYOUT_FLOOR_CENTS,
+    Math.round(Math.abs(payoutCents) * UNMATCHED_PAYOUT_FRACTION),
+  );
+  return Math.abs(leftoverCents) > tolerance;
 }
 
 /**
@@ -502,6 +747,15 @@ async function executeAllocationItems(
  * money used to get stranded. The action deliberately does not throw on a
  * failed item: it reports counts, audits each failure, and leaves the item
  * pending for the next pass.
+ *
+ * OBSERVABILITY is load-bearing here, not decoration. Once this returns, the
+ * `processedStripePayouts` row is written and the webhook 200s, so Stripe
+ * never redelivers — and `retryStaleAllocations` only resumes donations a
+ * pass already BOUND. A payout that matched nothing therefore has no
+ * automatic recovery at all, which is the same silent-stall failure class
+ * this whole job was rewritten to eliminate. So an empty plan and a material
+ * unmatched remainder both audit and `console.error`, rather than returning
+ * zero quietly.
  */
 export const runAllocation = internalAction({
   args: {
@@ -521,27 +775,68 @@ export const runAllocation = internalAction({
       return { allocated: 0, failed: 0 };
     }
 
-    const { listPayoutChargeNets } = await import("../../lib/finance/stripeConnect");
-    const charges = await listPayoutChargeNets(
+    const { getPayoutComposition } = await import("../../lib/finance/stripeConnect");
+    const composition = await getPayoutComposition(
       communityFinance.stripeConnectedAccountId,
       args.stripePayoutId,
     );
 
-    const { plan, alreadyClaimed } = await ctx.runMutation(
-      internal.functions.finance.jobs.planAllocations,
-      {
+    if (composition.reversedPaymentIntentIds.length > 0) {
+      // Not an error: the netting did its job and kept refunded money out of
+      // a group's Account. Logged because it explains a short payout.
+      console.log(
+        `[finance] runAllocation: payout ${args.stripePayoutId} carried ${composition.reversedPaymentIntentIds.length} fully reversed charge(s) — nothing will be allocated for them`,
+      );
+    }
+    if (composition.unattributedReversalCents !== 0) {
+      console.error(
+        `[finance] runAllocation: payout ${args.stripePayoutId} carries ${composition.unattributedReversalCents} cents of reversals with no resolvable PaymentIntent — the payout is short by money that cannot be netted against any donation`,
+      );
+    }
+
+    const { plan, alreadyClaimed, leftoverCents, leasedElsewhere } =
+      await ctx.runMutation(internal.functions.finance.jobs.planAllocations, {
         communityId: args.communityId,
         payoutCents: args.payoutCents,
         stripePayoutId: args.stripePayoutId,
-        charges,
-      },
-    );
+        charges: composition.charges,
+      });
 
     if (alreadyClaimed) {
       console.log(
         `[finance] runAllocation: payout ${args.stripePayoutId} was already planned — resuming ${plan.length} unfinished item(s)`,
       );
     }
+    if (leasedElsewhere > 0) {
+      console.log(
+        `[finance] runAllocation: payout ${args.stripePayoutId} skipped ${leasedElsewhere} item(s) another in-flight pass is holding`,
+      );
+    }
+
+    const unmatchedIsAlarming =
+      // An item another pass holds is accounted for, just not by us.
+      leasedElsewhere === 0 &&
+      unmatchedPayoutIsAlarming(leftoverCents, args.payoutCents);
+
+    if (plan.length === 0 || unmatchedIsAlarming) {
+      console.error(
+        `[finance] runAllocation: payout ${args.stripePayoutId} (${args.payoutCents} cents) matched ${plan.length} donation(s) from ${composition.charges.length} charge(s), leaving ${leftoverCents} cents unattributed`,
+      );
+      await ctx.runMutation(
+        internal.functions.finance.jobs.recordUnmatchedPayout,
+        {
+          communityId: args.communityId,
+          stripePayoutId: args.stripePayoutId,
+          payoutCents: args.payoutCents,
+          leftoverCents,
+          matchedCount: plan.length,
+          chargeCount: composition.charges.length,
+          reversedCount: composition.reversedPaymentIntentIds.length,
+          unattributedReversalCents: composition.unattributedReversalCents,
+        },
+      );
+    }
+
     if (plan.length === 0) {
       return { allocated: 0, failed: 0 };
     }
@@ -550,6 +845,20 @@ export const runAllocation = internalAction({
       console.error(
         `[finance] runAllocation: community ${args.communityId} has no receiving Account — ${plan.length} matched item(s) stay pending`,
       );
+      // Audit each item (which also releases its lease) rather than leaving
+      // them claimed for the lease TTL over a condition no retry can fix.
+      for (const item of plan) {
+        await ctx.runMutation(
+          internal.functions.finance.jobs.recordAllocationFailure,
+          {
+            donationId: item.donationId,
+            fundId: item.fundId,
+            amountCents: item.amountCents,
+            reason: "community has no Increase receiving Account",
+            stage: "transfer" as const,
+          },
+        );
+      }
       return { allocated: 0, failed: plan.length };
     }
 
@@ -558,6 +867,95 @@ export const runAllocation = internalAction({
       items: plan,
       context: "runAllocation",
     });
+  },
+});
+
+/**
+ * Audits a payout whose allocation pass couldn't account for it: either it
+ * matched no donation at all, or a material slice of it went unattributed.
+ *
+ * This is the alarm for the one failure mode that has no automatic recovery
+ * (see `runAllocation`'s "OBSERVABILITY" note). Reachable in practice:
+ * Stripe attributes balance transactions to a payout asynchronously (hence
+ * `payout.reconciliation_completed`, which webhooks.ts also routes here);
+ * `?payout=` only ever lists AUTOMATIC payouts, so a community that switched
+ * to manual payouts in the Express dashboard gets an empty composition
+ * forever; and a refund with no resolvable PaymentIntent leaves the payout
+ * short by money nothing can be netted against.
+ */
+export const recordUnmatchedPayout = internalMutation({
+  args: {
+    communityId: v.id("communities"),
+    stripePayoutId: v.string(),
+    payoutCents: v.number(),
+    leftoverCents: v.number(),
+    matchedCount: v.number(),
+    chargeCount: v.number(),
+    reversedCount: v.number(),
+    unattributedReversalCents: v.number(),
+  },
+  handler: async (ctx, args) => {
+    await logFinanceAudit(ctx, {
+      communityId: args.communityId,
+      action: "allocation.payout_unmatched",
+      details: {
+        stripePayoutId: args.stripePayoutId,
+        payoutCents: args.payoutCents,
+        leftoverCents: args.leftoverCents,
+        matchedCount: args.matchedCount,
+        chargeCount: args.chargeCount,
+        reversedCount: args.reversedCount,
+        unattributedReversalCents: args.unattributedReversalCents,
+      },
+    });
+  },
+});
+
+/**
+ * `payout.failed` entry point: undo the bindings a `payout.paid` for the same
+ * payout already made.
+ *
+ * Stripe can follow `payout.paid` with `payout.failed` (the bank rejected
+ * it). The money never reached the receiving Account, so every donation this
+ * payout bound must be unbound — otherwise the hourly retry cron, which now
+ * genuinely resumes bound items, would keep trying to move money out of an
+ * Account that never received it. Unbinding puts them back where they were:
+ * `pending` and unbound, waiting for whichever payout does land.
+ *
+ * Donations already flipped to "allocated" are left alone — their transfer
+ * really did happen, and reversing a completed bank movement is a clawback,
+ * not a rollback. They surface as reconcile drift instead.
+ */
+export const unbindFailedPayout = internalMutation({
+  args: {
+    communityId: v.id("communities"),
+    stripePayoutId: v.string(),
+  },
+  handler: async (ctx, args): Promise<{ unbound: number }> => {
+    const pending = await ctx.db
+      .query("donations")
+      .withIndex("by_allocationStatus", (q) => q.eq("allocationStatus", "pending"))
+      .collect();
+
+    let unbound = 0;
+    for (const donation of pending) {
+      if (donation.allocationPayoutId !== args.stripePayoutId) continue;
+      const fund = await ctx.db.get(donation.fundId);
+      if (fund?.communityId !== args.communityId) continue;
+      await ctx.db.patch(donation._id, {
+        allocationPayoutId: undefined,
+        payoutNetCents: undefined,
+        allocationTransferStartedAt: undefined,
+      });
+      unbound += 1;
+    }
+
+    await logFinanceAudit(ctx, {
+      communityId: args.communityId,
+      action: "allocation.payout_failed",
+      details: { stripePayoutId: args.stripePayoutId, unboundCount: unbound },
+    });
+    return { unbound };
   },
 });
 
@@ -606,7 +1004,17 @@ export interface PendingAllocation {
  * same way as the rest of this file's mutations; it performs no writes.
  */
 export const computePendingAllocationCents = internalMutation({
-  args: { communityId: v.id("communities") },
+  args: {
+    communityId: v.id("communities"),
+    /**
+     * Only count donations created before this timestamp. Omitted by the
+     * nightly reconcile (which wants the whole pending term of the
+     * invariant); passed by the staleness alert, whose audit row is labelled
+     * "pending for > 3 days" and must therefore not report a community's
+     * entire pending sum including gifts that arrived this morning.
+     */
+    createdBeforeMs: v.optional(v.number()),
+  },
   handler: async (ctx, args): Promise<PendingAllocation[]> => {
     const funds = await ctx.db
       .query("funds")
@@ -621,7 +1029,10 @@ export const computePendingAllocationCents = internalMutation({
         .filter((q) => q.eq(q.field("allocationStatus"), "pending"))
         .collect();
       const pendingCents = pendingDonations.reduce(
-        (sum, donation) => sum + allocationAmountCents(donation),
+        (sum, donation) =>
+          args.createdBeforeMs !== undefined && donation.createdAt >= args.createdBeforeMs
+            ? sum
+            : sum + allocationAmountCents(donation),
         0,
       );
       results.push({ fundId: fund._id, pendingCents });
@@ -808,6 +1219,12 @@ const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
  * waiting on a normal Stripe payout cycle (T+2) anymore — something in the
  * primary allocation trigger (the payout webhook, routed by the webhook
  * agent) didn't fire or failed. This is the backstop, not the primary path.
+ *
+ * Scans every pending donation across every community, hourly. That is the
+ * `by_allocationStatus` index rather than the whole table, and pending is a
+ * *transient* state (a healthy donation leaves it within T+2), so the working
+ * set stays small. If a community ever accumulates a large stuck backlog this
+ * becomes the wrong shape and wants a (allocationStatus, createdAt) index.
  */
 export const getCommunitiesWithStalePendingDonations = internalQuery({
   args: { olderThanMs: v.number() },
@@ -867,9 +1284,14 @@ export const getCommunitiesWithStrandedAllocations = internalQuery({
  * on the row: the exact payout they belong to and the exact NET Stripe
  * delivered for them. Nothing is inferred, so replaying them is safe.
  *
+ * CLAIMS each item it returns, exactly like `planAllocations` does, and skips
+ * anything another pass is still holding. This is the racy one: the cron
+ * fires on a wall clock, so it will eventually land in the middle of a
+ * `runAllocation` triggered by a payout webhook. Without the lease both would
+ * issue the same `alloc:{donationId}` transfer concurrently.
+ *
  * Modeled as an internal mutation, like `computePendingAllocationCents`
- * above, so the retry action can call it with the same plumbing; it performs
- * no writes.
+ * above, so the retry action can call it with the same plumbing.
  */
 export const listResumableAllocations = internalMutation({
   args: { communityId: v.id("communities") },
@@ -879,6 +1301,7 @@ export const listResumableAllocations = internalMutation({
       .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
       .collect();
 
+    const nowMs = now();
     const rows: Array<{ item: AllocationPlanItem; createdAt: number }> = [];
     for (const fund of funds) {
       const pendingDonations = await ctx.db
@@ -892,6 +1315,8 @@ export const listResumableAllocations = internalMutation({
         if (netCents === undefined || !Number.isInteger(netCents) || netCents <= 0) {
           continue;
         }
+        if (allocationLeaseHeld(donation, nowMs)) continue;
+        await ctx.db.patch(donation._id, { allocationTransferStartedAt: nowMs });
         rows.push({
           createdAt: donation.createdAt,
           item: {
@@ -980,10 +1405,15 @@ export const retryStaleAllocations = internalAction({
       { olderThanMs: THREE_DAYS_MS },
     );
 
+    const staleCutoffMs = now() - THREE_DAYS_MS;
     for (const communityId of staleCommunityIds) {
+      // Scoped to the >3-day slice: the audit row this feeds is labelled
+      // "pending for > 3 days", and summing the community's ENTIRE pending
+      // balance into it (as this used to) reports this morning's gifts as
+      // stalled money.
       const pending = await ctx.runMutation(
         internal.functions.finance.jobs.computePendingAllocationCents,
-        { communityId },
+        { communityId, createdBeforeMs: staleCutoffMs },
       );
       const stalePendingCents = pending.reduce(
         (sum: number, p: PendingAllocation) => sum + p.pendingCents,

--- a/apps/convex/functions/finance/jobs.ts
+++ b/apps/convex/functions/finance/jobs.ts
@@ -56,7 +56,10 @@
  *
  * (`pendingAllocationCents` switches from gross to net the moment a donation
  * is bound to a payout — see `allocationAmountCents` — because from that
- * point on, net is all that will ever arrive.)
+ * point on, net is all that will ever arrive. Every selection path values a
+ * donation through that same helper, so what the planner asks Increase to
+ * transfer and what the nightly reconcile calls "pending" can never be
+ * different numbers.)
  *
  * REFUNDS AND DISPUTES — the fourth and fifth states, and the one place the
  * model is deliberately incomplete:
@@ -67,6 +70,9 @@
  *   refunded in part after a payout bound it (but before the transfer):
  *                                  ledger gross−refund, bank 0,
  *                                  pending min(net, gross−refund)     → ok
+ *   …and once that transfer lands : ledger gross−refund,
+ *                                  bank min(net, gross−refund),
+ *                                  pending 0                          → ok
  *   refunded after allocation    : ledger gross−fee−refund (+fee back
  *                                  once refunds exceed the net),
  *                                  bank NET, pending 0   → DRIFT = the money
@@ -91,12 +97,16 @@
  * credit rather than left as an overdraft (see `recordDonationRefund`).
  *
  * DISPUTES are the same shape and are known-drifting: `recordDonationDisputed`
- * is audit-only (no provisional debit, no fund-status change), so a disputed
- * gift's ledger credit stands until the nightly reconcile flags it. The money
- * path is nonetheless safe, because Stripe posts a chargeback as an
- * `adjustment` balance transaction, which `getPayoutComposition` nets against
- * the charge just like a refund — a disputed gift is not transferred out of
- * the receiving Account.
+ * is audit-only (no provisional debit, no `refundedCents`, no status change),
+ * so a disputed gift's ledger credit stands until the nightly reconcile flags
+ * it. The money path is safe ONLY when the chargeback settles in the same
+ * payout as the charge: Stripe posts it as an `adjustment` balance
+ * transaction, which `getPayoutComposition` nets against the charge just like
+ * a refund, so nothing is transferred. Disputes typically arrive weeks after
+ * the payout, by which point the gift is already allocated; and a dispute
+ * filed before the payout but settling in a LATER one funds the gift in full,
+ * because — unlike a refund — nothing about a dispute marks the donation.
+ * Both cases surface as reconcile drift, not as a blocked transfer.
  *
  * Every provider call (lib/finance/increase.ts, lib/finance/stripeConnect.ts)
  * is a lazy `await import(...)` inside an action body — never a top-level
@@ -222,6 +232,19 @@ export interface AllocationPlan {
   alreadyClaimed: boolean;
   /** Matched donations another in-flight pass currently holds the lease on. */
   leasedElsewhere: number;
+  /**
+   * Donations this payout ALREADY finished — bound to it and "allocated".
+   * A redelivery of a healthy payout produces an empty plan, which is the
+   * success condition and must not be mistaken for "matched nothing".
+   */
+  alreadyAllocated: number;
+  /**
+   * Donations the residual-budget check refused because funding them would
+   * have overrun the payout. Each one is a gift left stranded to cover money
+   * we could not account for, so the pass has to say so out loud rather than
+   * letting `leftoverCents` come out at 0 and look healthy.
+   */
+  overrunSkipped: number;
 }
 
 /**
@@ -254,13 +277,16 @@ export interface AllocationPlan {
  *
  * REFUNDED gifts never reach here: a fully refunded donation is
  * `allocationStatus: "refunded"` (giving.ts `recordDonationRefund`) and the
- * selection below only ever reads `"pending"` rows, while a refund that
+ * selection below only ever plans `"pending"` rows, while a refund that
  * settled inside this payout has already been netted out of `charges` by
- * `getPayoutComposition`.
+ * `getPayoutComposition`. A PARTIALLY refunded gift stays pending and is
+ * still fundable, but only for what is left of it — every selection path
+ * values it through `allocationAmountCents`.
  *
- * `leftoverCents` is the payout minus every net this pass took responsibility
- * for: charges we couldn't map to an actionable donation, plus anything held
- * by another pass.
+ * `leftoverCents` is the payout minus every net this pass accounted for:
+ * items it planned, plus items an earlier pass already allocated out of this
+ * same payout. What remains is charges we couldn't map to an actionable
+ * donation, plus anything held by another pass.
  */
 export const planAllocations = internalMutation({
   args: {
@@ -310,39 +336,59 @@ export const planAllocations = internalMutation({
       .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
       .collect();
 
-    const pending: Array<Doc<"donations"> & { fundType: "group" | "general" }> = [];
+    // Every donation in the community, not just the pending ones: a donation
+    // this payout has ALREADY allocated still accounts for its slice of the
+    // payout, and a pass that ignored it would report the whole payout as
+    // unmatched on every redelivery. (`.filter()` on a Convex query is a
+    // post-read filter, so reading them all costs the same.)
+    const candidates: Array<Doc<"donations"> & { fundType: "group" | "general" }> = [];
     for (const fund of funds) {
       const fundDonations = await ctx.db
         .query("donations")
         .withIndex("by_fund", (q) => q.eq("fundId", fund._id))
-        .filter((q) => q.eq(q.field("allocationStatus"), "pending"))
         .collect();
       for (const donation of fundDonations) {
-        pending.push({ ...donation, fundType: fund.type });
+        candidates.push({ ...donation, fundType: fund.type });
       }
     }
     // Deterministic order: oldest gift first, tie-broken by id so two runs
     // over the same data always plan the same sequence.
-    pending.sort((a, b) => a.createdAt - b.createdAt || a._id.localeCompare(b._id));
+    candidates.sort((a, b) => a.createdAt - b.createdAt || a._id.localeCompare(b._id));
 
     const nowMs = now();
     const plan: AllocationPlanItem[] = [];
     let usedCents = 0;
     let leasedElsewhere = 0;
-    for (const donation of pending) {
-      if (
-        donation.allocationPayoutId &&
-        donation.allocationPayoutId !== args.stripePayoutId
-      ) {
+    let alreadyAllocated = 0;
+    let overrunSkipped = 0;
+    for (const donation of candidates) {
+      const boundHere = donation.allocationPayoutId === args.stripePayoutId;
+
+      if (boundHere && donation.allocationStatus === "allocated") {
+        // Finished on an earlier pass. Its net is spoken for, so count it
+        // against the payout — otherwise a redelivered `payout.paid` (and
+        // this branch also routes `payout.reconciliation_completed`, which
+        // arrives after EVERY healthy payout) reports `leftoverCents` equal
+        // to the entire payout and raises a false unmatched alarm.
+        usedCents += donation.payoutNetCents ?? 0;
+        alreadyAllocated += 1;
+        continue;
+      }
+      if (donation.allocationStatus !== "pending") {
+        continue; // "refunded" is terminal; "n/a" pre-dates Increase.
+      }
+      if (donation.allocationPayoutId && !boundHere) {
         continue; // Belongs to another payout's pass.
       }
 
       let netCents: number;
-      if (donation.allocationPayoutId === args.stripePayoutId) {
+      if (boundHere) {
         // Resume: an earlier pass over this payout matched this donation but
         // its transfer never landed. Re-use the net already recorded rather
-        // than re-deriving it, so the retry moves the identical amount.
-        netCents = donation.payoutNetCents ?? 0;
+        // than re-deriving it, so the retry moves the identical amount —
+        // capped, via `allocationAmountCents`, at what is left of the gift
+        // after any refund that landed since the binding.
+        netCents = allocationAmountCents(donation);
         if (netCents <= 0) {
           console.error(
             `[finance] planAllocations: donation ${donation._id} is bound to payout ${args.stripePayoutId} with no usable net — skipping`,
@@ -354,17 +400,33 @@ export const planAllocations = internalMutation({
         if (matched === undefined) {
           continue; // Not one of this payout's charges — a later payout owns it.
         }
-        // Defensive only: the nets came out of this payout, so they sum to
-        // it by construction. `continue` (never `break`) so one oversized
-        // outlier can't wedge the queue behind it forever, which is exactly
-        // how the old gross matcher stalled.
-        if (usedCents + matched > args.payoutCents) {
+        // Cap Stripe's net at the unrefunded gross. A partial refund whose
+        // own balance transaction settles in a DIFFERENT payout leaves this
+        // payout carrying the charge at its full net, while the ledger has
+        // already taken the refund debit — transferring the full net would
+        // put money the donor got back into a group's spendable Account.
+        // Same helper the nightly pending sum uses, so the planner and the
+        // invariant can never disagree about what a gift is worth.
+        netCents = allocationAmountCents({ ...donation, payoutNetCents: matched });
+        if (netCents <= 0) {
           console.error(
-            `[finance] planAllocations: donation ${donation._id} (net ${matched}) would overrun payout ${args.stripePayoutId} (${args.payoutCents}, ${usedCents} used) — skipping it, not the rest`,
+            `[finance] planAllocations: donation ${donation._id} is in payout ${args.stripePayoutId} at net ${matched} but nothing is left of it after ${donation.refundedCents ?? 0} refunded — skipping`,
           );
           continue;
         }
-        netCents = matched;
+        // Defensive only: the nets came out of this payout, so they sum to
+        // it by construction. `continue` (never `break`) so one oversized
+        // outlier can't wedge the queue behind it forever, which is exactly
+        // how the old gross matcher stalled. Counted, though — skipping a
+        // gift here is a gift stranded, and it must not look like a healthy
+        // pass just because the arithmetic then comes out even.
+        if (usedCents + netCents > args.payoutCents) {
+          overrunSkipped += 1;
+          console.error(
+            `[finance] planAllocations: donation ${donation._id} (net ${netCents}) would overrun payout ${args.stripePayoutId} (${args.payoutCents}, ${usedCents} used) — skipping it, not the rest`,
+          );
+          continue;
+        }
       }
 
       // Take the lease in the same transaction that hands the item out. A
@@ -395,6 +457,8 @@ export const planAllocations = internalMutation({
       leftoverCents: args.payoutCents - usedCents,
       alreadyClaimed: existingClaim !== null,
       leasedElsewhere,
+      alreadyAllocated,
+      overrunSkipped,
     };
   },
 });
@@ -779,6 +843,7 @@ export const runAllocation = internalAction({
     const composition = await getPayoutComposition(
       communityFinance.stripeConnectedAccountId,
       args.stripePayoutId,
+      args.payoutCents,
     );
 
     if (composition.reversedPaymentIntentIds.length > 0) {
@@ -788,19 +853,59 @@ export const runAllocation = internalAction({
         `[finance] runAllocation: payout ${args.stripePayoutId} carried ${composition.reversedPaymentIntentIds.length} fully reversed charge(s) — nothing will be allocated for them`,
       );
     }
-    if (composition.unattributedReversalCents !== 0) {
+    if (composition.unattributedNetCents < 0) {
+      // REFUSE. The payout is short by money we cannot subtract from any
+      // gift, so the charge rows sum to more than actually arrived. Allocate
+      // anyway and the residual-budget check absorbs the shortfall by
+      // skipping whichever gift happens to sort last — a healthy donor's
+      // money stranded, silently, to cover a reversal we couldn't attribute.
+      // Nothing is written here, so a redelivery (or a manual re-run once
+      // someone has read the Stripe rows) can still allocate it properly.
+      //
+      // The trade-off is deliberate: this also refuses a payout carrying a
+      // small unattributable Stripe platform fee, which would otherwise have
+      // funded everyone but one. Blocking a payout is recoverable by hand;
+      // stranding a gift silently is not noticed at all.
       console.error(
-        `[finance] runAllocation: payout ${args.stripePayoutId} carries ${composition.unattributedReversalCents} cents of reversals with no resolvable PaymentIntent — the payout is short by money that cannot be netted against any donation`,
+        `[finance] runAllocation: payout ${args.stripePayoutId} carries ${composition.unattributedNetCents} cents we cannot attribute to any PaymentIntent — the payout is short by money that cannot be netted against a donation, so NOTHING will be allocated`,
+      );
+      await ctx.runMutation(
+        internal.functions.finance.jobs.recordUnmatchedPayout,
+        {
+          communityId: args.communityId,
+          stripePayoutId: args.stripePayoutId,
+          payoutCents: args.payoutCents,
+          leftoverCents: args.payoutCents,
+          matchedCount: 0,
+          chargeCount: composition.charges.length,
+          reversedCount: composition.reversedPaymentIntentIds.length,
+          unattributedNetCents: composition.unattributedNetCents,
+          refused: true,
+        },
+      );
+      return { allocated: 0, failed: 0 };
+    }
+    if (composition.unattributedNetCents > 0) {
+      // Harmless direction: money arrived that we can't credit to a donor. It
+      // stays in the receiving Account and shows up as `leftoverCents`.
+      console.log(
+        `[finance] runAllocation: payout ${args.stripePayoutId} carries ${composition.unattributedNetCents} cents with no resolvable PaymentIntent — nothing will be allocated for it`,
       );
     }
 
-    const { plan, alreadyClaimed, leftoverCents, leasedElsewhere } =
-      await ctx.runMutation(internal.functions.finance.jobs.planAllocations, {
-        communityId: args.communityId,
-        payoutCents: args.payoutCents,
-        stripePayoutId: args.stripePayoutId,
-        charges: composition.charges,
-      });
+    const {
+      plan,
+      alreadyClaimed,
+      leftoverCents,
+      leasedElsewhere,
+      alreadyAllocated,
+      overrunSkipped,
+    } = await ctx.runMutation(internal.functions.finance.jobs.planAllocations, {
+      communityId: args.communityId,
+      payoutCents: args.payoutCents,
+      stripePayoutId: args.stripePayoutId,
+      charges: composition.charges,
+    });
 
     if (alreadyClaimed) {
       console.log(
@@ -818,9 +923,17 @@ export const runAllocation = internalAction({
       leasedElsewhere === 0 &&
       unmatchedPayoutIsAlarming(leftoverCents, args.payoutCents);
 
-    if (plan.length === 0 || unmatchedIsAlarming) {
+    // An empty plan is only a problem when the payout got nothing DONE — not
+    // when there is nothing left to do. A redelivered `payout.paid`, and the
+    // `payout.reconciliation_completed` that follows every healthy payout,
+    // both land here with `plan.length === 0` and every gift already
+    // allocated. Alarming on those made the alarm fire on every payout,
+    // forever, which is worse than not having one.
+    const matchedNothing = plan.length === 0 && alreadyAllocated === 0;
+
+    if (matchedNothing || unmatchedIsAlarming || overrunSkipped > 0) {
       console.error(
-        `[finance] runAllocation: payout ${args.stripePayoutId} (${args.payoutCents} cents) matched ${plan.length} donation(s) from ${composition.charges.length} charge(s), leaving ${leftoverCents} cents unattributed`,
+        `[finance] runAllocation: payout ${args.stripePayoutId} (${args.payoutCents} cents) matched ${plan.length} donation(s) from ${composition.charges.length} charge(s) (${alreadyAllocated} already allocated, ${overrunSkipped} skipped as overrunning), leaving ${leftoverCents} cents unattributed`,
       );
       await ctx.runMutation(
         internal.functions.finance.jobs.recordUnmatchedPayout,
@@ -832,7 +945,9 @@ export const runAllocation = internalAction({
           matchedCount: plan.length,
           chargeCount: composition.charges.length,
           reversedCount: composition.reversedPaymentIntentIds.length,
-          unattributedReversalCents: composition.unattributedReversalCents,
+          unattributedNetCents: composition.unattributedNetCents,
+          alreadyAllocatedCount: alreadyAllocated,
+          overrunSkippedCount: overrunSkipped,
         },
       );
     }
@@ -871,17 +986,21 @@ export const runAllocation = internalAction({
 });
 
 /**
- * Audits a payout whose allocation pass couldn't account for it: either it
- * matched no donation at all, or a material slice of it went unattributed.
+ * Audits a payout whose allocation pass couldn't account for it: it matched
+ * no donation at all, a material slice of it went unattributed, a gift was
+ * skipped for overrunning the payout, or the pass refused it outright.
  *
  * This is the alarm for the one failure mode that has no automatic recovery
  * (see `runAllocation`'s "OBSERVABILITY" note). Reachable in practice:
- * Stripe attributes balance transactions to a payout asynchronously (hence
- * `payout.reconciliation_completed`, which webhooks.ts also routes here);
  * `?payout=` only ever lists AUTOMATIC payouts, so a community that switched
  * to manual payouts in the Express dashboard gets an empty composition
- * forever; and a refund with no resolvable PaymentIntent leaves the payout
+ * forever; and a reversal with no resolvable PaymentIntent leaves the payout
  * short by money nothing can be netted against.
+ *
+ * It deliberately does NOT fire for a payout that simply has nothing left to
+ * do. Stripe attributes balance transactions asynchronously, so webhooks.ts
+ * routes `payout.reconciliation_completed` here after every healthy
+ * `payout.paid` — an empty plan on that second pass is success, not silence.
  */
 export const recordUnmatchedPayout = internalMutation({
   args: {
@@ -892,7 +1011,11 @@ export const recordUnmatchedPayout = internalMutation({
     matchedCount: v.number(),
     chargeCount: v.number(),
     reversedCount: v.number(),
-    unattributedReversalCents: v.number(),
+    unattributedNetCents: v.number(),
+    /** Set when the pass declined to allocate anything at all. */
+    refused: v.optional(v.boolean()),
+    alreadyAllocatedCount: v.optional(v.number()),
+    overrunSkippedCount: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     await logFinanceAudit(ctx, {
@@ -905,7 +1028,10 @@ export const recordUnmatchedPayout = internalMutation({
         matchedCount: args.matchedCount,
         chargeCount: args.chargeCount,
         reversedCount: args.reversedCount,
-        unattributedReversalCents: args.unattributedReversalCents,
+        unattributedNetCents: args.unattributedNetCents,
+        refused: args.refused ?? false,
+        alreadyAllocatedCount: args.alreadyAllocatedCount,
+        overrunSkippedCount: args.overrunSkippedCount,
       },
     });
   },
@@ -925,6 +1051,14 @@ export const recordUnmatchedPayout = internalMutation({
  * Donations already flipped to "allocated" are left alone — their transfer
  * really did happen, and reversing a completed bank movement is a clawback,
  * not a rollback. They surface as reconcile drift instead.
+ *
+ * So are donations whose transfer LEASE is still live. `payout.failed` can
+ * arrive while a `runAllocation` pass is mid-flight, and clearing
+ * `payoutNetCents` out from under it means the `recordAllocation` that
+ * follows flips the gift to "allocated" with no net and therefore posts no
+ * `fee` entry — drift of exactly the fee, on a gift whose money we just said
+ * never arrived. Leaving the lease alone lets that pass finish or fail on its
+ * own terms; the next hourly tick unbinds it once the lease expires.
  */
 export const unbindFailedPayout = internalMutation({
   args: {
@@ -937,11 +1071,20 @@ export const unbindFailedPayout = internalMutation({
       .withIndex("by_allocationStatus", (q) => q.eq("allocationStatus", "pending"))
       .collect();
 
+    const nowMs = now();
     let unbound = 0;
+    let leaseHeld = 0;
     for (const donation of pending) {
       if (donation.allocationPayoutId !== args.stripePayoutId) continue;
       const fund = await ctx.db.get(donation.fundId);
       if (fund?.communityId !== args.communityId) continue;
+      if (allocationLeaseHeld(donation, nowMs)) {
+        leaseHeld += 1;
+        console.error(
+          `[finance] unbindFailedPayout: donation ${donation._id} is bound to failed payout ${args.stripePayoutId} but a transfer pass still holds its lease — leaving it bound`,
+        );
+        continue;
+      }
       await ctx.db.patch(donation._id, {
         allocationPayoutId: undefined,
         payoutNetCents: undefined,
@@ -953,7 +1096,11 @@ export const unbindFailedPayout = internalMutation({
     await logFinanceAudit(ctx, {
       communityId: args.communityId,
       action: "allocation.payout_failed",
-      details: { stripePayoutId: args.stripePayoutId, unboundCount: unbound },
+      details: {
+        stripePayoutId: args.stripePayoutId,
+        unboundCount: unbound,
+        leaseHeldCount: leaseHeld,
+      },
     });
     return { unbound };
   },
@@ -1311,12 +1458,23 @@ export const listResumableAllocations = internalMutation({
         .collect();
       for (const donation of pendingDonations) {
         if (!donation.allocationPayoutId) continue;
-        const netCents = donation.payoutNetCents;
-        if (netCents === undefined || !Number.isInteger(netCents) || netCents <= 0) {
+        if (donation.payoutNetCents === undefined) continue;
+        // Same cap the planner applies: a refund that landed after the
+        // binding has already reduced the ledger, so the stamped net can be
+        // more than the gift is now worth.
+        const netCents = allocationAmountCents(donation);
+        if (!Number.isInteger(netCents) || netCents <= 0) {
           continue;
         }
         if (allocationLeaseHeld(donation, nowMs)) continue;
-        await ctx.db.patch(donation._id, { allocationTransferStartedAt: nowMs });
+        await ctx.db.patch(donation._id, {
+          allocationTransferStartedAt: nowMs,
+          // Re-stamp: the cap can only have come DOWN since the binding (a
+          // refund landed), and `recordAllocation` derives the `fee` entry
+          // from this field. Leaving the stale net there would have it
+          // computing a fee against money we no longer transferred.
+          payoutNetCents: netCents,
+        });
         rows.push({
           createdAt: donation.createdAt,
           item: {

--- a/apps/convex/functions/finance/webhooks.ts
+++ b/apps/convex/functions/finance/webhooks.ts
@@ -673,7 +673,16 @@ export async function handleFinanceStripeEvent(
       return;
     }
 
-    case "payout.paid": {
+    // Both events mean "this payout's composition is readable now". Stripe
+    // attributes balance transactions to a payout ASYNCHRONOUSLY, which is
+    // exactly what `payout.reconciliation_completed` announces — a query at
+    // `payout.paid` alone can come back partial or empty, and an empty plan
+    // has no automatic recovery (see jobs.ts `runAllocation`). Running both
+    // is safe: allocation is idempotent per (payout, donation), so the second
+    // pass either finds nothing left to do or finishes the tail the first
+    // one couldn't see yet.
+    case "payout.paid":
+    case "payout.reconciliation_completed": {
       // Payouts fire on the CONNECTED account, so the payload has no
       // metadata of ours — resolve the community from event.account.
       if (!event.account) {
@@ -692,6 +701,33 @@ export async function handleFinanceStripeEvent(
         stripePayoutId: payout.id,
         payoutCents: payout.amount,
       });
+      return;
+    }
+
+    case "payout.failed": {
+      // Stripe can follow `payout.paid` with `payout.failed` when the bank
+      // rejects it. Anything the paid event bound to this payout has to be
+      // unbound, or the hourly retry cron — which resumes bound items
+      // unconditionally now — spends forever trying to move money out of a
+      // receiving Account that never received it.
+      if (!event.account) {
+        return;
+      }
+      const finance = await ctx.runQuery(
+        internal.functions.finance.webhooks.getCommunityFinanceByStripeAccount,
+        { stripeConnectedAccountId: event.account },
+      );
+      if (!finance) {
+        return;
+      }
+      const payout = event.data.object;
+      const { unbound } = await ctx.runMutation(
+        internal.functions.finance.jobs.unbindFailedPayout,
+        { communityId: finance.communityId, stripePayoutId: payout.id },
+      );
+      console.error(
+        `[finance] payout.failed: ${payout.id} for community ${finance.communityId} — unbound ${unbound} donation(s)`,
+      );
       return;
     }
 

--- a/apps/convex/lib/finance/ledger.ts
+++ b/apps/convex/lib/finance/ledger.ts
@@ -59,6 +59,11 @@ const FROZEN_ALLOWED_KINDS: ReadonlySet<LedgerKind> = new Set([
   // spend; it just loses the record (webhook retries expire against an
   // indefinitely-frozen archived fund). Same in-flight reasoning as refunds.
   "card_capture",
+  // The Stripe processing fee on a donation given before the freeze, realised
+  // when its allocation transfer lands after it (jobs.ts recordAllocation).
+  // Stripe already kept the money; refusing the entry would leave the frozen
+  // fund's ledger overstating its balance forever. Same in-flight reasoning.
+  "fee",
 ]);
 
 // ============================================================================

--- a/apps/convex/lib/finance/stripeConnect.ts
+++ b/apps/convex/lib/finance/stripeConnect.ts
@@ -174,13 +174,22 @@ export interface PayoutComposition {
    */
   reversedPaymentIntentIds: string[];
   /**
-   * Reversal cents in this payout we could not attribute to any
-   * PaymentIntent. Should always be 0 — a Refund's expanded `source` carries
-   * `payment_intent` — but a non-zero value means the payout is short by
-   * money we cannot subtract from anything, so the caller must alarm rather
-   * than allocate as if the shortfall didn't exist.
+   * Signed cents this payout carried on rows we could NOT tie to any
+   * PaymentIntent — Stripe's own `stripe_fee`, a Refund whose `source` came
+   * back unexpanded, an Issuing row, anything.
+   *
+   * The SIGN is the whole point, and only one direction is dangerous:
+   *
+   *  - **Positive** — money arrived that we can't credit to a donor. Nothing
+   *    over-transfers; it simply shows up as `leftoverCents` in the plan.
+   *  - **Negative** — the payout is SHORT by money we cannot subtract from
+   *    any gift. The charge rows then sum to more than the payout actually
+   *    delivered, so funding every one of them at its full net would move
+   *    more out of the receiving Account than went in. `runAllocation`
+   *    refuses the payout rather than letting the residual-budget check
+   *    absorb the shortfall by silently skipping whichever gift sorts last.
    */
-  unattributedReversalCents: number;
+  unattributedNetCents: number;
 }
 
 /** One page of `GET /v1/balance_transactions` is 100 rows; a payout with more
@@ -192,33 +201,30 @@ const BALANCE_TXN_PAGE_LIMIT = 100;
 const BALANCE_TXN_MAX_PAGES = 100;
 
 /**
+ * The payout's OWN leg. Listing balance transactions by payout returns the
+ * payout itself alongside its contents ("`payout`: The payout itself, which
+ * is also a transaction that moved funds from your Stripe account to your
+ * bank account" — Stripe, Payout reconciliation), at `net = -payout.amount`.
+ * Counting it would net the whole payout to zero, so it is excluded from
+ * every total below. The cancel/failure variants are the same leg in its
+ * other terminal states.
+ */
+const PAYOUT_LEG_TXN_TYPES: ReadonlySet<string> = new Set([
+  "payout",
+  "payout_cancel",
+  "payout_failure",
+]);
+
+/**
  * Balance-transaction types that represent donor money ARRIVING. "charge" is
  * a card payment; "payment" is the ACH-debit equivalent (ADR-032 §3 offers
  * ACH for large gifts).
+ *
+ * This is a SANITY set, not a filter: membership no longer decides whether a
+ * row counts (see `getPayoutComposition`), it only tells us that a negative
+ * `net` on such a row is nonsense worth logging.
  */
 const INBOUND_TXN_TYPES: ReadonlySet<string> = new Set(["charge", "payment"]);
-
-/**
- * Balance-transaction types that represent money for an EARLIER charge
- * moving back out (or, for the `*_failure` pair, a failed reversal coming
- * back in). Their `net` is already signed by Stripe, so they are summed
- * as-is against the charge's own net.
- *
- * These MUST NOT be discarded. A donation refunded before its payout settles
- * is still `allocationStatus: "pending"`, so dropping the refund row would
- * leave the surviving charge row looking like a fundable gift and transfer
- * money the donor already got back into a group's spendable Increase
- * Account. `adjustment` covers the dispute/chargeback case, whose source is
- * a Dispute — also `payment_intent`-bearing.
- */
-const REVERSAL_TXN_TYPES: ReadonlySet<string> = new Set([
-  "refund",
-  "payment_refund",
-  "refund_failure",
-  "payment_refund_failure",
-  "payment_failure_refund",
-  "adjustment",
-]);
 
 /**
  * Read what one Stripe payout was actually composed of, per PaymentIntent.
@@ -233,9 +239,37 @@ const REVERSAL_TXN_TYPES: ReadonlySet<string> = new Set([
  *
  * Charges and their reversals are NETTED per PaymentIntent rather than the
  * reversals being thrown away, because both directions are donor money and
- * only their sum is fundable. Pure bookkeeping rows (`stripe_fee`, `payout`,
- * `transfer`, …) are skipped — those are the difference between the payout
- * total and the sum of the nets.
+ * only their sum is fundable.
+ *
+ * MEMBERSHIP IS DECIDED BY `payment_intent`, NOT BY `type`. Any row whose
+ * expanded `source` resolves to a PaymentIntent is that gift's money moving,
+ * in whichever direction Stripe already signed `net`; everything else is
+ * bookkeeping we cannot attribute. This used to be an allowlist of reversal
+ * types, and an allowlist is the wrong shape here because every omission
+ * fails OPEN — it leaves the charge row looking like a fundable gift and
+ * over-transfers. The old list proved the point twice over: it contained
+ * `payment_refund_failure`, which is not a type Stripe emits at all, and
+ * omitted `payment_reversal`, which is ("Created when a debit/failure related
+ * to a payment is detected from a banking partner. This balance transaction
+ * takes funds that were previously credited to the merchant for a payment out
+ * of the merchant balance") — the post-credit bank reversal of an ACH
+ * `payment`, and ACH is live in this flow. Reading `payment_intent` instead
+ * handles that type, and every type Stripe adds after this comment was
+ * written, without anyone having to notice.
+ *
+ * TWO STRUCTURAL GUARDS make a miss loud instead of expensive:
+ *
+ *  1. Every row's `net` must add up. A payout IS the sum of the nets Stripe
+ *     attributed to it, so `Σ net (excluding the payout's own leg)` must
+ *     equal `payoutCents` exactly. It doesn't when the composition is
+ *     partial — Stripe attributes balance transactions asynchronously, which
+ *     is what `payout.reconciliation_completed` announces — or when paging
+ *     dropped something. Either way, allocating against a view that doesn't
+ *     add up is allocating against money that may not be there, so this
+ *     throws (like the page-cap guard below) and lets the redelivery retry.
+ *  2. Anything we could not attribute lands in `unattributedNetCents`, and
+ *     the negative direction is refused by the caller. So a reversal type we
+ *     somehow still can't map fails CLOSED.
  *
  * `expand: ["data.source"]` inflates each balance transaction's `source`
  * into the full Charge / Refund / Dispute, which is where `payment_intent`
@@ -254,12 +288,15 @@ const REVERSAL_TXN_TYPES: ReadonlySet<string> = new Set([
 export async function getPayoutComposition(
   connectedAccountId: string,
   payoutId: string,
+  /** `payout.amount`, in integer cents — the total guard #1 checks against. */
+  payoutCents: number,
 ): Promise<PayoutComposition> {
   const stripe = await getStripeClient();
   // Insertion-ordered so the emitted charge list is stable across runs, which
   // keeps a re-plan of the same payout deterministic.
   const netByPaymentIntent = new Map<string, number>();
-  let unattributedReversalCents = 0;
+  let unattributedNetCents = 0;
+  let totalNetCents = 0;
   let startingAfter: string | undefined;
   let pagedToEnd = false;
 
@@ -275,44 +312,40 @@ export async function getPayoutComposition(
     );
 
     for (const txn of result.data) {
-      const isInbound = INBOUND_TXN_TYPES.has(txn.type);
-      const isReversal = REVERSAL_TXN_TYPES.has(txn.type);
-      if (!isInbound && !isReversal) continue;
+      // The payout's own leg is the movement to the bank, not part of what
+      // the payout carried.
+      if (PAYOUT_LEG_TXN_TYPES.has(txn.type)) continue;
 
-      // Integer cents only — a fractional net would be a Stripe-side
-      // surprise, and allocating against it would move a wrong amount of
-      // real money. Skip loudly instead.
+      // Integer cents only. A fractional net means we cannot state what this
+      // payout was composed of, and guard #1 below would compare a float
+      // against an integer forever. Refuse the whole payout rather than
+      // dropping one row and allocating against the rest.
       if (!Number.isInteger(txn.net)) {
-        console.error(
-          `[finance] getPayoutComposition: balance transaction ${txn.id} has a non-integer net (${txn.net}) — skipping`,
+        throw new Error(
+          `getPayoutComposition: balance transaction ${txn.id} on payout ${payoutId} has a non-integer net (${txn.net}) — refusing to allocate against a composition we cannot state exactly`,
         );
-        continue;
-      }
-      if (txn.net === 0) continue;
-      // An inbound row must bring money in; a reversal must take it out (or,
-      // for a failed reversal, put it back). Either way, `net`'s own sign is
-      // what we sum — a wrong-signed row is nonsense we refuse to reason on.
-      if (isInbound && txn.net < 0) {
-        console.error(
-          `[finance] getPayoutComposition: ${txn.type} balance transaction ${txn.id} has a negative net (${txn.net}) — skipping`,
-        );
-        continue;
       }
 
+      totalNetCents += txn.net;
+      if (txn.net === 0) continue;
+
+      // Money in for a gift should never be negative. Logged, not skipped:
+      // dropping it would put guard #1 out of balance, and netting it signed
+      // is the safe reading anyway (it can only push that PaymentIntent's
+      // total DOWN, i.e. towards not being funded).
+      if (INBOUND_TXN_TYPES.has(txn.type) && txn.net < 0) {
+        console.error(
+          `[finance] getPayoutComposition: ${txn.type} balance transaction ${txn.id} has a negative net (${txn.net}) — netting it signed, which can only reduce what is allocated`,
+        );
+      }
+
+      // `payment_intent`, not `type`, decides whether this is donor money.
       const paymentIntentId = paymentIntentIdFromSource(txn.source);
       if (!paymentIntentId) {
-        if (isReversal) {
-          // Losing a reversal is the dangerous direction: the payout is short
-          // by this much and we would allocate as though it weren't.
-          unattributedReversalCents += txn.net;
-          console.error(
-            `[finance] getPayoutComposition: ${txn.type} balance transaction ${txn.id} on payout ${payoutId} (net ${txn.net}) has no resolvable payment_intent — it cannot be netted against any donation`,
-          );
-        } else {
-          console.error(
-            `[finance] getPayoutComposition: balance transaction ${txn.id} on payout ${payoutId} has no resolvable payment_intent — skipping`,
-          );
-        }
+        unattributedNetCents += txn.net;
+        console.error(
+          `[finance] getPayoutComposition: ${txn.type} balance transaction ${txn.id} on payout ${payoutId} (net ${txn.net}) has no resolvable payment_intent — it cannot be netted against any donation`,
+        );
         continue;
       }
 
@@ -343,6 +376,21 @@ export async function getPayoutComposition(
     );
   }
 
+  // GUARD #1. A payout is exactly the sum of the nets Stripe attributed to
+  // it. If our reading doesn't add up, we are looking at a composition that
+  // isn't the payout — most likely a partial one, because Stripe attributes
+  // balance transactions asynchronously (hence
+  // `payout.reconciliation_completed`). Throwing leaves the payout entirely
+  // unwritten, so the redelivery — or the reconciliation event — simply runs
+  // it again against the complete set. Note this guard alone does NOT catch a
+  // misclassified row: a reversal we failed to recognise is still inside the
+  // sum. Guard #2 (`unattributedNetCents`) is what covers that.
+  if (totalNetCents !== payoutCents) {
+    throw new Error(
+      `getPayoutComposition: payout ${payoutId} balance transactions net to ${totalNetCents} cents but the payout is ${payoutCents} — refusing to allocate against a composition that does not add up`,
+    );
+  }
+
   const charges: PayoutChargeNet[] = [];
   const reversedPaymentIntentIds: string[] = [];
   for (const [paymentIntentId, netCents] of netByPaymentIntent) {
@@ -356,7 +404,7 @@ export async function getPayoutComposition(
     }
   }
 
-  return { charges, reversedPaymentIntentIds, unattributedReversalCents };
+  return { charges, reversedPaymentIntentIds, unattributedNetCents };
 }
 
 /**

--- a/apps/convex/lib/finance/stripeConnect.ts
+++ b/apps/convex/lib/finance/stripeConnect.ts
@@ -136,6 +136,125 @@ export async function createAccountOnboardingLink(
   return link.url;
 }
 
+// ============================================================================
+// Payout composition — the NET amounts allocation matches against (ADR-032
+// Phase-2 requirement 6)
+// ============================================================================
+
+export interface PayoutChargeNet {
+  /**
+   * The PaymentIntent behind the charge. `donations` rows key on
+   * `stripePaymentIntentId`, so this is what maps a balance transaction back
+   * to a donation — the charge id itself is never stored on our side.
+   */
+  paymentIntentId: string;
+  /**
+   * Integer cents this charge contributed to the payout: Stripe's `net`
+   * (gross minus the processing fee), NOT the gross the donor was charged.
+   * A payout is the sum of its charges' nets, so this is the only basis on
+   * which an allocation can actually be funded.
+   */
+  netCents: number;
+}
+
+/** One page of `GET /v1/balance_transactions` is 100 rows; a payout with more
+ * charges than this is entirely normal for a busy community, so we page. The
+ * cap is a runaway guard, not an expected limit (100 pages = 10k charges in
+ * a single payout). */
+const BALANCE_TXN_PAGE_LIMIT = 100;
+const BALANCE_TXN_MAX_PAGES = 100;
+
+/**
+ * List the per-charge NET amounts that composed one Stripe payout.
+ *
+ * ADR-032's allocation job splits a bulk payout into per-group Increase
+ * Accounts. A payout is paid NET of Stripe's processing fees, so matching
+ * donations by their GROSS total can never fit (the gross always exceeds
+ * what arrived) — this is the balance-transaction lookup that ADR-032's
+ * Phase-2 requirement 6 names as the fix. It also removes the guesswork
+ * entirely: Stripe reports exactly WHICH charges the payout contained, so
+ * allocation no longer has to infer membership from a running total.
+ *
+ * `expand: ["data.source"]` inflates each balance transaction's `source`
+ * into the full Charge, which is where `payment_intent` lives — without it
+ * `source` is just a `ch_…` id we have no mapping for. Non-charge rows
+ * (`stripe_fee`, `payout`, `refund`, `adjustment`, …) are skipped: they are
+ * the difference between the payout total and the sum of the nets, i.e. the
+ * expected `leftoverCents` on the allocation plan.
+ *
+ * Runs against the CONNECTED account (`stripeAccount`), the same way
+ * donations are collected — the platform account has no view of a
+ * community's payouts.
+ */
+export async function listPayoutChargeNets(
+  connectedAccountId: string,
+  payoutId: string,
+): Promise<PayoutChargeNet[]> {
+  const stripe = await getStripeClient();
+  const nets: PayoutChargeNet[] = [];
+  let startingAfter: string | undefined;
+
+  for (let page = 0; page < BALANCE_TXN_MAX_PAGES; page++) {
+    const result = await stripe.balanceTransactions.list(
+      {
+        payout: payoutId,
+        limit: BALANCE_TXN_PAGE_LIMIT,
+        expand: ["data.source"],
+        ...(startingAfter ? { starting_after: startingAfter } : {}),
+      },
+      { stripeAccount: connectedAccountId },
+    );
+
+    for (const txn of result.data) {
+      // "charge" is a card payment; "payment" is the ACH-debit equivalent
+      // (ADR-032 §3 offers ACH for large gifts). Everything else is fee or
+      // reversal bookkeeping, not donor money arriving.
+      if (txn.type !== "charge" && txn.type !== "payment") continue;
+
+      const paymentIntentId = paymentIntentIdFromSource(txn.source);
+      if (!paymentIntentId) {
+        console.error(
+          `[finance] listPayoutChargeNets: balance transaction ${txn.id} on payout ${payoutId} has no resolvable payment_intent — skipping`,
+        );
+        continue;
+      }
+      // Integer cents only — a non-integer or non-positive net would be a
+      // Stripe-side surprise, and allocating against it would move a wrong
+      // amount of real money. Skip loudly instead.
+      if (!Number.isInteger(txn.net) || txn.net <= 0) {
+        console.error(
+          `[finance] listPayoutChargeNets: balance transaction ${txn.id} has a non-positive/non-integer net (${txn.net}) — skipping`,
+        );
+        continue;
+      }
+
+      nets.push({ paymentIntentId, netCents: txn.net });
+    }
+
+    if (!result.has_more) break;
+    startingAfter = result.data[result.data.length - 1]?.id;
+    if (!startingAfter) break;
+  }
+
+  return nets;
+}
+
+/**
+ * A balance transaction's `source` is `string | BalanceTransactionSource |
+ * null`; only the expanded Charge object carries `payment_intent`, which
+ * itself may be an id or (if something else expanded it) a full object.
+ */
+function paymentIntentIdFromSource(source: unknown): string | undefined {
+  if (!source || typeof source !== "object") return undefined;
+  const paymentIntent = (source as { payment_intent?: unknown }).payment_intent;
+  if (typeof paymentIntent === "string") return paymentIntent;
+  if (paymentIntent && typeof paymentIntent === "object") {
+    const id = (paymentIntent as { id?: unknown }).id;
+    return typeof id === "string" ? id : undefined;
+  }
+  return undefined;
+}
+
 /**
  * Set the community's Increase receiving Account as the connected account's
  * external payout destination, so Stripe's bulk payout (ADR-032 §3) lands

--- a/apps/convex/lib/finance/stripeConnect.ts
+++ b/apps/convex/lib/finance/stripeConnect.ts
@@ -149,23 +149,79 @@ export interface PayoutChargeNet {
    */
   paymentIntentId: string;
   /**
-   * Integer cents this charge contributed to the payout: Stripe's `net`
-   * (gross minus the processing fee), NOT the gross the donor was charged.
-   * A payout is the sum of its charges' nets, so this is the only basis on
-   * which an allocation can actually be funded.
+   * Integer cents this PaymentIntent contributed to the payout: Stripe's
+   * `net` (gross minus the processing fee) MINUS any refund/adjustment for
+   * the same PaymentIntent that settled in this same payout. NOT the gross
+   * the donor was charged. A payout is the sum of its rows' nets, so this is
+   * the only basis on which an allocation can actually be funded.
    */
   netCents: number;
 }
 
+export interface PayoutComposition {
+  /**
+   * One entry per PaymentIntent the payout carried, at the amount it
+   * actually contributed — netted across every row Stripe attributed to it.
+   * Only strictly positive totals appear; see `reversedPaymentIntentIds`.
+   */
+  charges: PayoutChargeNet[];
+  /**
+   * PaymentIntents present in this payout whose netted total came out <= 0 —
+   * the charge was refunded (or charged back) by at least as much as it
+   * brought in, so the payout delivered nothing for them and NOTHING may be
+   * allocated on their behalf. Reported rather than silently dropped so the
+   * caller can say why a donation went unmatched.
+   */
+  reversedPaymentIntentIds: string[];
+  /**
+   * Reversal cents in this payout we could not attribute to any
+   * PaymentIntent. Should always be 0 — a Refund's expanded `source` carries
+   * `payment_intent` — but a non-zero value means the payout is short by
+   * money we cannot subtract from anything, so the caller must alarm rather
+   * than allocate as if the shortfall didn't exist.
+   */
+  unattributedReversalCents: number;
+}
+
 /** One page of `GET /v1/balance_transactions` is 100 rows; a payout with more
  * charges than this is entirely normal for a busy community, so we page. The
- * cap is a runaway guard, not an expected limit (100 pages = 10k charges in
- * a single payout). */
+ * cap is a runaway guard, not an expected limit (100 pages = 10k rows in
+ * a single payout). Exhausting it while Stripe still reports `has_more`
+ * throws — see `getPayoutComposition`. */
 const BALANCE_TXN_PAGE_LIMIT = 100;
 const BALANCE_TXN_MAX_PAGES = 100;
 
 /**
- * List the per-charge NET amounts that composed one Stripe payout.
+ * Balance-transaction types that represent donor money ARRIVING. "charge" is
+ * a card payment; "payment" is the ACH-debit equivalent (ADR-032 §3 offers
+ * ACH for large gifts).
+ */
+const INBOUND_TXN_TYPES: ReadonlySet<string> = new Set(["charge", "payment"]);
+
+/**
+ * Balance-transaction types that represent money for an EARLIER charge
+ * moving back out (or, for the `*_failure` pair, a failed reversal coming
+ * back in). Their `net` is already signed by Stripe, so they are summed
+ * as-is against the charge's own net.
+ *
+ * These MUST NOT be discarded. A donation refunded before its payout settles
+ * is still `allocationStatus: "pending"`, so dropping the refund row would
+ * leave the surviving charge row looking like a fundable gift and transfer
+ * money the donor already got back into a group's spendable Increase
+ * Account. `adjustment` covers the dispute/chargeback case, whose source is
+ * a Dispute — also `payment_intent`-bearing.
+ */
+const REVERSAL_TXN_TYPES: ReadonlySet<string> = new Set([
+  "refund",
+  "payment_refund",
+  "refund_failure",
+  "payment_refund_failure",
+  "payment_failure_refund",
+  "adjustment",
+]);
+
+/**
+ * Read what one Stripe payout was actually composed of, per PaymentIntent.
  *
  * ADR-032's allocation job splits a bulk payout into per-group Increase
  * Accounts. A payout is paid NET of Stripe's processing fees, so matching
@@ -175,24 +231,37 @@ const BALANCE_TXN_MAX_PAGES = 100;
  * entirely: Stripe reports exactly WHICH charges the payout contained, so
  * allocation no longer has to infer membership from a running total.
  *
+ * Charges and their reversals are NETTED per PaymentIntent rather than the
+ * reversals being thrown away, because both directions are donor money and
+ * only their sum is fundable. Pure bookkeeping rows (`stripe_fee`, `payout`,
+ * `transfer`, …) are skipped — those are the difference between the payout
+ * total and the sum of the nets.
+ *
  * `expand: ["data.source"]` inflates each balance transaction's `source`
- * into the full Charge, which is where `payment_intent` lives — without it
- * `source` is just a `ch_…` id we have no mapping for. Non-charge rows
- * (`stripe_fee`, `payout`, `refund`, `adjustment`, …) are skipped: they are
- * the difference between the payout total and the sum of the nets, i.e. the
- * expected `leftoverCents` on the allocation plan.
+ * into the full Charge / Refund / Dispute, which is where `payment_intent`
+ * lives — without it `source` is just an id we have no mapping for.
  *
  * Runs against the CONNECTED account (`stripeAccount`), the same way
  * donations are collected — the platform account has no view of a
  * community's payouts.
+ *
+ * NOTE: `?payout=` filters to AUTOMATIC payouts only. A community that
+ * switches to manual payouts in its Stripe Express dashboard gets an empty
+ * list here forever — that is the payout-destination-drift risk ADR-032
+ * Phase-2 requirement 4 tracks, and `runAllocation` alarms on the empty plan
+ * it produces rather than stalling silently.
  */
-export async function listPayoutChargeNets(
+export async function getPayoutComposition(
   connectedAccountId: string,
   payoutId: string,
-): Promise<PayoutChargeNet[]> {
+): Promise<PayoutComposition> {
   const stripe = await getStripeClient();
-  const nets: PayoutChargeNet[] = [];
+  // Insertion-ordered so the emitted charge list is stable across runs, which
+  // keeps a re-plan of the same payout deterministic.
+  const netByPaymentIntent = new Map<string, number>();
+  let unattributedReversalCents = 0;
   let startingAfter: string | undefined;
+  let pagedToEnd = false;
 
   for (let page = 0; page < BALANCE_TXN_MAX_PAGES; page++) {
     const result = await stripe.balanceTransactions.list(
@@ -206,43 +275,95 @@ export async function listPayoutChargeNets(
     );
 
     for (const txn of result.data) {
-      // "charge" is a card payment; "payment" is the ACH-debit equivalent
-      // (ADR-032 §3 offers ACH for large gifts). Everything else is fee or
-      // reversal bookkeeping, not donor money arriving.
-      if (txn.type !== "charge" && txn.type !== "payment") continue;
+      const isInbound = INBOUND_TXN_TYPES.has(txn.type);
+      const isReversal = REVERSAL_TXN_TYPES.has(txn.type);
+      if (!isInbound && !isReversal) continue;
+
+      // Integer cents only — a fractional net would be a Stripe-side
+      // surprise, and allocating against it would move a wrong amount of
+      // real money. Skip loudly instead.
+      if (!Number.isInteger(txn.net)) {
+        console.error(
+          `[finance] getPayoutComposition: balance transaction ${txn.id} has a non-integer net (${txn.net}) — skipping`,
+        );
+        continue;
+      }
+      if (txn.net === 0) continue;
+      // An inbound row must bring money in; a reversal must take it out (or,
+      // for a failed reversal, put it back). Either way, `net`'s own sign is
+      // what we sum — a wrong-signed row is nonsense we refuse to reason on.
+      if (isInbound && txn.net < 0) {
+        console.error(
+          `[finance] getPayoutComposition: ${txn.type} balance transaction ${txn.id} has a negative net (${txn.net}) — skipping`,
+        );
+        continue;
+      }
 
       const paymentIntentId = paymentIntentIdFromSource(txn.source);
       if (!paymentIntentId) {
-        console.error(
-          `[finance] listPayoutChargeNets: balance transaction ${txn.id} on payout ${payoutId} has no resolvable payment_intent — skipping`,
-        );
-        continue;
-      }
-      // Integer cents only — a non-integer or non-positive net would be a
-      // Stripe-side surprise, and allocating against it would move a wrong
-      // amount of real money. Skip loudly instead.
-      if (!Number.isInteger(txn.net) || txn.net <= 0) {
-        console.error(
-          `[finance] listPayoutChargeNets: balance transaction ${txn.id} has a non-positive/non-integer net (${txn.net}) — skipping`,
-        );
+        if (isReversal) {
+          // Losing a reversal is the dangerous direction: the payout is short
+          // by this much and we would allocate as though it weren't.
+          unattributedReversalCents += txn.net;
+          console.error(
+            `[finance] getPayoutComposition: ${txn.type} balance transaction ${txn.id} on payout ${payoutId} (net ${txn.net}) has no resolvable payment_intent — it cannot be netted against any donation`,
+          );
+        } else {
+          console.error(
+            `[finance] getPayoutComposition: balance transaction ${txn.id} on payout ${payoutId} has no resolvable payment_intent — skipping`,
+          );
+        }
         continue;
       }
 
-      nets.push({ paymentIntentId, netCents: txn.net });
+      netByPaymentIntent.set(
+        paymentIntentId,
+        (netByPaymentIntent.get(paymentIntentId) ?? 0) + txn.net,
+      );
     }
 
-    if (!result.has_more) break;
+    if (!result.has_more) {
+      pagedToEnd = true;
+      break;
+    }
     startingAfter = result.data[result.data.length - 1]?.id;
-    if (!startingAfter) break;
+    if (!startingAfter) {
+      pagedToEnd = true;
+      break;
+    }
   }
 
-  return nets;
+  if (!pagedToEnd) {
+    // Returning the prefix would look like a complete payout composition and
+    // silently allocate against a partial view — and every retry would read
+    // the same first 100 pages, so the tail could never bind. Fail loudly
+    // instead; nothing has been written at this point in the pass.
+    throw new Error(
+      `getPayoutComposition: payout ${payoutId} has more than ${BALANCE_TXN_MAX_PAGES * BALANCE_TXN_PAGE_LIMIT} balance transactions — refusing to allocate on a truncated view`,
+    );
+  }
+
+  const charges: PayoutChargeNet[] = [];
+  const reversedPaymentIntentIds: string[] = [];
+  for (const [paymentIntentId, netCents] of netByPaymentIntent) {
+    if (netCents > 0) {
+      charges.push({ paymentIntentId, netCents });
+    } else {
+      // Fully refunded/reversed inside this payout. It delivered nothing, so
+      // there is nothing to allocate — and its donation may well still be
+      // "pending" if the refund webhook has not been processed yet.
+      reversedPaymentIntentIds.push(paymentIntentId);
+    }
+  }
+
+  return { charges, reversedPaymentIntentIds, unattributedReversalCents };
 }
 
 /**
  * A balance transaction's `source` is `string | BalanceTransactionSource |
- * null`; only the expanded Charge object carries `payment_intent`, which
- * itself may be an id or (if something else expanded it) a full object.
+ * null`; only the expanded Charge / Refund / Dispute object carries
+ * `payment_intent`, which itself may be an id or (if something else expanded
+ * it) a full object.
  */
 function paymentIntentIdFromSource(source: unknown): string | undefined {
   if (!source || typeof source !== "object") return undefined;

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -3901,6 +3901,22 @@ export default defineSchema({
     ),
     recurringId: v.optional(v.string()), // Stripe subscription/recurring-donation id, if recurring
     receiptEmailStatus: v.string(), // "pending" | "sent" | "failed" — Resend receipt from the church's name/EIN
+    // The Stripe payout this donation was matched into by planAllocations
+    // (functions/finance/jobs.ts). Stamped once, at plan time, and never
+    // re-stamped — it is what makes allocation replay-safe per DONATION
+    // rather than per payout: a redelivered `payout.paid` re-processes only
+    // the donations already bound to that payout id and still "pending".
+    // Optional/backfill-safe: donations recorded before net matching shipped
+    // (and any donation not yet paid out) simply have neither field.
+    allocationPayoutId: v.optional(v.string()),
+    // Integer cents this donation actually contributed to that payout — the
+    // Stripe balance-transaction NET (gross minus Stripe's processing fee),
+    // which is what the bulk payout physically delivered and therefore the
+    // only amount we can transfer on to the group's Increase Account. The
+    // gross (amountCents + feeCoverCents) is what the ledger credited at
+    // donation time; the difference is posted as a "fee" debit once the
+    // allocation transfer lands (see jobs.ts recordAllocation).
+    payoutNetCents: v.optional(v.number()),
     createdAt: v.number(), // Unix timestamp ms
   })
     .index("by_fund", ["fundId"])
@@ -3992,13 +4008,19 @@ export default defineSchema({
 
   /**
    * One row per Stripe payout that has had an allocation pass run against
-   * it. Payout-LEVEL replay protection: a redelivered `payout.paid` webhook
-   * must not run a second allocation pass, because the first pass already
-   * marked its donations "allocated" — a second planAllocations would grab
-   * the NEXT pending donations and move money that payout never contained
-   * (Codex review, PR #653). Per-donation idempotency keys can't catch that;
-   * this table does. Insert-if-absent via claimPayout (functions/finance/
-   * jobs.ts) is transactional under Convex OCC.
+   * it — a record of when the payout was first seen, plus the payout amount
+   * we matched against.
+   *
+   * This used to be the ONLY replay protection: a redelivered `payout.paid`
+   * was dropped outright, because the old gross-total matcher would have
+   * grabbed the NEXT pending donations on a re-plan and moved money the
+   * payout never contained (Codex review, PR #653). That also meant a
+   * partially-failed pass could never be retried. Replay protection now
+   * lives on the donation rows themselves (`donations.allocationPayoutId` —
+   * matched by Stripe payment-intent id out of the payout's own balance
+   * transactions, so a re-plan can only ever re-select the SAME donations),
+   * which makes a redelivery a safe resume of the unfinished items. This row
+   * remains as the audit/bookkeeping record of the pass.
    */
   processedStripePayouts: defineTable({
     communityId: v.id("communities"),

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -3920,10 +3920,15 @@ export default defineSchema({
     // Optional/backfill-safe: donations recorded before net matching shipped
     // (and any donation not yet paid out) simply have neither field.
     allocationPayoutId: v.optional(v.string()),
-    // Integer cents this donation actually contributed to that payout — the
-    // Stripe balance-transaction NET (gross minus Stripe's processing fee),
-    // which is what the bulk payout physically delivered and therefore the
-    // only amount we can transfer on to the group's Increase Account. The
+    // Integer cents allocation will move for this donation out of that
+    // payout: the Stripe balance-transaction NET (gross minus Stripe's
+    // processing fee) — what the bulk payout physically delivered, and
+    // therefore the ceiling on what we can transfer on to the group's
+    // Increase Account — CAPPED at the unrefunded gross. The cap matters when
+    // a partial refund's own balance transaction settles in a different
+    // payout: the charge still appears here at its full net while the ledger
+    // has already taken the refund debit, and transferring the full net would
+    // move money the donor got back (jobs.ts `allocationAmountCents`). The
     // gross (amountCents + feeCoverCents) is what the ledger credited at
     // donation time; the difference is posted as a "fee" debit once the
     // allocation transfer lands (see jobs.ts recordAllocation).

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -3887,6 +3887,10 @@ export default defineSchema({
    * Stripe-bulk-payout -> Increase-AccountTransfer allocation job (ADR-032
    * §3); "n/a" covers donations made before Increase went live for the
    * community, which never need allocating out of a receiving Account.
+   * "refunded" is terminal and means the donor got the whole gift back, so
+   * nothing will ever be allocated for it — every allocation query selects on
+   * `allocationStatus === "pending"`, so this one flag is what keeps a
+   * refunded gift out of the planner, the retry cron, AND the pending sum.
    */
   donations: defineTable({
     fundId: v.id("funds"),
@@ -3897,8 +3901,15 @@ export default defineSchema({
     allocationStatus: v.union(
       v.literal("pending"),
       v.literal("allocated"),
+      v.literal("refunded"),
       v.literal("n/a"),
     ),
+    // Stripe's CUMULATIVE `amount_refunded` for this donation's charge, as of
+    // the last `charge.refunded` we processed (giving.ts
+    // recordDonationRefund). Absent means never refunded. Allocation reads it
+    // so a partially-refunded gift is only ever transferred/counted at what
+    // is actually left of it.
+    refundedCents: v.optional(v.number()),
     recurringId: v.optional(v.string()), // Stripe subscription/recurring-donation id, if recurring
     receiptEmailStatus: v.string(), // "pending" | "sent" | "failed" — Resend receipt from the church's name/EIN
     // The Stripe payout this donation was matched into by planAllocations
@@ -3917,6 +3928,15 @@ export default defineSchema({
     // donation time; the difference is posted as a "fee" debit once the
     // allocation transfer lands (see jobs.ts recordAllocation).
     payoutNetCents: v.optional(v.number()),
+    // LEASE, not a marker: set in the same transaction that selects this
+    // donation for a transfer, and cleared when that transfer resolves either
+    // way. A second pass (a redelivered `payout.paid`, or the hourly retry
+    // cron racing an in-flight `runAllocation`) skips a donation whose lease
+    // is still live, so two passes can never both issue the same
+    // `alloc:{donationId}` transfer concurrently. Stale leases expire after
+    // ALLOCATION_LEASE_TTL_MS (jobs.ts) so a crashed pass can't strand an
+    // item forever.
+    allocationTransferStartedAt: v.optional(v.number()),
     createdAt: v.number(), // Unix timestamp ms
   })
     .index("by_fund", ["fundId"])
@@ -4020,7 +4040,9 @@ export default defineSchema({
    * matched by Stripe payment-intent id out of the payout's own balance
    * transactions, so a re-plan can only ever re-select the SAME donations),
    * which makes a redelivery a safe resume of the unfinished items. This row
-   * remains as the audit/bookkeeping record of the pass.
+   * remains as the audit/bookkeeping record of the FIRST pass over a payout
+   * (`payoutCents` is never re-written by a later pass — the per-pass detail
+   * lives in `financeAuditEvents` instead).
    */
   processedStripePayouts: defineTable({
     communityId: v.id("communities"),

--- a/apps/mobile/features/finance/leader/GivingHubScreen.tsx
+++ b/apps/mobile/features/finance/leader/GivingHubScreen.tsx
@@ -95,6 +95,7 @@ export function GivingHubScreen() {
       monthDonationsCents: overview.monthToDate.donationsCents,
       monthDonationCount: overview.monthToDate.donationCount,
       monthSpentCents: overview.monthToDate.spentCents,
+      monthFeesCents: overview.monthToDate.feesCents ?? 0,
     };
   }, [overview]);
 

--- a/apps/mobile/features/finance/leader/GivingHubView.tsx
+++ b/apps/mobile/features/finance/leader/GivingHubView.tsx
@@ -191,7 +191,17 @@ export function GivingHubView({
               value={formatCents(balance.monthDonationsCents)}
               sub={`${balance.monthDonationCount} ${balance.monthDonationCount === 1 ? "gift" : "gifts"}`}
             />
-            <StatTile label="SPENT THIS MONTH" value={formatCents(balance.monthSpentCents)} />
+            <StatTile
+              label="SPENT THIS MONTH"
+              value={formatCents(balance.monthSpentCents)}
+              // Processing fees aren't spend, but hiding them makes "given"
+              // minus "spent" fail to reconcile against the balance above.
+              sub={
+                balance.monthFeesCents > 0
+                  ? `+ ${formatCents(balance.monthFeesCents)} fees`
+                  : undefined
+              }
+            />
             <StatTile
               label="PENDING"
               value={formatCents(pendingTotalCents)}

--- a/apps/mobile/features/finance/leader/__tests__/GivingHubView.test.tsx
+++ b/apps/mobile/features/finance/leader/__tests__/GivingHubView.test.tsx
@@ -48,6 +48,7 @@ const balance: GivingHubBalanceSummary = {
   monthDonationsCents: 64000,
   monthDonationCount: 12,
   monthSpentCents: 21238,
+  monthFeesCents: 1886,
 };
 
 const baseProps = {
@@ -89,6 +90,25 @@ describe("GivingHubView", () => {
       expect(screen.getByText("$1,284.50")).toBeTruthy();
       expect(screen.getByText("Giving is live")).toBeTruthy();
       expect(screen.getByText("$640.00")).toBeTruthy();
+    });
+
+    it("shows Stripe fees beside 'spent' rather than folded into it", () => {
+      render(<GivingHubView {...baseProps} />);
+
+      // Spend is the group's own outgoings only ($212.38). The processing
+      // fees Stripe kept ($18.86) get their own line — a fee bucketed into
+      // "spent" reports spending on a group that spent nothing, and a fee
+      // shown nowhere leaves "given" minus "spent" not reconciling.
+      expect(screen.getByText("$212.38")).toBeTruthy();
+      expect(screen.getByText("+ $18.86 fees")).toBeTruthy();
+    });
+
+    it("omits the fees line entirely when there are none", () => {
+      render(
+        <GivingHubView {...baseProps} balance={{ ...balance, monthFeesCents: 0 }} />,
+      );
+
+      expect(screen.queryByText(/fees/)).toBeNull();
     });
 
     it("hides the 'Giving is live' chip when givingLive is false", () => {

--- a/apps/mobile/features/finance/leader/types.ts
+++ b/apps/mobile/features/finance/leader/types.ts
@@ -161,6 +161,12 @@ export interface GivingHubBalanceSummary {
   monthDonationsCents: number;
   monthDonationCount: number;
   monthSpentCents: number;
+  /**
+   * Stripe's processing fees this month. Kept OUT of `monthSpentCents` — the
+   * group didn't spend them — but shown, because a fee nobody can see is a
+   * gap between "given" and "balance" that leaders can't explain.
+   */
+  monthFeesCents: number;
 }
 
 /** A single "Recent activity" row — mirrors `getFundOverview`'s `activity` entries. */

--- a/apps/mobile/features/finance/member/FundScreenView.tsx
+++ b/apps/mobile/features/finance/member/FundScreenView.tsx
@@ -120,6 +120,11 @@ export function FundScreenView({
                 {overview.monthToDate.donationCount}{" "}
                 {overview.monthToDate.donationCount === 1 ? "gift" : "gifts"}
               </Text>
+              {overview.monthToDate.feesCents > 0 && (
+                <Text style={[styles.statSubvalue, { color: colors.textSecondary }]}>
+                  {formatCents(overview.monthToDate.feesCents)} card fees
+                </Text>
+              )}
             </View>
             <View style={[styles.statCard, { backgroundColor: colors.surfaceSecondary }]}>
               <Text style={[styles.statHeader, { color: colors.textSecondary }]}>
@@ -133,6 +138,11 @@ export function FundScreenView({
                 {overview.yearToDate.donationCount}{" "}
                 {overview.yearToDate.donationCount === 1 ? "gift" : "gifts"}
               </Text>
+              {overview.yearToDate.feesCents > 0 && (
+                <Text style={[styles.statSubvalue, { color: colors.textSecondary }]}>
+                  {formatCents(overview.yearToDate.feesCents)} card fees
+                </Text>
+              )}
             </View>
           </View>
 

--- a/apps/mobile/features/finance/member/__tests__/FundScreenView.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/FundScreenView.test.tsx
@@ -54,8 +54,20 @@ jest.mock("@components/ui", () => {
 const baseOverview: FundOverview = {
   fund: { id: "fund1", name: "Small Group Fund", status: "active" },
   balanceCents: 123456,
-  monthToDate: { donationsCents: 5000, spentCents: 2000, donationCount: 2 },
-  yearToDate: { donationsCents: 50000, spentCents: 20000, donationCount: 12 },
+  monthToDate: {
+    donationsCents: 5000,
+    spentCents: 2000,
+    feesCents: 175,
+    refundedCents: 0,
+    donationCount: 2,
+  },
+  yearToDate: {
+    donationsCents: 50000,
+    spentCents: 20000,
+    feesCents: 1810,
+    refundedCents: 0,
+    donationCount: 12,
+  },
   activity: [
     {
       id: "e1",
@@ -129,6 +141,42 @@ describe("FundScreenView", () => {
       />,
     );
     expect(screen.getByText(formatCents(123456))).toBeTruthy();
+  });
+
+  it("shows card fees on their own line instead of inflating 'spent'", () => {
+    render(
+      <FundScreenView
+        overview={baseOverview}
+        myExpenses={baseExpenses}
+        onBack={noop}
+        onGivePress={noop}
+        onGetReimbursedPress={noop}
+      />,
+    );
+
+    // MTD spent stays $20.00 — the group's own outgoings — and the $1.75
+    // Stripe kept is named rather than counted as spending.
+    expect(screen.getByText(/\$20\.00 spent/)).toBeTruthy();
+    expect(screen.getByText("$1.75 card fees")).toBeTruthy();
+    expect(screen.getByText("$18.10 card fees")).toBeTruthy();
+  });
+
+  it("omits the fees line when a period had none", () => {
+    render(
+      <FundScreenView
+        overview={{
+          ...baseOverview,
+          monthToDate: { ...baseOverview.monthToDate, feesCents: 0 },
+          yearToDate: { ...baseOverview.yearToDate, feesCents: 0 },
+        }}
+        myExpenses={baseExpenses}
+        onBack={noop}
+        onGivePress={noop}
+        onGetReimbursedPress={noop}
+      />,
+    );
+
+    expect(screen.queryByText(/card fees/)).toBeNull();
   });
 
   it("labels activity kinds and formats signed amounts, showing donor names when present", () => {

--- a/apps/mobile/features/finance/member/types.ts
+++ b/apps/mobile/features/finance/member/types.ts
@@ -17,7 +17,15 @@ export interface FundActivityEntry {
 
 export interface FundPeriodTotals {
   donationsCents: number;
+  /**
+   * What the group chose to spend — card swipes, reimbursements, transfers,
+   * sweeps. Deliberately excludes processing fees and refunds; see
+   * `summarizePeriod` in apps/convex/functions/finance/giving.ts.
+   */
   spentCents: number;
+  /** Stripe's processing fees, shown as their own line rather than as spend. */
+  feesCents: number;
+  refundedCents: number;
   donationCount: number;
 }
 

--- a/docs/architecture/decisions/ADR-032-group-giving.md
+++ b/docs/architecture/decisions/ADR-032-group-giving.md
@@ -311,17 +311,26 @@ already flagged in `functions/finance/ARCHITECTURE.md`:
    ACH'd to its verified bank and its Increase accounts closed — tooling +
    terms-of-service clause, not a support ticket.
 6. **Net-amount allocation.** ✅ **Done** — allocation matching now reads
-   Stripe balance-transaction per-charge NET amounts for the payout
-   (`listPayoutChargeNets`) instead of gross donation totals, which also
+   Stripe balance-transaction per-PaymentIntent NET amounts for the payout
+   (`getPayoutComposition`) instead of gross donation totals, which also
    means the payout tells us exactly which donations it contained rather
    than the job inferring membership from a running total. Falls out of
    that: allocation is retried per (payout, donation) rather than dropped
    whole on a redelivered webhook, so one failed Increase transfer no longer
    strands the rest of the batch; and the fee Stripe kept is posted as a
    `fee` ledger debit when the transfer lands, which is what makes the
-   §3 invariant satisfiable and a stalled allocation visible as drift. See
+   §3 invariant satisfiable and a stalled allocation visible as drift.
+   Reversals (refunds and chargeback `adjustment`s) are netted against their
+   own charge rather than discarded, so a gift refunded before its payout
+   contributes nothing and is never transferred into a group's spendable
+   Account; a fully refunded gift is additionally flipped to a terminal
+   `donations.allocationStatus: "refunded"`. Concurrency between an
+   in-flight payout webhook and the hourly retry cron is closed by a
+   per-donation transfer lease taken in the selection mutation. See
    `functions/finance/ARCHITECTURE.md` → "Known Seams & TODOs" for the full
-   recovery semantics.
+   recovery semantics, the refund/dispute states, and the one case that is
+   deliberately left drifting (a refund arriving after allocation needs a
+   bank-side clawback that is not designed yet).
 
 ## Open questions
 

--- a/docs/architecture/decisions/ADR-032-group-giving.md
+++ b/docs/architecture/decisions/ADR-032-group-giving.md
@@ -126,11 +126,13 @@ and can delegate from there.
   fees as a charge), ACH debit offered for large gifts. `payment_intent.
   succeeded` writes `donations` + a credit `ledgerEntries` row and sends the
   Resend receipt from the church's name/EIN.
-- **Allocation**: Stripe pays out in bulk (T+2) to the receiving Account. An
-  allocation job splits each payout into group Accounts via Increase
-  AccountTransfers, driven by donation metadata; `donations.allocationStatus`
-  tracks it. This is the one place the seam between vendors shows, and it is
-  a background job, not a user-facing flow.
+- **Allocation**: Stripe pays out in bulk (T+2) to the receiving Account,
+  **net** of processing fees. An allocation job asks Stripe which charges
+  composed the payout and at what net (balance transactions), then splits
+  those nets into group Accounts via Increase AccountTransfers;
+  `donations.allocationStatus` tracks it and the `gross − net` fee is posted
+  to the ledger as the transfer lands. This is the one place the seam between
+  vendors shows, and it is a background job, not a user-facing flow.
 - **Card spend**: Increase Card bound to the group's Account, spend limit,
   digital wallet token (Apple/Google Pay). Authorization is scoped by the
   Account balance natively. The card-transaction webhook writes the debit
@@ -187,7 +189,10 @@ fundRoles         fundId, userId, role: "finance_admin" | "manager"
                       | "cardholder", grantedBy, grantedAt, revokedAt?
 donations         fundId, donorUserId?, amountCents, feeCoverCents,
                   stripePaymentIntentId, allocationStatus, recurringId?,
-                  receiptEmailStatus
+                  receiptEmailStatus,
+                  allocationPayoutId?, payoutNetCents?  (the payout this gift
+                  was matched into and the NET it delivered — see §3
+                  Allocation and Phase-2 requirement 6)
 cards             fundId, holderUserId, increaseCardId, status,
                   spendLimitCents, controls
 expenses          fundId, submitterId, amountCents,
@@ -305,9 +310,18 @@ already flagged in `functions/finance/ARCHITECTURE.md`:
 5. **Offboarding runbook.** A church leaving Togather gets its full balance
    ACH'd to its verified bank and its Increase accounts closed — tooling +
    terms-of-service clause, not a support ticket.
-6. **Net-amount allocation.** Allocation matching must switch from gross
-   donation totals to Stripe balance-transaction per-charge NET amounts
-   (already documented as a hard go-live prerequisite in ARCHITECTURE.md).
+6. **Net-amount allocation.** ✅ **Done** — allocation matching now reads
+   Stripe balance-transaction per-charge NET amounts for the payout
+   (`listPayoutChargeNets`) instead of gross donation totals, which also
+   means the payout tells us exactly which donations it contained rather
+   than the job inferring membership from a running total. Falls out of
+   that: allocation is retried per (payout, donation) rather than dropped
+   whole on a redelivered webhook, so one failed Increase transfer no longer
+   strands the rest of the batch; and the fee Stripe kept is posted as a
+   `fee` ledger debit when the transfer lands, which is what makes the
+   §3 invariant satisfiable and a stalled allocation visible as drift. See
+   `functions/finance/ARCHITECTURE.md` → "Known Seams & TODOs" for the full
+   recovery semantics.
 
 ## Open questions
 


### PR DESCRIPTION
## Why

Money could never reach a group fund.

`planAllocations` matched **gross** donation totals (`amountCents + feeCoverCents`) against a Stripe payout, but a payout is **net** of processing fees. Gross always exceeds net, so in the common one-donation-per-payout case the first donation never fit its own payout — and the loop `break`ed rather than `continue`d, so the queue never advanced again. Group Increase Accounts stayed at zero while `funds.balanceCents` reported the money was there.

This was invisible to every alarm we have: the nightly invariant computed pending allocations on the same gross basis, so gross-vs-gross stayed perfectly self-consistent. `ARCHITECTURE.md` described it as "a tail of donations pending". It is not a tail; it is a deterministic total stall. ADR-032 named net matching a hard go-live prerequisite (Phase 2 item 6).

Two further defects in the same job:

- `runAllocation` claimed the payout in `processedStripePayouts` **before** transferring, then looped `createAccountTransfer` with no per-item error handling. One transient Increase failure stranded every remaining donation permanently — the redelivered webhook was ignored as "already processed", and `retryStaleAllocations` is alert-only.
- Nothing ever wrote the `"fee"` ledger kind, so processing fees were absent from the books entirely.

## What changed

**Net matching.** New `listPayoutChargeNets` (`lib/finance/stripeConnect.ts`) reads `GET /v1/balance_transactions?payout=…` on the connected account and returns each charge's `net` in integer cents. Stripe tells us exactly which donations a payout carried, so membership is read rather than inferred from a running total.

**Never stall.** The residual-budget check `continue`s. Ordering stays deterministic.

**Exactly-once under partial failure.** Replay protection moved from the payout to the **(payout, donation)** pair: `planAllocations` stamps `allocationPayoutId` + `payoutNetCents` in the same transaction that selects a donation. A redelivered `payout.paid` re-derives the identical set, drops what is already allocated, and finishes only the tail. `claimPayout` is gone. Each transfer is individually wrapped; a failure audits `allocation.transfer_failed`, leaves the donation pending-with-stamp, and the loop continues. Two independent locks hold the guarantee: `recordAllocation` no-ops an already-allocated donation, and the `alloc:{donationId}` Increase idempotency key collapses the transfer-landed-then-crashed case. Stripe is queried before any write, so an unreachable Stripe leaves the payout untouched.

**An honest invariant.** `computePendingAllocationCents` sums through `allocationAmountCents` — gross while a donation is in the pipeline, net once a payout binds it. On its own that would make every healthy fund drift by its fees forever, so `recordAllocation` posts the realised `gross − net` as a `fee` ledger debit when the transfer lands:

| state | ledger | bank | pending | result |
|---|---|---|---|---|
| in pipeline | gross | 0 | gross | ok |
| bound, transfer stalled | gross | 0 | net | **drift = fee** |
| allocated | net | net | 0 | ok |

**Reviewer note — this changes `funds.balanceCents` semantics** from gross to net after allocation. Net is what the bank actually holds, so the mirror is now truthful, but it is a behavioural change worth a second opinion. It also means a `Fee` row appears alongside each `Donation` row in the member-visible activity feed.

## Tests

`finance-allocation.test.ts` (16) drives the `runAllocation` action itself with the provider boundary mocked and **no suite-wide fake timers**, so an awaited action cannot silently no-op. Covers the exact stall (gross 10000 vs net 9680 now allocates), skip-don't-stall, per-donation replay protection, a 3-item partial failure whose redelivery finishes only the missing item without re-transferring the first, no-op replay, Stripe-down leaving zero writes, cron resume, and the drift-then-close reconcile sequence. `finance-payout-nets.test.ts` (7) covers net extraction, PaymentIntent mapping, paging, and malformed rows.

Full convex suite: **159 files, 2720 tests passing.**

Schema adds `donations.allocationPayoutId?` and `donations.payoutNetCents?`, both optional and backfill-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNdjLrxmbpZ3qSVCh9h5s6