### PR TITLE
Drain the scheduled-function leaks the last two fixes didn't reach

### DIFF
--- a/apps/convex/__tests__/auth.test.ts
+++ b/apps/convex/__tests__/auth.test.ts
@@ -560,6 +560,9 @@ describe("createUserInternal", () => {
       lastName: "User",
       email: "new@example.com",
     });
+    // createUserInternal schedules linkPlaceholderTasksForUser via runAfter(0, ...);
+    // left running it strands global.Convex's transaction for the next convexTest() call.
+    await t.finishInProgressScheduledFunctions();
 
     expect(userId).toBeDefined();
 
@@ -633,6 +636,7 @@ describe("createUserInternal", () => {
       firstName: "New",
       lastName: "User",
     });
+    await t.finishInProgressScheduledFunctions();
 
     expect(userId).toBeDefined();
 
@@ -1035,6 +1039,7 @@ describe("Auth Flow Integration Tests", () => {
         lastName: "User",
         email: "new@example.com",
       });
+      await t.finishInProgressScheduledFunctions();
 
       expect(userId).toBeDefined();
 

--- a/apps/convex/__tests__/community-archival.test.ts
+++ b/apps/convex/__tests__/community-archival.test.ts
@@ -19,6 +19,7 @@ import { api, internal } from "../_generated/api";
 import { modules } from "../test.setup";
 import type { Id } from "../_generated/dataModel";
 import { generateTokens } from "../lib/auth";
+import { drainScheduledFunctions } from "./helpers/drainScheduledFunctions";
 
 // Set up JWT secret for testing - must be at least 32 characters
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
@@ -292,6 +293,10 @@ describe("archived communities block access", () => {
       token: setup.outsiderToken,
       communityId: setup.communityId,
     });
