### PR TITLE
Drain the scheduled jobs event-checkin leaves behind

### DIFF
--- a/apps/convex/__tests__/event-checkin.test.ts
+++ b/apps/convex/__tests__/event-checkin.test.ts
@@ -267,6 +267,33 @@ describe("event check-in — permissions", () => {
   });
 });
 
+// `markAttendance` schedules two background jobs (followup + community score
+// recompute) via plain `runAfter(0, …)`. Left running, the job is still open
+// when the next `convexTest()` calls `setConvexGlobal`, which throws "test
+// began while previous transaction was still open" — and `global.Convex`
+// outlives the file, so under contention the throw can land on a later test
+// in this same file (or a different one in the same worker). Every check-in
+// is therefore drained on real timers, the same way the messaging suite
+// drains `sendMessage`'s scheduled work (see waThreadReplies.test.ts).
+// Deliberately NOT `vi.useFakeTimers()`: fake timers are installed
+// process-wide and share the same worker-global lifetime, so a file that
+// installs them owns a second way to strand another file's scheduled work.
+//
+// A single `finishInProgressScheduledFunctions()` call right after the
+// mutation is not enough on its own: a zero-delay job may still be PENDING
+// (its `setTimeout(0)` hasn't fired yet) at that instant — the function only
+// awaits jobs already IN_PROGRESS (see the same race documented in
+// auth/placeholder-claim.test.ts) — and under real CPU contention that race
+// is losable. Yield to the real macrotask queue first so the pending timer
+// gets to run, then drain, repeating a couple of times to also cover a job
+// that itself schedules another.
+async function drainScheduledFunctions(t: ReturnType<typeof convexTest>) {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await t.finishInProgressScheduledFunctions();
+  }
+}
+
 describe("event check-in — check in / undo", () => {
   test("a leader checks a Going attendee in, then undoes it", async () => {
     const t = convexTest(schema, modules);
@@ -280,6 +307,7 @@ describe("event check-in — check in / undo", () => {
       userId: goingUserId,
       status: 1,
     });
+    await drainScheduledFunctions(t);
 
     let attendance = await t.query(
       api.functions.meetings.attendance.listAttendance,
@@ -296,6 +324,7 @@ describe("event check-in — check in / undo", () => {
       userId: goingUserId,
       status: 0,
     });
+    await drainScheduledFunctions(t);
 
     attendance = await t.query(
       api.functions.meetings.attendance.listAttendance,


### PR DESCRIPTION
## Why

`__tests__/event-checkin.test.ts` intermittently failed under parallel load with `Error: test began while previous transaction was still open`, and had been getting manual CI reruns instead of a fix.

**Reproduced on the very first full-suite run**, before changing anything — the failure happens between tests *within the same file*, at `setConvexGlobal`.

## Root cause (confirmed, not assumed)

`markAttendance` (`functions/meetings/attendance.ts`) schedules two background jobs with plain `ctx.scheduler.runAfter(0, …)` — a followup-score recompute and a community-score recompute. `convex-test` implements that with a real `setTimeout(fn, 0)` (verified by reading `convex-test@0.0.41`'s `dist/index.js`). The check-in/undo test never drained them, so under CPU contention a leftover job was still pending or running when a later test called `convexTest()` again, tripping the guard.

## The obvious fix isn't sufficient

A single `t.finishInProgressScheduledFunctions()` after the mutation — matching the most recent house commit `d90fe3dd` — is **not reliable here**, and I proved it by reproducing the identical failure with that fix applied under forced 10-thread parallelism.

`finishInProgressScheduledFunctions()` only awaits jobs already in the `inProgress` state. A zero-delay job can still be `pending` at the instant you call it, because its `setTimeout(0)` hasn't fired yet. That race is already documented in `__tests__/auth/placeholder-claim.test.ts`.

## What changed

A `drainScheduledFunctions(t)` helper that yields to the real macrotask queue (`await new Promise(r => setTimeout(r, 0))`) before each `finishInProgressScheduledFunctions()` call, looped a few times, called after both `markAttendance` invocations.

Real timers only — no `vi.useFakeTimers()`. That's deliberate on two counts: `d90fe3dd`'s lesson that process-wide fake timers leak across files, and the separate failure mode where suite-wide fake timers make scheduled actions silently never fire, so tests pass while testing nothing.

Pattern is the real-timer drain from `__tests__/messaging/waThreadReplies.test.ts`, extended with the pending-vs-inProgress fix from `placeholder-claim.test.ts`.

## Verification

**8 consecutive full-suite runs at forced `--maxThreads=10 --minThreads=10`**, 2699/2699 passing each time, plus default-parallelism runs. Zero occurrences after the fix, versus reproducing on the first run before it. Typecheck passes with only the 3 pre-existing `TS7016` errors in `lib/email/templates/*.tsx`.

## Left alone

- `__tests__/security-rsvp-attendance.test.ts` is the only other suite calling `markAttendance`, but its `afterEach(() => vi.clearAllTimers())` already wipes pending jobs before the next test. ~20 stress runs, including forced single-worker runs pairing it directly with event-checkin, never reproduced a cross-file leak.
- A **separate pre-existing flake** in `__tests__/demo-community.test.ts` (three tests hitting the 5000ms default timeout under heavy contention) surfaced repeatedly during stress testing. Different problem, different file, untouched here — flagging it rather than folding it in.

## Note on the original report

This was handed to me as flaking "3× in one day, every PR needed a manual rerun." CI history shows **one** genuine occurrence in two days; a second failure blamed on this file was a different error (`Write outside of transaction`) that Vitest misattributed. The bug is real and worth fixing — it reproduces on demand under load — but it was not the CI tax it was described as.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNdjLrxmbpZ3qSVCh9h5s6