### PR TITLE
Stop demo-community leaking scheduled callbacks into a shared fake clock

### DIFF
--- a/apps/convex/__tests__/demo-community.test.ts
+++ b/apps/convex/__tests__/demo-community.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { convexTest } from "convex-test";
-import { expect, test, describe, vi } from "vitest";
+import { expect, test, describe, vi, afterEach } from "vitest";
 import schema from "../schema";
 import { api, internal } from "../_generated/api";
 import { modules } from "../test.setup";
@@ -19,6 +19,25 @@ import type { Id } from "../_generated/dataModel";
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 
 vi.useFakeTimers();
+
+// `vi.useFakeTimers()` above is a SUITE-WIDE fake clock — it is not reset
+// between tests in this file. `createDemoCommunity` schedules
+// `seedMemberActivity` via a real `ctx.scheduler.runAfter(0, …)`, and most
+// tests here never drain it (they don't touch member-health scoring), so
+// its `setTimeout(0)` callback stays registered on the shared fake-timer
+// queue after that test's own `t` (and its `global.Convex`) is gone.
+// Whichever LATER test first calls `vi.runAllTimers()` (via
+// finishAllScheduledFunctions) then fires every orphaned callback left by
+// every earlier test at once, each racing against a `global.Convex` that
+// has long since moved on to a different `convexTest()` instance —
+// throwing convex-test's "Write outside of transaction" (suppressed as
+// expected noise in vitest.setup.ts). That's real thrown-and-caught work
+// piling onto whichever test happens to trigger the drain. Clear the queue
+// after every test so a test's own undrained scheduled function is
+// discarded instead of accumulating for a later test to pay for.
+afterEach(() => {
+  vi.clearAllTimers();
+});
 
 const COMMUNITY_ROLES = {
   MEMBER: 1,
@@ -935,6 +954,17 @@ describe("getDemoStatus", () => {
 });
 
 describe("demo conversion (go live)", () => {
+  // This test's single `finishAllScheduledFunctions` call drains TWO real
+  // pipelines back to back: createDemoCommunity's own seedMemberActivity ->
+  // communityScoreComputation chain (batched cross-group attendance +
+  // per-group scoring across ~100 seeded members), and
+  // handleCheckoutCompleted's purgeDemoSeedUsers (deletes ~100 placeholder
+  // members and everything keyed to them, one query/delete at a time). That
+  // is genuinely a lot of real synchronous work, not a hang: baseline is
+  // ~1.5s, but it measurably scales with CPU contention — reproduced at
+  // 6.3-6.6s under forced 2x-oversubscribed parallel load (2 full suites at
+  // 10 threads each on a 10-core box), which blew the default 5s budget.
+  // Widened narrowly on just this test rather than raised globally.
   test("checkout completion leaves demo mode and purges placeholder members", async () => {
     const t = convexTest(schema, modules);
     const { userId, token } = await createUser(t, "Conv", "+15555550150");
@@ -1031,10 +1061,15 @@ describe("demo conversion (go live)", () => {
         c.groupId === announcementGroup?._id && c.channelType === "main",
     );
     expect(announcementMain?.memberCount).toBe(1);
-  });
+  }, 20000);
 });
 
 describe("demo conversion race + purge safety (codex review)", () => {
+  // Same shape as "checkout completion" above — one drain covers
+  // createDemoCommunity's score-computation chain plus purgeDemoSeedUsers
+  // (scheduled by the first, winning checkout). Reproduced at 5.3-6.0s
+  // under the same forced 2x-oversubscribed parallel load; see the comment
+  // above.
   test("a second completed checkout for a different subscription never overwrites the first", async () => {
     const t = convexTest(schema, modules);
     const { token } = await createUser(t, "Race", "+15555550160");
@@ -1065,7 +1100,7 @@ describe("demo conversion race + purge safety (codex review)", () => {
     expect(community?.stripeSubscriptionId).toBe("sub_first");
     expect(community?.isDemo).toBe(false);
     expect(community?.billingModel).toBe("per_active_user");
-  });
+  }, 20000);
 
   test("purge deletes only seeded demo members, never other placeholder users", async () => {
     const t = convexTest(schema, modules);


### PR DESCRIPTION
## Why

`__tests__/demo-community.test.ts` times out in CI with `Test timed out in 5000ms` on two tests, blocking unrelated PRs from merging. Confirmed on a real run (2718/2720 passed, these two failed).

Reproduced reliably by forcing 2×-oversubscribed parallelism (two full suites at 10 threads each on a 10-core box) — same two tests, same signature, every time. A single 10-thread run never fails, which is why this looked like noise.

## Root cause — two compounding issues, both real

Found by temporarily un-suppressing `vitest.setup.ts`'s "Write outside of transaction" handler.

**1. A genuine leak.** `vi.useFakeTimers()` here is suite-wide and never reset between tests. `createDemoCommunity` schedules `seedMemberActivity` via `ctx.scheduler.runAfter(0, …)`, and roughly 30 of this file's 39 tests never drain it. Each orphaned `setTimeout(0)` stays registered in the shared fake-timer queue after that test's `t` and `global.Convex` are gone.

`checkout completion` is the **first** test in the file to call `vi.runAllTimers()` — so it fires every orphaned callback from every preceding test at once, each racing a stale `global.Convex` and throwing convex-test's normally-suppressed "Write outside of transaction". Over 200 occurrences under stress. That is real thrown-and-caught work, executed inside these two tests' time budget.

Fixed with a file-level `afterEach(() => vi.clearAllTimers())`.

**2. The two tests are also genuinely heavy.** Even with the leak fixed, their single `finishAllScheduledFunctions` drains two full pipelines back to back: `createDemoCommunity`'s `seedMemberActivity → communityScoreComputation` (batched scoring across ~100 seeded members) and `handleCheckoutCompleted`'s `purgeDemoSeedUsers` (deleting ~100 placeholder members and everything keyed to them).

I tried splitting that into two drain calls to avoid interleaving. It measurably made things **worse** — 10s+, plus extra collateral failures — which is the evidence that the cost is the work itself, not interleaving.

So the timeout goes to 20s on **those two tests only**, backed by a measured worst case of 6.6–10s under deliberately extreme contention. Not a global bump, and not a substitute for fixing the leak — both changes carry comments explaining the evidence.

## Verification

6 full-suite runs at forced 2×-oversubscribed 10-thread parallelism (3 pairs): **zero** `demo-community.test.ts` failures, target tests consistently 4.7–5.8s. Plus a clean default-parallelism run (2699/2699) and a clean `npx convex typecheck`.

## Left alone

`event-checkin.test.ts`'s separate "test began while previous transaction was still open" flake surfaced in a few stress runs. Different root cause, already fixed in #694 — deliberately not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNdjLrxmbpZ3qSVCh9h5s6