+    // A new membership schedules 4 background syncs (PCO, clearstream,
+    // flodesk, placeholder-task linking) via runAfter(0, ...); drain them
+    // (see helpers/drainScheduledFunctions.ts for why).
+    await drainScheduledFunctions(t);
 
     const membership = await t.run(async (ctx) => {
       return await ctx.db

--- a/apps/convex/__tests__/communityPeople-convert-followup.test.ts
+++ b/apps/convex/__tests__/communityPeople-convert-followup.test.ts
@@ -8,6 +8,7 @@ import schema from "../schema";
 import { api } from "../_generated/api";
 import { modules } from "../test.setup";
 import { generateTokens } from "../lib/auth";
+import { drainScheduledFunctions } from "./helpers/drainScheduledFunctions";
 
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 
@@ -134,6 +135,11 @@ describe("communityPeople.convertFollowupType", () => {
       followupId,
       newType: "call",
     });
+    // convertFollowupType schedules computeSingleMemberScore and
+    // recomputeForGroupMember (which itself schedules a nested
+    // computeSingleCommunityMember) via runAfter(0, ...); drain them (see
+    // helpers/drainScheduledFunctions.ts for why).
+    await drainScheduledFunctions(t);
 
     const row = await t.run(async (ctx) => ctx.db.get(followupId));
     expect(row?.type).toBe("call");

--- a/apps/convex/__tests__/event-checkin.test.ts
+++ b/apps/convex/__tests__/event-checkin.test.ts
@@ -15,6 +15,7 @@ import schema from "../schema";
 import { api } from "../_generated/api";
 import { modules } from "../test.setup";
 import { generateTokens } from "../lib/auth";
+import { drainScheduledFunctions } from "./helpers/drainScheduledFunctions";
 
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 
@@ -268,31 +269,12 @@ describe("event check-in — permissions", () => {
 });
 
 // `markAttendance` schedules two background jobs (followup + community score
-// recompute) via plain `runAfter(0, …)`. Left running, the job is still open
-// when the next `convexTest()` calls `setConvexGlobal`, which throws "test
-// began while previous transaction was still open" — and `global.Convex`
-// outlives the file, so under contention the throw can land on a later test
-// in this same file (or a different one in the same worker). Every check-in
-// is therefore drained on real timers, the same way the messaging suite
-// drains `sendMessage`'s scheduled work (see waThreadReplies.test.ts).
-// Deliberately NOT `vi.useFakeTimers()`: fake timers are installed
-// process-wide and share the same worker-global lifetime, so a file that
-// installs them owns a second way to strand another file's scheduled work.
-//
-// A single `finishInProgressScheduledFunctions()` call right after the
-// mutation is not enough on its own: a zero-delay job may still be PENDING
-// (its `setTimeout(0)` hasn't fired yet) at that instant — the function only
-// awaits jobs already IN_PROGRESS (see the same race documented in
-// auth/placeholder-claim.test.ts) — and under real CPU contention that race
-// is losable. Yield to the real macrotask queue first so the pending timer
-// gets to run, then drain, repeating a couple of times to also cover a job
-// that itself schedules another.
-async function drainScheduledFunctions(t: ReturnType<typeof convexTest>) {
-  for (let i = 0; i < 5; i++) {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    await t.finishInProgressScheduledFunctions();
-  }
-}
+// recompute) via plain `runAfter(0, …)`. Left undrained, that leaks into
+// other test files in the same worker — see `helpers/drainScheduledFunctions.ts`
+// for the full mechanism. Deliberately NOT `vi.useFakeTimers()`: it's
+// installed process-wide and shares the same worker-global lifetime, so a
+// file that installs it owns a second way to strand another file's
+// scheduled work.
 
 describe("event check-in — check in / undo", () => {
   test("a leader checks a Going attendee in, then undoes it", async () => {

--- a/apps/convex/__tests__/followup-refresh-state.test.ts
+++ b/apps/convex/__tests__/followup-refresh-state.test.ts
@@ -1,13 +1,26 @@
 import { convexTest } from "convex-test";
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 import schema from "../schema";
 import { modules } from "../test.setup";
 import { api, internal } from "../_generated/api";
 import { generateTokens } from "../lib/auth";
+import { drainScheduledFunctions } from "./helpers/drainScheduledFunctions";
 
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 
-vi.useFakeTimers();
+// `refreshFollowupScores` schedules `computeCommunityScores` via a plain
+// `runAfter(0, …)`, which itself schedules further work of its own (e.g.
+// pre-archive notices) — left undrained, that leaks into other test files
+// in the same worker; see `helpers/drainScheduledFunctions.ts` for the full
+// mechanism.
+//
+// Deliberately NOT `vi.useFakeTimers()` (this file used to call it at
+// module scope with no matching `afterEach(vi.useRealTimers)` — that is
+// exactly the hazard the helper's doc comment warns about: fake timers are
+// installed process-wide and share the same worker-global lifetime, so a
+// file that installs them without resetting owns a second way to strand
+// another file's scheduled work, and it also freezes the `setTimeout(0)` a
+// scheduled job needs to progress in the first place).
 
 async function seedFollowupRefreshFixture(t: ReturnType<typeof convexTest>) {
   const baseTs = Date.now();
@@ -134,6 +147,7 @@ describe("followup refresh state + lastActiveAt", () => {
         groupId: fixture.groupId,
       }
     );
+    await drainScheduledFunctions(t);
 
     // New pipeline returns { success: true } and schedules communityScoreComputation
     expect((result as any).success).toBe(true);
@@ -146,6 +160,7 @@ describe("followup refresh state + lastActiveAt", () => {
         groupId: fixture.groupId,
       }
     );
+    await drainScheduledFunctions(t);
     expect((second as any).success).toBe(true);
   });
 
@@ -168,6 +183,7 @@ describe("followup refresh state + lastActiveAt", () => {
         groupId: fixture.groupId,
       }
     );
+    await drainScheduledFunctions(t);
 
     expect((first as any).success).toBe(true);
     expect((second as any).success).toBe(true);

--- a/apps/convex/__tests__/helpers/drainScheduledFunctions.ts
+++ b/apps/convex/__tests__/helpers/drainScheduledFunctions.ts
@@ -1,0 +1,40 @@
+import type { convexTest } from "convex-test";
+
+/**
+ * Drain scheduled functions on real timers after a mutation/action call that
+ * used `ctx.scheduler.runAfter(...)` (directly, or transitively).
+ *
+ * Left running, a scheduled job leaves convex-test's global transaction
+ * state open — `global.Convex` outlives a single test file in a reused
+ * vitest worker fork, so an undrained job in one file can trip "test began
+ * while previous transaction was still open" in a completely unrelated test
+ * file later in the same worker. That's what made this bug so hard to pin
+ * down: it kept surfacing in event-checkin.test.ts even after that file's
+ * own leak was fixed, because followup-refresh-state.test.ts (and others)
+ * were leaking too and just happened to run before it.
+ *
+ * A single `t.finishInProgressScheduledFunctions()` call right after the
+ * triggering call is not always enough on its own: it only awaits jobs
+ * already IN_PROGRESS, and a zero-delay job may still be PENDING (its
+ * `setTimeout(0)` hasn't fired yet) the instant the mutation returns — under
+ * real CPU contention that race is losable, and a scheduled function that
+ * itself schedules further work needs another pass to catch the nested job
+ * too. This helper yields to the real macrotask queue first so a pending
+ * timer gets a chance to fire, then drains, repeating a few times.
+ *
+ * Deliberately real timers only — never call this from a file that has
+ * `vi.useFakeTimers()` active without an accompanying `vi.useRealTimers()`.
+ * Fake timers are installed process-wide and share the same worker-global
+ * lifetime as `global.Convex`, so a file that leaves them on owns a second
+ * way to strand another file's scheduled work — and it also freezes the
+ * `setTimeout(0)` this helper relies on to make progress in the first place.
+ */
+export async function drainScheduledFunctions(
+  t: ReturnType<typeof convexTest>,
+  iterations = 5,
+): Promise<void> {
+  for (let i = 0; i < iterations; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await t.finishInProgressScheduledFunctions();
+  }
+}

--- a/apps/convex/__tests__/member-created-events.test.ts
+++ b/apps/convex/__tests__/member-created-events.test.ts
@@ -13,6 +13,7 @@ import { modules } from "../test.setup";
 import { api } from "../_generated/api";
 import { generateTokens } from "../lib/auth";
 import type { Id } from "../_generated/dataModel";
+import { drainScheduledFunctions } from "./helpers/drainScheduledFunctions";
 
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 
@@ -22,7 +23,19 @@ process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 // transaction was still open" — intermittently locally, consistently in CI.
 // Yielding to the microtask + timer queues between tests lets the harness
 // unwind before the next test starts.
+//
+// A non-leader `meetings.index.create`/`update` here also schedules
+// `notifyEventCreatedByMember` (and, on completion-status changes,
+// followup/community score recomputation) via runAfter(0, ...) — this file's
+// whole point is member-created events, so many tests hit that branch.
+// `activeHandle` is set by each test right after it creates its `t`, and
+// drained here on real timers (see helpers/drainScheduledFunctions.ts).
+let activeHandle: ReturnType<typeof convexTest> | null = null;
 afterEach(async () => {
+  if (activeHandle) {
+    await drainScheduledFunctions(activeHandle);
+    activeHandle = null;
+  }
   await new Promise((resolve) => setImmediate(resolve));
 });
 
@@ -167,6 +180,7 @@ const FUTURE = () => Date.now() + 24 * 60 * 60 * 1000;
 describe("meetings.create — member flow", () => {
   test("active member can create an event", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const meetingId = await t.mutation(api.functions.meetings.index.create, {
@@ -183,6 +197,7 @@ describe("meetings.create — member flow", () => {
 
   test("non-member is rejected", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     await expect(
@@ -198,6 +213,7 @@ describe("meetings.create — member flow", () => {
 
   test("non-leader cannot attach seriesId", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const seriesId = await t.run(async (ctx) =>
@@ -224,6 +240,7 @@ describe("meetings.create — member flow", () => {
 
   test("second future event from same non-leader is capped", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     await t.mutation(api.functions.meetings.index.create, {
@@ -260,6 +277,7 @@ describe("meetings.create — member flow", () => {
     // still file a separate event for someone else as long as they don't
     // include themselves in the new event's hostUserIds.
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     // Member hosts their own future event (default hostUserIds = [creator]).
@@ -286,6 +304,7 @@ describe("meetings.create — member flow", () => {
     // The cap counts hostUserIds — if the new event includes the creator as
     // a host alongside someone else, it still counts.
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     await t.mutation(api.functions.meetings.index.create, {
@@ -310,6 +329,7 @@ describe("meetings.create — member flow", () => {
 
   test("leaders are unthrottled by the cap", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     // Two back-to-back creations by the leader should both succeed.
@@ -337,6 +357,7 @@ describe("meetings.create — member flow", () => {
 describe("meetings — CWE children + cover", () => {
   test("CWE child inherits parent coverImage on getByShortId when its own is empty", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const groupTypeId = await t.run(async (ctx) =>
@@ -386,6 +407,7 @@ describe("meetings — CWE children + cover", () => {
 
   test("update on a CWE child with empty location succeeds — location is inherited", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     // Build a community-wide parent + a child meeting linked to it.
@@ -442,6 +464,7 @@ describe("meetings — CWE children + cover", () => {
 
   test("CWE update writes coverImage to parent only, leaving leader overrides intact", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const groupTypeId = await t.run(async (ctx) =>
@@ -519,6 +542,7 @@ describe("meetings — CWE children + cover", () => {
 
   test("createCommunityWideEvent does not stamp coverImage on children", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const groupTypeId = await t.run(async (ctx) =>
@@ -581,6 +605,7 @@ describe("meetings — CWE children + cover", () => {
 
   test("coverImage: \"\" clears the cover (both meetings.update and communityWideEvents.update)", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     // Standalone meeting — leader clears their own cover.
@@ -641,6 +666,7 @@ describe("meetings — CWE children + cover", () => {
 
   test("tbd accepts empty location + link", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const id = await t.mutation(api.functions.meetings.index.create, {
@@ -655,6 +681,7 @@ describe("meetings — CWE children + cover", () => {
 
   test("getByShortId surfaces the host list; legacy rows with no hosts show none", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     // Member-led: the create mutation defaults hostUserIds to [creator], so
@@ -724,6 +751,7 @@ describe("meetings — CWE children + cover", () => {
 describe("meetings.update/cancel — perms", () => {
   test("creator can update their own event; another member cannot", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const meetingId = await t.mutation(api.functions.meetings.index.create, {
@@ -751,6 +779,7 @@ describe("meetings.update/cancel — perms", () => {
 
   test("creator cannot cascade series-wide update to siblings they don't lead", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const seriesId = await t.run(async (ctx) =>
@@ -797,6 +826,7 @@ describe("meetings.update/cancel — perms", () => {
 
   test("leader can apply series-wide cancel; bare host cannot", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const seriesId = await t.run(async (ctx) =>
@@ -841,6 +871,7 @@ describe("meetings.update/cancel — perms", () => {
 
   test("group leader and community admin can both cancel a member's event", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const meetingId1 = await t.mutation(api.functions.meetings.index.create, {
@@ -878,6 +909,7 @@ describe("meetings.update/cancel — perms", () => {
 describe("meetingReports", () => {
   test("createReport → leader listReportsForGroup → resolveReport", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const meetingId = await t.mutation(api.functions.meetings.index.create, {
@@ -919,6 +951,7 @@ describe("meetingReports", () => {
 
   test("re-reporting a dismissed event reopens it as pending", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const meetingId = await t.mutation(api.functions.meetings.index.create, {
@@ -968,6 +1001,7 @@ describe("meetingReports", () => {
 
   test("host cannot report their own event", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     // `create` defaults hostUserIds to [creator], so the filer is seated
@@ -991,6 +1025,7 @@ describe("meetingReports", () => {
 
   test("filer cannot report a delegated event they filed (hostUserIds empty)", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     // Insert directly so hostUserIds stays empty (delegated/legacy state).
@@ -1021,6 +1056,7 @@ describe("meetingReports", () => {
 
   test("rejects invalid reason", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const meetingId = await t.mutation(api.functions.meetings.index.create, {
@@ -1048,6 +1084,7 @@ describe("meetingReports", () => {
 describe("leave community — future-meeting ownership", () => {
   test("creator leaving community transfers future meetings to primary admin", async () => {
     const t = convexTest(schema, modules);
+    activeHandle = t;
     const s = await seed(t);
 
     const meetingId = await t.mutation(api.functions.meetings.index.create, {

--- a/apps/convex/__tests__/tasks.test.ts
+++ b/apps/convex/__tests__/tasks.test.ts
@@ -1056,6 +1056,12 @@ describe("tasks functions", () => {
         content: "Can someone follow up with me this week?",
       },
     );
+    // submitTaskRequest posts the reach-out card via sendMessage, which
+    // schedules onMessageSent via runAfter(0, ...). Left running, the
+    // still-open transaction trips convex-test's guard on the next
+    // convexTest() call — possibly in an unrelated later test file, since
+    // global.Convex outlives this one.
+    await t.finishInProgressScheduledFunctions();
 
     const linkedTask = await t.run(async (ctx) => ctx.db.get(reachOutTaskId));
     expect(linkedTask?.sourceType).toBe("reach_out");

--- a/apps/convex/__tests__/update-attendance-permissions.test.ts
+++ b/apps/convex/__tests__/update-attendance-permissions.test.ts
@@ -11,6 +11,7 @@ import schema from "../schema";
 import { api } from "../_generated/api";
 import { modules } from "../test.setup";
 import { generateTokens } from "../lib/auth";
+import { drainScheduledFunctions } from "./helpers/drainScheduledFunctions";
 
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 
@@ -169,6 +170,11 @@ describe("updateAttendance permissions", () => {
       targetUserId: regularUserId,
       status: 1,
     });
+    // updateAttendance schedules computeSingleMemberScore and
+    // recomputeForGroupMember (which itself schedules a nested
+    // computeSingleCommunityMember) via runAfter(0, ...); drain them (see
+    // helpers/drainScheduledFunctions.ts for why).
+    await drainScheduledFunctions(t);
 
     expect(result.status).toBe(1);
     expect(result.odUserId).toEqual(regularUserId);

--- a/apps/convex/__tests__/uploads-confirmUpload.test.ts
+++ b/apps/convex/__tests__/uploads-confirmUpload.test.ts
@@ -119,6 +119,11 @@ describe("confirmUpload — user profile photo", () => {
       entityId: userId,
       folder: "profiles",
     });
+    // A "user" entity confirmUpload schedules syncUserProfileToChannels via
+    // runAfter(0, ...). Left running, the still-open transaction trips
+    // convex-test's guard on the next convexTest() call — possibly in an
+    // unrelated later test file, since global.Convex outlives this one.
+    await t.finishInProgressScheduledFunctions();
 
     expect(result.success).toBe(true);
     expect(result.url).toBeDefined();

--- a/apps/convex/__tests__/uploads.test.ts
+++ b/apps/convex/__tests__/uploads.test.ts
@@ -154,6 +154,11 @@ describe("confirmUpload", () => {
       entityId: userId,
       folder: "profiles",
     });
+    // A "user" entity confirmUpload schedules syncUserProfileToChannels via
+    // runAfter(0, ...). Left running, the still-open transaction trips
+    // convex-test's guard on the next convexTest() call — possibly in an
+    // unrelated later test file, since global.Convex outlives this one.
+    await t.finishInProgressScheduledFunctions();
 
     expect(result.success).toBe(true);
     expect(result.url).toBeTruthy();


### PR DESCRIPTION
## Why

#694 and #696 each fixed a real scheduled-function leak, but the `test began while previous transaction was still open` failures kept surfacing in `event-checkin.test.ts` afterwards. That file wasn't the culprit.

`global.Convex` outlives a single test file in a reused vitest worker fork, so an undrained scheduled job trips the guard in **whichever file runs next in that worker**. The reported filename is actively misleading — which is why three separate investigations all landed on event-checkin.

An engineer instrumented convex-test's guard to print the actually-open transaction and traced it to `followup-refresh-state.test.ts` scheduling `getSingleMemberForScoring` / `internalGetGroupConfig` and never draining them.

## Root cause

`followup-refresh-state.test.ts` called `vi.useFakeTimers()` at module scope with **no matching `afterEach(() => vi.useRealTimers())`** — the only file in the suite doing that unsafely. Every other file either pairs it with a reset or freezes deliberately and says so (e.g. `finance-cards.test.ts`, keeping scheduled actions off external APIs).

It also wasn't used for anything: no `setSystemTime`, no `advanceTimers`, no `runAllTimers`. Dead code from the file's original commit. It froze the `setTimeout(0)` that `refreshFollowupScores`'s scheduled `computeCommunityScores` job needed to progress.

## Honesty about the evidence

**I could not reproduce the failure.** 28 full-suite runs against unmodified `main` at forced `--maxThreads=10 --minThreads=10` produced zero transaction errors, so the 50 clean runs after the fix are not by themselves proof it was fixed.

What stands on its own is the static defect: an unpaired module-scope `vi.useFakeTimers()` that freezes a scheduler the file then never drains is a hazard regardless of whether it fired today, and the instrumented trace from a separate investigation points at exactly this file.

## What changed

- `followup-refresh-state.test.ts` — removed the dead `vi.useFakeTimers()`, drains after each `refreshFollowupScores`.
- **Swept the rest of `__tests__/**`** and fixed 8 more genuine leaks: `auth`, `community-archival`, `communityPeople-convert-followup`, `member-created-events` (largest — 24 test blocks via a shared handle), `tasks`, `update-attendance-permissions`, `uploads-confirmUpload`, `uploads`. Files with properly-paired fake timers, or deliberate freezes, were left alone.
- **Extracted `__tests__/helpers/drainScheduledFunctions.ts`.** The yield-then-drain loop was needed in 6 files; copying it a third time crossed the line. The simpler single-call `finishInProgressScheduledFunctions()` variant stays inline in the 5 files that only need one line.

## Verification

50 full-suite runs at forced 10/10 parallelism post-fix, all green, plus a normal default-parallelism run (157 files / 2717 tests). `tsc -p apps/convex` clean throughout.

Two unrelated CPU-contention timeouts (`password-reset`, `demo-community`) appear under forced oversubscription. Different flake class, pre-existing, left alone.

## Worth knowing

This is the third layer of the same bug class, each hiding behind the last. The general lesson for this codebase: **because `global.Convex` outlives a test file, every scheduled-function leak masquerades as a failure in an innocent neighbour.** Trust the instrumented trace, not the filename in the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNdjLrxmbpZ3qSVCh9h5s6