### PR TITLE
Say why the serving Tasks tab is empty instead of always blaming the team lead

### DIFF
--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -2235,6 +2235,7 @@ function TeamRow({
 /** The slice of a `listPlanTasks` row this section reads. */
 type AuthorTask = {
   _id: string;
+  teamIds: string[];
   roleIds: string[];
   segment: Segment;
   title: string;
@@ -2302,9 +2303,12 @@ function AuthorSection({
     (r) => r.roleId === selectedRoleId,
   );
 
+  // Team-scoped: `listPlanTasks` is plan-wide and the role catalog spans every
+  // team in the group, so team-level tasks must be matched on the SELECTED
+  // role's team or a leader would see (and be able to delete) another team's.
   const bySegment = useMemo(
-    () => tasksForRole(planTasks ?? [], selectedRoleId),
-    [planTasks, selectedRoleId],
+    () => tasksForRole(planTasks ?? [], selectedRole ?? null),
+    [planTasks, selectedRole],
   );
 
   const [addingSegment, setAddingSegment] = useState<Segment | null>(null);

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -21,6 +21,14 @@
  * A "＋ Add task" affordance opens a small inline form (title + optional note +
  * segment; a time label when adding under During) that calls `addPersonalTask`.
  *
+ * When "Mine" is empty, `MineEmptyNotice` says WHY — a plan with no tasks at
+ * all, a viewer who holds no role on the plan, or tasks that exist but name
+ * other roles are three different problems with three different fixes (see
+ * `utils/servingTaskEmptyState.ts`). It also offers a jump to "Shared" when the
+ * team has whole-team tasks, and — for a leader on a task-less plan —
+ * `PopulateFromTemplate`, which links one of the group's saved task templates
+ * via the existing `setPlanTaskTemplate`.
+ *
  * A fifth pill, "Edit", appears only for a leader/community admin
  * (`canAuthorPlanTasks` — mirrors the backend's `isGroupScheduler` gate on
  * `createTask`/`updateTask`/`deleteTask`): `AuthorSection` lets them switch
@@ -89,6 +97,7 @@ import {
   mineEmptyCopy,
   myRoleNamesFromCrew,
   planTaskCountFromAllTeams,
+  type MineEmptyFacts,
   type MineEmptyReason,
 } from "../utils/servingTaskEmptyState";
 
@@ -748,10 +757,27 @@ function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean
   const overallTotal = allTasks.length;
 
   // "Preloaded" tasks are the template (assigned) tasks for the user's role;
-  // personal tasks are the ones the user adds themselves. When the role has no
-  // preloaded tasks, we guide the user to their team lead while still letting
-  // them add their own tasks per segment.
-  const hasPreloadedTasks = allTasks.some((t) => !t.isPersonal);
+  // personal tasks are the ones the user adds themselves.
+  const myTemplateTaskCount = allTasks.filter((t) => !t.isPersonal).length;
+
+  // WHY the "Mine" list is empty. Three unrelated causes used to share one
+  // message ("No preloaded task. Please contact your team lead to add tasks.")
+  // that was wrong for two of them; `diagnoseMineEmpty` tells them apart from
+  // data these four queries already carry. See `servingTaskEmptyState.ts`.
+  const mineFacts = useMemo(
+    () => ({
+      planTaskCount: planTaskCountFromAllTeams(effAllTeams),
+      myRoleNames: myRoleNamesFromCrew(effCrew),
+      myTemplateTaskCount,
+      sharedTaskCount: effShared?.length ?? 0,
+    }),
+    [effAllTeams, effCrew, myTemplateTaskCount, effShared],
+  );
+  const mineEmptyReason: MineEmptyReason = diagnoseMineEmpty(mineFacts);
+  // `loading` renders nothing, so the per-segment empty cards stay visible
+  // until we can say something true.
+  const showMineNotice =
+    mineEmptyReason !== "has-tasks" && mineEmptyReason !== "loading";
 
   // Small badges on the section pills (null hides the badge).
   const sectionCounts: Record<Section, string | null> = {
@@ -809,7 +835,21 @@ function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean
             )
           ) : (
             <>
-            {!hasPreloadedTasks ? <NoPreloadedNotice colors={colors} wa={wa} /> : null}
+            {showMineNotice ? (
+              <MineEmptyNotice
+                reason={mineEmptyReason}
+                facts={mineFacts}
+                onViewShared={() => setSection("shared")}
+                leader={
+                  canAuthor && mineEmptyReason === "no-plan-tasks"
+                    ? { planId, groupId, isEffectivelyOffline }
+                    : null
+                }
+                colors={colors}
+                primaryColor={primaryColor}
+                wa={wa}
+              />
+            ) : null}
             {SEGMENTS.map(({ key, label }) => {
             const segmentTasks = mineWithOverlay[key] ?? [];
             const done = segmentTasks.filter((t) => t.completed).length;
@@ -845,10 +885,11 @@ function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean
                   height={4}
                 />
 
-                {/* When the role has no preloaded tasks, the notice above already
-                    explains the empty state, so we skip the per-segment empty
-                    card and leave just the "Add my own task" affordance. */}
-                {segmentTasks.length === 0 && !hasPreloadedTasks ? null : (
+                {/* When the notice above is explaining the empty state, skip
+                    the per-segment empty card and leave just the "Add my own
+                    task" affordance. (While the diagnosis is still `loading`
+                    no notice shows, so the cards stay.) */}
+                {segmentTasks.length === 0 && showMineNotice ? null : (
                 <View
                   style={[
                     styles.card,
@@ -2845,11 +2886,43 @@ function OfflineBanner({ colors, wa }: { colors: ThemeColors; wa: boolean }) {
 }
 
 /**
- * Shown at the top of the "Mine" section when the user's role has no preloaded
- * (template) tasks. Explains the empty state and points the user to their team
- * lead, while the per-segment "Add my own task" affordances remain available.
+ * Shown at the top of the "Mine" section when the viewer has no preloaded
+ * (template) tasks — and says WHICH of the several possible reasons applies
+ * (`diagnoseMineEmpty`). The per-segment "Add my own task" affordances stay
+ * available underneath in every case.
+ *
+ * Two extra affordances hang off it:
+ *   • a one-tap jump to "Shared" whenever the team HAS whole-team tasks — the
+ *     screen opens on "Mine" and `getMyServingTasks` deliberately omits
+ *     team-level tasks, so otherwise the viewer has to guess they exist;
+ *   • for a leader on a plan with NO tasks, `PopulateFromTemplate` — the
+ *     nothing-backfills-a-new-plan case is theirs to fix, in place.
  */
-function NoPreloadedNotice({ colors, wa }: { colors: ThemeColors; wa: boolean }) {
+function MineEmptyNotice({
+  reason,
+  facts,
+  onViewShared,
+  leader,
+  colors,
+  primaryColor,
+  wa,
+}: {
+  reason: MineEmptyReason;
+  facts: MineEmptyFacts;
+  onViewShared: () => void;
+  /** Non-null only for a leader on a plan with zero tasks (see `canAuthorPlanTasks`). */
+  leader: {
+    planId: Id<"eventPlans">;
+    groupId: Id<"groups">;
+    isEffectivelyOffline: boolean;
+  } | null;
+  colors: ThemeColors;
+  primaryColor: string;
+  wa: boolean;
+}) {
+  const copy = mineEmptyCopy(reason, facts);
+  if (!copy) return null;
+
   return (
     <View style={[styles.segment, wa && waStyles.segment]}>
       <View
@@ -2868,7 +2941,7 @@ function NoPreloadedNotice({ colors, wa }: { colors: ThemeColors; wa: boolean })
           <Text
             style={[styles.noticeMessage, wa && waStyles.noticeMessage, { color: colors.text }]}
           >
-            No preloaded task. Please contact your team lead to add tasks.
+            {copy.title}
           </Text>
           <Text
             style={[
@@ -2877,10 +2950,156 @@ function NoPreloadedNotice({ colors, wa }: { colors: ThemeColors; wa: boolean })
               { color: colors.textTertiary },
             ]}
           >
-            You can still add your own tasks below.
+            {copy.hint}
           </Text>
+
+          {facts.sharedTaskCount > 0 ? (
+            <Pressable
+              onPress={onViewShared}
+              style={styles.noticeAction}
+              accessibilityRole="button"
+              accessibilityLabel="Open the Shared tab"
+            >
+              <Text
+                style={[
+                  styles.noticeActionText,
+                  wa && waStyles.noticeActionText,
+                  { color: primaryColor },
+                ]}
+              >
+                {`Open Shared (${facts.sharedTaskCount})`}
+              </Text>
+              <Ionicons name="arrow-forward" size={15} color={primaryColor} />
+            </Pressable>
+          ) : null}
+
+          {leader ? (
+            <PopulateFromTemplate
+              planId={leader.planId}
+              groupId={leader.groupId}
+              isEffectivelyOffline={leader.isEffectivelyOffline}
+              colors={colors}
+              primaryColor={primaryColor}
+              wa={wa}
+            />
+          ) : null}
         </View>
       </View>
+    </View>
+  );
+}
+
+/**
+ * Leader-only: fill an EMPTY plan's task list from one of the group's saved
+ * task templates, without leaving serving mode.
+ *
+ * A plan created by `createEventDraftImpl` has no `taskTemplateId` and no
+ * tasks, and nothing ever backfills it — tasks only materialise when someone
+ * links a template from the rostering grid (or duplicates an event). That grid
+ * is where a leader would otherwise have to go, on a laptop, mid-service. This
+ * calls the SAME existing `setPlanTaskTemplate` mutation the grid uses (no new
+ * backend surface); the default `carryover` is irrelevant here because the
+ * plan has no rows to carry over.
+ *
+ * Only rendered when the plan has zero tasks, so there is nothing to destroy
+ * and no confirmation step is warranted.
+ *
+ * OFFLINE: hidden, for the same reason `AuthorSection` hides its controls —
+ * this is a plan-wide, server-validated write with no dedupe key.
+ */
+function PopulateFromTemplate({
+  planId,
+  groupId,
+  isEffectivelyOffline,
+  colors,
+  primaryColor,
+  wa,
+}: {
+  planId: Id<"eventPlans">;
+  groupId: Id<"groups">;
+  isEffectivelyOffline: boolean;
+  colors: ThemeColors;
+  primaryColor: string;
+  wa: boolean;
+}) {
+  const templates = useAuthenticatedQuery(
+    api.functions.scheduling.taskTemplates.listTaskTemplates,
+    isEffectivelyOffline ? "skip" : { groupId },
+  ) as Array<{ _id: string; name: string; itemCount: number }> | undefined;
+  const setPlanTaskTemplate = useAuthenticatedMutation(
+    api.functions.scheduling.planTemplates.setPlanTaskTemplate,
+  );
+  const [applyingId, setApplyingId] = useState<string | null>(null);
+
+  if (isEffectivelyOffline || templates === undefined) return null;
+
+  // A template with no items would link cleanly and still leave the plan empty.
+  const usable = templates.filter((t) => t.itemCount > 0);
+
+  if (usable.length === 0) {
+    return (
+      <Text
+        style={[
+          styles.noticeHint,
+          wa && waStyles.noticeHint,
+          { color: colors.textTertiary },
+        ]}
+      >
+        This campus has no saved task lists yet. Use the Edit tab above to add
+        tasks role by role.
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.noticeActions}>
+      <Text
+        style={[
+          styles.noticeHint,
+          wa && waStyles.noticeHint,
+          { color: colors.textTertiary },
+        ]}
+      >
+        Add this event&apos;s tasks from a saved list:
+      </Text>
+      {usable.map((template) => (
+        <Pressable
+          key={template._id}
+          disabled={applyingId !== null}
+          onPress={async () => {
+            setApplyingId(template._id);
+            try {
+              await setPlanTaskTemplate({
+                planId,
+                templateId: template._id as Id<"eventTaskTemplates">,
+              });
+            } catch (err) {
+              notify(
+                "Couldn't add these tasks",
+                String((err as Error)?.message ?? err),
+              );
+            } finally {
+              setApplyingId(null);
+            }
+          }}
+          style={styles.noticeAction}
+          accessibilityRole="button"
+          accessibilityLabel={`Add tasks from ${template.name}`}
+        >
+          <Ionicons name="add" size={16} color={primaryColor} />
+          <Text
+            style={[
+              styles.noticeActionText,
+              wa && waStyles.noticeActionText,
+              { color: primaryColor },
+            ]}
+          >
+            {`${template.name} · ${template.itemCount} ${
+              template.itemCount === 1 ? "task" : "tasks"
+            }`}
+          </Text>
+        </Pressable>
+      ))}
     </View>
   );
 }
@@ -3003,6 +3222,16 @@ const styles = StyleSheet.create({
   noticeBody: { flex: 1 },
   noticeMessage: { fontSize: 14, lineHeight: 20, fontWeight: "500" },
   noticeHint: { fontSize: 13, lineHeight: 18, marginTop: 4 },
+  // Actions inside the "Mine" empty-state notice (jump to Shared; a leader's
+  // "populate from a saved task list" rows).
+  noticeActions: { marginTop: 4 },
+  noticeAction: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingVertical: 8,
+  },
+  noticeActionText: { fontSize: 14, fontWeight: "600" },
 
   // Author (leader "Edit" surface) role-switcher caption
   authorHint: {
@@ -3212,6 +3441,7 @@ const waStyles = StyleSheet.create({
   noticeCard: { borderRadius: WA_GROUP_RADIUS, borderWidth: 0, padding: WA_CELL_PADDING },
   noticeMessage: { fontSize: WA_TYPE_ROW_TITLE, lineHeight: 22, fontWeight: WA_WEIGHT_REGULAR },
   noticeHint: { fontSize: WA_TYPE_FOOTNOTE, lineHeight: 18 },
+  noticeActionText: { fontSize: WA_TYPE_SUBTITLE, fontWeight: WA_WEIGHT_SEMIBOLD },
   authorHint: { fontSize: WA_TYPE_FOOTNOTE, marginHorizontal: WA_GROUP_MARGIN },
 
   // Task rows (§3.2 cell anatomy)

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -80,9 +80,17 @@ import { HowToViewer, type HowToViewerContent } from "./HowToViewer";
 import {
   buildRoleCatalog,
   canAuthorPlanTasks,
+  isTeamLevelTask,
   tasksForRole,
   type RoleCatalogEntry,
 } from "../utils/taskAuthoring";
+import {
+  diagnoseMineEmpty,
+  mineEmptyCopy,
+  myRoleNamesFromCrew,
+  planTaskCountFromAllTeams,
+  type MineEmptyReason,
+} from "../utils/servingTaskEmptyState";
 
 type Segment = "before" | "during" | "after";
 
@@ -2447,6 +2455,7 @@ function AuthorRoleAndSegments({
                   <AuthorTaskRow
                     key={task._id}
                     title={task.title}
+                    teamLevel={isTeamLevelTask(task)}
                     first={i === 0}
                     editable={!isEffectivelyOffline}
                     editing={editingTaskId === task._id}
@@ -2561,9 +2570,14 @@ function RoleLoader({
 }
 
 /** One task row in the Edit surface: title, tap-to-edit (title only) when
- *  online; read-only when offline (see the OFFLINE note above). */
+ *  online; read-only when offline (see the OFFLINE note above).
+ *
+ *  `teamLevel` rows belong to the WHOLE TEAM, not the role currently selected
+ *  in the switcher — they show under every role (that's the only place a
+ *  leader can reach them), so they carry a caption saying so. */
 function AuthorTaskRow({
   title,
+  teamLevel,
   first,
   editable,
   editing,
@@ -2576,6 +2590,7 @@ function AuthorTaskRow({
   onDelete,
 }: {
   title: string;
+  teamLevel: boolean;
   first: boolean;
   editable: boolean;
   editing: boolean;
@@ -2607,6 +2622,19 @@ function AuthorTaskRow({
         <Text style={[styles.taskTitle, wa && waStyles.taskTitle, { color: colors.text }]}>
           {title}
         </Text>
+        {teamLevel ? (
+          <View style={styles.taskMetaRow}>
+            <Text
+              style={[
+                styles.taskMeta,
+                wa && waStyles.taskMeta,
+                { color: colors.textTertiary },
+              ]}
+            >
+              Whole team — not just this role
+            </Text>
+          </View>
+        ) : null}
       </Pressable>
 
       {editing && editable ? (

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -97,6 +97,7 @@ import {
   mineEmptyCopy,
   myRoleNamesFromCrew,
   planTaskCountFromAllTeams,
+  shouldOfferSharedJump,
   type MineEmptyFacts,
   type MineEmptyReason,
 } from "../utils/servingTaskEmptyState";
@@ -769,7 +770,10 @@ function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean
       planTaskCount: planTaskCountFromAllTeams(effAllTeams),
       myRoleNames: myRoleNamesFromCrew(effCrew),
       myTemplateTaskCount,
-      sharedTaskCount: effShared?.length ?? 0,
+      // `null`, not 0, while unresolved — offline this NEVER self-corrects when
+      // the shared section was never cached, and a defaulted 0 hid the "Open
+      // Shared" pointer exactly when it matters most.
+      sharedTaskCount: effShared?.length ?? null,
     }),
     [effAllTeams, effCrew, myTemplateTaskCount, effShared],
   );
@@ -2896,7 +2900,8 @@ function OfflineBanner({ colors, wa }: { colors: ThemeColors; wa: boolean }) {
  * available underneath in every case.
  *
  * Two extra affordances hang off it:
- *   • a one-tap jump to "Shared" whenever the team HAS whole-team tasks — the
+ *   • a one-tap jump to "Shared" whenever the team HAS whole-team tasks AND the
+ *     diagnosis is one that Shared could answer (`shouldOfferSharedJump`) — the
  *     screen opens on "Mine" and `getMyServingTasks` deliberately omits
  *     team-level tasks, so otherwise the viewer has to guess they exist;
  *   • for a leader on a plan with NO tasks, `PopulateFromTemplate` — the
@@ -2957,7 +2962,7 @@ function MineEmptyNotice({
             {copy.hint}
           </Text>
 
-          {facts.sharedTaskCount > 0 ? (
+          {shouldOfferSharedJump(reason, facts) ? (
             <Pressable
               onPress={onViewShared}
               style={styles.noticeAction}
@@ -2971,7 +2976,7 @@ function MineEmptyNotice({
                   { color: primaryColor },
                 ]}
               >
-                {`Open Shared (${facts.sharedTaskCount})`}
+                {`Open Shared (${facts.sharedTaskCount ?? 0})`}
               </Text>
               <Ionicons name="arrow-forward" size={15} color={primaryColor} />
             </Pressable>

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -3006,7 +3006,8 @@ function MineEmptyNotice({
  * grid can't be destroyed by this device's stale "the plan is empty" snapshot.
  *
  * Only rendered when the plan has zero tasks, so there is nothing to destroy
- * and no confirmation step is warranted.
+ * and no confirmation step is warranted — and only on an UPCOMING plan, since
+ * the backend freezes template linkage once the event has started (see below).
  *
  * OFFLINE: hidden, for the same reason `AuthorSection` hides its controls —
  * this is a plan-wide, server-validated write with no dedupe key.
@@ -3030,15 +3031,29 @@ function PopulateFromTemplate({
     api.functions.scheduling.taskTemplates.listTaskTemplates,
     isEffectivelyOffline ? "skip" : { groupId },
   ) as Array<{ _id: string; name: string; itemCount: number }> | undefined;
+  // `setPlanTaskTemplate` throws "Past events are frozen and cannot be
+  // re-linked." once `plan.eventDate` (the FIRST service's start time, not a
+  // day bucket) has passed — which is most of the serving window this
+  // affordance exists for: serving opens 12h before the plan and stays open 4h
+  // past the last service, so for a 9:00 service every tap from 09:00 to 13:00
+  // would fail with a raw ConvexError. Read the same `isPast` the rostering
+  // grid's `PlanTemplateToolbar` uses and don't offer the rows at all.
+  // `createTask` has NO past-plan freeze, so the Edit tab genuinely still works.
+  const linkage = useAuthenticatedQuery(
+    api.functions.scheduling.planTemplates.getPlanTemplateState,
+    isEffectivelyOffline ? "skip" : { planId },
+  ) as { isPast: boolean } | undefined;
   const setPlanTaskTemplate = useAuthenticatedMutation(
     api.functions.scheduling.planTemplates.setPlanTaskTemplate,
   );
   const [applyingId, setApplyingId] = useState<string | null>(null);
 
-  if (isEffectivelyOffline || templates === undefined) return null;
+  if (isEffectivelyOffline || templates === undefined || linkage === undefined) {
+    return null;
+  }
 
   // A template with no items would link cleanly and still leave the plan empty.
-  const usable = templates.filter((t) => t.itemCount > 0);
+  const usable = linkage.isPast ? [] : templates.filter((t) => t.itemCount > 0);
 
   if (usable.length === 0) {
     return (
@@ -3049,8 +3064,9 @@ function PopulateFromTemplate({
           { color: colors.textTertiary },
         ]}
       >
-        This campus has no saved task lists yet. Use the Edit tab above to add
-        tasks role by role.
+        {linkage.isPast
+          ? "This event has already started, so it can no longer be linked to a saved task list. Use the Edit tab above to add tasks role by role."
+          : "This campus has no saved task lists yet. Use the Edit tab above to add tasks role by role."}
       </Text>
     );
   }

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -3002,8 +3002,8 @@ function MineEmptyNotice({
  * links a template from the rostering grid (or duplicates an event). That grid
  * is where a leader would otherwise have to go, on a laptop, mid-service. This
  * calls the SAME existing `setPlanTaskTemplate` mutation the grid uses (no new
- * backend surface); the default `carryover` is irrelevant here because the
- * plan has no rows to carry over.
+ * backend surface), with `carryover: "copy"` so a concurrent write from the
+ * grid can't be destroyed by this device's stale "the plan is empty" snapshot.
  *
  * Only rendered when the plan has zero tasks, so there is nothing to destroy
  * and no confirmation step is warranted.
@@ -3076,6 +3076,14 @@ function PopulateFromTemplate({
               await setPlanTaskTemplate({
                 planId,
                 templateId: template._id as Id<"eventTaskTemplates">,
+                // "copy" — NOT the backend's "discard" default. This affordance
+                // only renders off a `no-plan-tasks` snapshot, but that snapshot
+                // is reactive and can be stale: if another leader adds tasks
+                // from the grid between their write and this device receiving
+                // the update, "discard" would silently delete every one of them
+                // and cascade their completions, with no confirm and no undo.
+                // On a genuinely empty plan "copy" is a no-op.
+                carryover: "copy",
               });
             } catch (err) {
               notify(

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -328,10 +328,12 @@ describe("ServingTasksScreen — diagnostic empty state (Mine)", () => {
     const { getByText } = render(<ServingTasksScreen />);
 
     expect(getByText(NOT_ROSTERED_MESSAGE)).toBeTruthy();
-    expect(getByText(/The event has 2 tasks/)).toBeTruthy();
+    // True whether the assignment was removed OR declined — the only two ways
+    // to reach this state with the screen already open.
+    expect(getByText(/your assignment was removed, or you declined it/)).toBeTruthy();
   });
 
-  it("quotes the task count and the viewer's actual roles on a role mismatch", () => {
+  it("scopes the task count to all teams and names the viewer's actual roles on a role mismatch", () => {
     mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
       allTeams: [allTeamsRow(["task-1", "task-2", "task-3"])],
       crew: [myCrewRow("Greeter"), myCrewRow("Usher")],
@@ -339,9 +341,14 @@ describe("ServingTasksScreen — diagnostic empty state (Mine)", () => {
     const { getByText } = render(<ServingTasksScreen />);
 
     expect(
-      getByText("This event has 3 tasks, but none are assigned to your roles."),
+      getByText("None of this event's tasks are assigned to your roles."),
     ).toBeTruthy();
     expect(getByText(/You're serving as Greeter and Usher\./)).toBeTruthy();
+    // The count is plan-wide, so it must say so rather than implying the
+    // viewer was singled out.
+    expect(getByText(/across all teams/)).toBeTruthy();
+    // …and the actionable instruction the old single-message copy had is back.
+    expect(getByText(/Ask your team lead to add tasks for your roles\./)).toBeTruthy();
   });
 
   it("shows nothing until the plan-wide data has loaded, rather than guessing", () => {

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -398,7 +398,11 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     expect(getAllByText("No tasks yet for this role.")).toHaveLength(3);
   });
 
-  it("excludes a team-level (no-role) task from every role's list", () => {
+  // Team-level tasks used to be hidden here, which left the Edit surface — a
+  // leader's only authoring surface inside serving mode — blind to them: they
+  // are excluded from "Mine" by design and appear only under the read-only
+  // Shared pill. They now show under every role, captioned as whole-team.
+  it("shows a team-level (no-role) task under every role, labelled whole-team", () => {
     mockUser = { is_admin: true };
     mockAuthorQueries([
       {
@@ -409,11 +413,17 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
         sortOrder: 0,
       },
     ]);
-    const { queryByText, getByLabelText, getAllByText } = render(<ServingTasksScreen />);
+    const { getByText, getByLabelText, getAllByText } = render(<ServingTasksScreen />);
     fireEvent.press(getByLabelText("Edit"));
 
-    expect(queryByText("Unlock the building")).toBeNull();
-    expect(getAllByText("No tasks yet for this role.")).toHaveLength(3);
+    expect(getByText("Unlock the building")).toBeTruthy();
+    expect(getByText("Whole team — not just this role")).toBeTruthy();
+    // Only Before has the task; During/After stay empty.
+    expect(getAllByText("No tasks yet for this role.")).toHaveLength(2);
+
+    // Still visible after switching to a role that owns no tasks of its own.
+    fireEvent.press(getByLabelText("View and edit Hospitality Usher tasks"));
+    expect(getByText("Unlock the building")).toBeTruthy();
   });
 
   it("adds a task for the selected role via createTask", async () => {

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -448,7 +448,26 @@ describe("ServingTasksScreen — leader affordance on a task-less plan", () => {
     expect(mockSetPlanTaskTemplate).toHaveBeenCalledWith({
       planId: "plan-1",
       templateId: "tmpl-1",
+      carryover: "copy",
     });
+  });
+
+  // The backend defaults `carryover` to "discard", which DELETES every
+  // pre-existing task on the plan and cascades its completions — and
+  // `setPlanTaskTemplate` does no emptiness check of its own. The only guard is
+  // this device's reactive "the plan has no tasks" snapshot, which is stale for
+  // as long as it takes another leader's grid write to arrive. "copy" is a
+  // no-op on a genuinely empty plan and preserves their rows in the race.
+  it("passes carryover 'copy' so a concurrent write is never discarded", async () => {
+    mockUser = { is_admin: true };
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, { taskTemplates: TEMPLATES });
+    const { getByLabelText } = render(<ServingTasksScreen />);
+
+    await fireEvent.press(getByLabelText("Add tasks from Midweek"));
+
+    expect(mockSetPlanTaskTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ carryover: "copy" }),
+    );
   });
 
   it("omits an item-less template rather than offering a no-op", () => {

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -569,8 +569,22 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
   ];
   const NO_SHARED_TASKS: unknown[] = [];
 
-  function mockAuthorQueries(planTasks: unknown[] = []) {
-    mockQuery.mockImplementation((ref: string) => {
+  // A second team, for the cross-team leakage regression below. `listPlanTasks`
+  // is PLAN-wide and the role catalog spans every team in the group, so these
+  // two teams' tasks arrive in the same array.
+  const MULTI_TEAMS = [
+    { _id: "team-kids", name: "Kids" },
+    { _id: "team-worship", name: "Worship" },
+  ];
+  const KIDS_ROLES = [{ _id: "role-checkin", name: "Check-in" }];
+  const WORSHIP_ROLES = [{ _id: "role-sound", name: "Sound" }];
+
+  function mockAuthorQueries(
+    planTasks: unknown[] = [],
+    teams: unknown = AUTHOR_TEAMS,
+    rolesFor: (teamId?: string) => unknown = () => AUTHOR_ROLES,
+  ) {
+    mockQuery.mockImplementation((ref: string, args?: { teamId?: string }) => {
       switch (ref) {
         case REF.mine:
           return EMPTY_MINE;
@@ -583,9 +597,9 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
         case REF.groupById:
           return { userRole: undefined };
         case REF.listTeams:
-          return AUTHOR_TEAMS;
+          return teams;
         case REF.listRoles:
-          return AUTHOR_ROLES;
+          return rolesFor(args?.teamId);
         case REF.listPlanTasks:
           return planTasks;
         case REF.listTaskTemplates:
@@ -596,6 +610,12 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
           return undefined;
       }
     });
+  }
+
+  function mockMultiTeamAuthorQueries(planTasks: unknown[]) {
+    mockAuthorQueries(planTasks, MULTI_TEAMS, (teamId) =>
+      teamId === "team-kids" ? KIDS_ROLES : WORSHIP_ROLES,
+    );
   }
 
   beforeEach(() => {
@@ -628,6 +648,7 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     mockAuthorQueries([
       {
         _id: "task-1",
+        teamIds: ["team-1"],
         roleIds: ["role-greeter"],
         segment: "before",
         title: "Set up welcome table",
@@ -646,6 +667,7 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     mockAuthorQueries([
       {
         _id: "task-1",
+        teamIds: ["team-1"],
         roleIds: ["role-greeter"],
         segment: "before",
         title: "Set up welcome table",
@@ -674,6 +696,7 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     mockAuthorQueries([
       {
         _id: "task-shared",
+        teamIds: ["team-1"],
         roleIds: [],
         segment: "before",
         title: "Unlock the building",
@@ -691,6 +714,65 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     // Still visible after switching to a role that owns no tasks of its own.
     fireEvent.press(getByLabelText("View and edit Hospitality Usher tasks"));
     expect(getByText("Unlock the building")).toBeTruthy();
+  });
+
+  // REGRESSION: `listPlanTasks` returns EVERY task on the plan (all teams) and
+  // the role catalog spans every team in the group, so team-level tasks used to
+  // appear under other teams' roles — captioned "Whole team — not just this
+  // role" (false) and one tap from an unconfirmed Delete that cascades
+  // completions and permanently detaches the row from its template.
+  it("never shows another team's team-level task", () => {
+    mockUser = { is_admin: true };
+    mockMultiTeamAuthorQueries([
+      {
+        _id: "task-worship",
+        teamIds: ["team-worship"],
+        roleIds: [],
+        segment: "before",
+        title: "Sound check",
+        sortOrder: 0,
+      },
+      {
+        _id: "task-kids",
+        teamIds: ["team-kids"],
+        roleIds: [],
+        segment: "before",
+        title: "Check-in table setup",
+        sortOrder: 1,
+      },
+    ]);
+    const { getByText, getByLabelText, queryByText } = render(<ServingTasksScreen />);
+    fireEvent.press(getByLabelText("Edit"));
+
+    // Kids sorts before Worship, so Kids · Check-in is selected by default.
+    expect(getByText("Kids · Check-in")).toBeTruthy();
+    expect(getByText("Check-in table setup")).toBeTruthy();
+    expect(queryByText("Sound check")).toBeNull();
+
+    fireEvent.press(getByLabelText("View and edit Worship Sound tasks"));
+
+    expect(getByText("Sound check")).toBeTruthy();
+    expect(queryByText("Check-in table setup")).toBeNull();
+  });
+
+  it("shows a task spanning both teams under each team's roles", () => {
+    mockUser = { is_admin: true };
+    mockMultiTeamAuthorQueries([
+      {
+        _id: "task-both",
+        teamIds: ["team-kids", "team-worship"],
+        roleIds: [],
+        segment: "before",
+        title: "Clear the stage",
+        sortOrder: 0,
+      },
+    ]);
+    const { getByText, getByLabelText } = render(<ServingTasksScreen />);
+    fireEvent.press(getByLabelText("Edit"));
+
+    expect(getByText("Clear the stage")).toBeTruthy();
+    fireEvent.press(getByLabelText("View and edit Worship Sound tasks"));
+    expect(getByText("Clear the stage")).toBeTruthy();
   });
 
   it("adds a task for the selected role via createTask", async () => {
@@ -719,6 +801,7 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     mockAuthorQueries([
       {
         _id: "task-1",
+        teamIds: ["team-1"],
         roleIds: ["role-greeter"],
         segment: "before",
         title: "Set up welcome table",
@@ -744,6 +827,7 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     mockAuthorQueries([
       {
         _id: "task-1",
+        teamIds: ["team-1"],
         roleIds: ["role-greeter"],
         segment: "before",
         title: "Set up welcome table",
@@ -765,6 +849,7 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     mockAuthorQueries([
       {
         _id: "task-1",
+        teamIds: ["team-1"],
         roleIds: ["role-greeter"],
         segment: "before",
         title: "Set up welcome table",

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -404,6 +404,48 @@ describe("ServingTasksScreen — Shared discoverability from an empty Mine", () 
     expect(getByText("Set the thermostat")).toBeTruthy();
   });
 
+  // `getSharedTeamTasks` was the one fact defaulted to 0 rather than treated as
+  // unloaded, so the notice rendered a confident (wrong) shared hint and no
+  // jump, which then popped in. Offline it never corrected itself at all: the
+  // stale-cache read returns null when that section was never cached.
+  it("says nothing until the shared count has resolved, rather than assuming zero", () => {
+    mockQuery.mockImplementation((ref: string) => {
+      if (ref === REF.mine) return EMPTY_MINE;
+      if (ref === REF.eligibility) return { plans: DEFAULT_PLANS };
+      if (ref === REF.allTeams) return [allTeamsRow(["task-1", "task-2"])];
+      if (ref === REF.crew) return [myCrewRow("Greeter")];
+      if (ref === REF.shared) return undefined; // unresolved
+      return undefined;
+    });
+    const { queryByText, queryByLabelText, getAllByText } = render(
+      <ServingTasksScreen />,
+    );
+
+    expect(queryByText(/Check All teams/)).toBeNull();
+    expect(queryByLabelText("Open the Shared tab")).toBeNull();
+    expect(queryByText(/none are assigned to your role/)).toBeNull();
+    // The per-segment empty cards stay visible while we can't say anything.
+    expect(getAllByText("Nothing here yet.")).toHaveLength(3);
+  });
+
+  // A stale-cache mix (an empty all-teams snapshot next to a cached shared
+  // list) used to render "This event has no tasks set up yet." directly above
+  // "Open Shared (2)" — two statements that contradict each other.
+  it("never puts an Open Shared jump under 'this event has no tasks set up yet'", () => {
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
+      allTeams: [],
+      crew: [myCrewRow("Greeter")],
+      shared: [
+        sharedRow("task-1", "Unlock the building"),
+        sharedRow("task-2", "Set the thermostat"),
+      ],
+    });
+    const { getByText, queryByLabelText } = render(<ServingTasksScreen />);
+
+    expect(getByText(NO_PLAN_TASKS_MESSAGE)).toBeTruthy();
+    expect(queryByLabelText("Open the Shared tab")).toBeNull();
+  });
+
   it("offers no Shared jump when the team has no shared tasks", () => {
     mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
       allTeams: [allTeamsRow(["task-1"])],

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -14,6 +14,7 @@ const REF = {
   listPlanTasks: "api.functions.scheduling.eventTasks.listPlanTasks",
   listTeams: "api.functions.scheduling.teams.listTeams",
   listRoles: "api.functions.scheduling.roles.listRoles",
+  listTaskTemplates: "api.functions.scheduling.taskTemplates.listTaskTemplates",
 };
 
 jest.mock("@services/api/convex", () => ({
@@ -49,6 +50,12 @@ jest.mock("@services/api/convex", () => ({
         },
         roles: {
           listRoles: "api.functions.scheduling.roles.listRoles",
+        },
+        taskTemplates: {
+          listTaskTemplates: "api.functions.scheduling.taskTemplates.listTaskTemplates",
+        },
+        planTemplates: {
+          setPlanTaskTemplate: "setPlanTaskTemplate",
         },
       },
     },
@@ -179,7 +186,70 @@ const DEFAULT_PLANS: EligiblePlan[] = [
   { planId: "plan-1", title: "Sunday Gathering", startsAt: 0 },
 ];
 
-function mockQueries(mine: unknown, plans: EligiblePlan[] = DEFAULT_PLANS) {
+/** An `getAllTeamsTasks` row. Only `tasks[].taskId` is read for the count. */
+function allTeamsRow(taskIds: string[], teamId = "team-1") {
+  return {
+    teamId,
+    teamName: "Hospitality",
+    taskCount: taskIds.length,
+    done: 0,
+    total: taskIds.length,
+    tasks: taskIds.map((taskId) => ({
+      taskId,
+      title: taskId,
+      segment: "before",
+      roleNames: [],
+      completed: false,
+      howToType: "none",
+    })),
+  };
+}
+
+/** A `getCrewTasks` row for the viewer themself (they hold `roleName`). */
+function myCrewRow(roleName: string) {
+  return {
+    userId: "user-1",
+    name: "Alex",
+    roleId: `role-${roleName}`,
+    roleName,
+    teamId: "team-1",
+    teamName: "Hospitality",
+    isCurrentUser: true,
+    status: "confirmed",
+    done: 0,
+    total: 0,
+    tasks: [],
+  };
+}
+
+/** A `getSharedTeamTasks` row (team-level task, Shared pill only). */
+function sharedRow(taskId: string, title: string) {
+  return {
+    taskId,
+    teamIds: ["team-1"],
+    teamNames: ["Hospitality"],
+    title,
+    segment: "before",
+    howToType: "none",
+    completed: false,
+  };
+}
+
+/**
+ * The empty-state discrimination needs more than "Mine" to tell its four
+ * states apart, so the shared/crew/all-teams results are overridable.
+ * Defaulting them all to `[]` reproduces the plan-has-no-tasks-at-all case.
+ */
+function mockQueries(
+  mine: unknown,
+  plans: EligiblePlan[] = DEFAULT_PLANS,
+  extra: {
+    shared?: unknown;
+    crew?: unknown;
+    allTeams?: unknown;
+    taskTemplates?: unknown;
+  } = {},
+) {
   mockQuery.mockImplementation((ref: string) => {
     switch (ref) {
       case REF.mine:
@@ -187,53 +257,246 @@ function mockQueries(mine: unknown, plans: EligiblePlan[] = DEFAULT_PLANS) {
       case REF.eligibility:
         return { plans };
       case REF.shared:
+        return extra.shared ?? [];
       case REF.crew:
+        return extra.crew ?? [];
       case REF.allTeams:
-        return [];
+        return extra.allTeams ?? [];
+      case REF.listTaskTemplates:
+        return extra.taskTemplates ?? [];
       default:
         return undefined;
     }
   });
 }
 
-const NO_PRELOAD_MESSAGE =
-  "No preloaded task. Please contact your team lead to add tasks.";
+const NO_PLAN_TASKS_MESSAGE = "This event has no tasks set up yet.";
+const NOT_ROSTERED_MESSAGE = "You're not on the roster for this event.";
 
-describe("ServingTasksScreen — no preloaded tasks", () => {
+/**
+ * The "Mine" tab's diagnostic empty state. One generic sentence ("No preloaded
+ * task. Please contact your team lead to add tasks.") used to cover three
+ * unrelated causes; these pin that each now gets its own honest message. The
+ * discrimination itself is unit-tested in
+ * `utils/__tests__/servingTaskEmptyState.test.ts` — these cover the wiring.
+ */
+describe("ServingTasksScreen — diagnostic empty state (Mine)", () => {
   beforeEach(() => {
     mockIsServingMode = true;
   });
   afterEach(() => jest.clearAllMocks());
 
-  it("shows the no-preloaded-task notice when the role has no template tasks", () => {
+  it("says the EVENT has no tasks when the plan has zero task rows", () => {
     mockQueries(EMPTY_MINE);
     const { getByText, queryByText, getAllByText } = render(<ServingTasksScreen />);
 
-    // The exact guidance message is shown.
-    expect(getByText(NO_PRELOAD_MESSAGE)).toBeTruthy();
+    expect(getByText(NO_PLAN_TASKS_MESSAGE)).toBeTruthy();
+    // It must NOT imply tasks exist and are misconfigured.
+    expect(queryByText(/contact your team lead/i)).toBeNull();
     // The generic per-segment empty text is suppressed in this state.
     expect(queryByText("Nothing here yet.")).toBeNull();
     // Users can still add their own tasks in every segment.
     expect(getAllByText("Add my own task")).toHaveLength(3);
   });
 
-  it("still shows the notice when only personal (user-added) tasks exist", () => {
+  it("still explains the empty state when only personal tasks exist", () => {
     mockQueries({ before: [personalTask()], during: [], after: [] });
     const { getByText } = render(<ServingTasksScreen />);
 
-    expect(getByText(NO_PRELOAD_MESSAGE)).toBeTruthy();
+    expect(getByText(NO_PLAN_TASKS_MESSAGE)).toBeTruthy();
     // The personal task is still rendered.
     expect(getByText("Bring water bottle")).toBeTruthy();
+  });
+
+  it("names the rostering gap when the viewer holds no role on the plan", () => {
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
+      allTeams: [allTeamsRow(["task-1", "task-2"])],
+      crew: [], // no non-declined assignment => getCrewTasks short-circuits
+    });
+    const { getByText } = render(<ServingTasksScreen />);
+
+    expect(getByText(NOT_ROSTERED_MESSAGE)).toBeTruthy();
+    expect(getByText(/The event has 2 tasks/)).toBeTruthy();
+  });
+
+  it("quotes the task count and the viewer's actual roles on a role mismatch", () => {
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
+      allTeams: [allTeamsRow(["task-1", "task-2", "task-3"])],
+      crew: [myCrewRow("Greeter"), myCrewRow("Usher")],
+    });
+    const { getByText } = render(<ServingTasksScreen />);
+
+    expect(
+      getByText("This event has 3 tasks, but none are assigned to your roles."),
+    ).toBeTruthy();
+    expect(getByText(/You're serving as Greeter and Usher\./)).toBeTruthy();
+  });
+
+  it("shows nothing until the plan-wide data has loaded, rather than guessing", () => {
+    // `getAllTeamsTasks` unresolved: no honest statement is possible yet.
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, { allTeams: undefined });
+    mockQuery.mockImplementation((ref: string) => {
+      if (ref === REF.mine) return EMPTY_MINE;
+      if (ref === REF.eligibility) return { plans: DEFAULT_PLANS };
+      if (ref === REF.crew || ref === REF.shared) return [];
+      return undefined;
+    });
+    const { queryByText, getAllByText } = render(<ServingTasksScreen />);
+
+    expect(queryByText(NO_PLAN_TASKS_MESSAGE)).toBeNull();
+    expect(queryByText(NOT_ROSTERED_MESSAGE)).toBeNull();
+    // The per-segment empty cards stay visible while we can't say anything.
+    expect(getAllByText("Nothing here yet.")).toHaveLength(3);
   });
 
   it("hides the notice when the role has preloaded (template) tasks", () => {
     mockQueries({ before: [templateTask()], during: [], after: [] });
     const { queryByText, getByText, getAllByText } = render(<ServingTasksScreen />);
 
-    expect(queryByText(NO_PRELOAD_MESSAGE)).toBeNull();
+    expect(queryByText(NO_PLAN_TASKS_MESSAGE)).toBeNull();
     expect(getByText("Set up chairs")).toBeTruthy();
     // The other (empty) segments fall back to the generic empty text.
     expect(getAllByText("Nothing here yet.")).toHaveLength(2);
+  });
+});
+
+/**
+ * "Mine" omits team-level tasks by design (`getMyServingTasks` skips them) and
+ * the screen opens on "Mine" — so a team whose tasks are ALL team-level saw an
+ * empty tab with no hint that "Shared" held everything. The notice now says so
+ * and jumps there in one tap.
+ */
+describe("ServingTasksScreen — Shared discoverability from an empty Mine", () => {
+  beforeEach(() => {
+    mockIsServingMode = true;
+  });
+  afterEach(() => jest.clearAllMocks());
+
+  it("advertises Shared and jumps to it when Mine is empty but Shared has tasks", () => {
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
+      allTeams: [allTeamsRow(["task-1", "task-2"])],
+      crew: [myCrewRow("Greeter")],
+      shared: [
+        sharedRow("task-1", "Unlock the building"),
+        sharedRow("task-2", "Set the thermostat"),
+      ],
+    });
+    const { getByText, getByLabelText } = render(<ServingTasksScreen />);
+
+    expect(getByText(/Shared has 2 tasks for your whole team\./)).toBeTruthy();
+
+    fireEvent.press(getByLabelText("Open the Shared tab"));
+
+    // The Shared section is now showing its tasks.
+    expect(getByText("Unlock the building")).toBeTruthy();
+    expect(getByText("Set the thermostat")).toBeTruthy();
+  });
+
+  it("offers no Shared jump when the team has no shared tasks", () => {
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
+      allTeams: [allTeamsRow(["task-1"])],
+      crew: [myCrewRow("Greeter")],
+      shared: [],
+    });
+    const { queryByLabelText, getByText } = render(<ServingTasksScreen />);
+
+    expect(queryByLabelText("Open the Shared tab")).toBeNull();
+    expect(getByText(/Check All teams/)).toBeTruthy();
+  });
+});
+
+/**
+ * A plan created by `createEventDraftImpl` has no tasks and nothing backfills
+ * it — tasks only appear when someone links a task template from the rostering
+ * grid. This lets a leader do that from serving mode, via the SAME existing
+ * `setPlanTaskTemplate` mutation.
+ */
+describe("ServingTasksScreen — leader affordance on a task-less plan", () => {
+  const mockSetPlanTaskTemplate = jest.fn().mockResolvedValue({});
+
+  beforeEach(() => {
+    mockIsServingMode = true;
+    mockMutation.mockImplementation((ref: string) =>
+      ref === "setPlanTaskTemplate" ? mockSetPlanTaskTemplate : jest.fn(),
+    );
+  });
+  afterEach(() => {
+    mockUser = { is_admin: false };
+    mockIsEffectivelyOffline = false;
+    mockMutation.mockImplementation(() => jest.fn());
+    jest.clearAllMocks();
+  });
+
+  const TEMPLATES = [
+    { _id: "tmpl-1", name: "Sunday Production", itemCount: 12 },
+    { _id: "tmpl-2", name: "Midweek", itemCount: 1 },
+    { _id: "tmpl-empty", name: "Draft", itemCount: 0 },
+  ];
+
+  it("links a saved task template via the existing setPlanTaskTemplate", async () => {
+    mockUser = { is_admin: true };
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, { taskTemplates: TEMPLATES });
+    const { getByText, getByLabelText } = render(<ServingTasksScreen />);
+
+    expect(getByText("Sunday Production · 12 tasks")).toBeTruthy();
+    // A template with no items would link cleanly and still leave the plan
+    // empty, so it isn't offered.
+    expect(getByText("Midweek · 1 task")).toBeTruthy();
+
+    await fireEvent.press(getByLabelText("Add tasks from Sunday Production"));
+
+    expect(mockSetPlanTaskTemplate).toHaveBeenCalledWith({
+      planId: "plan-1",
+      templateId: "tmpl-1",
+    });
+  });
+
+  it("omits an item-less template rather than offering a no-op", () => {
+    mockUser = { is_admin: true };
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, { taskTemplates: TEMPLATES });
+    const { queryByLabelText } = render(<ServingTasksScreen />);
+
+    expect(queryByLabelText("Add tasks from Draft")).toBeNull();
+  });
+
+  it("points at the manual path instead of dead-ending when there are no templates", () => {
+    mockUser = { is_admin: true };
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, { taskTemplates: [] });
+    const { getByText } = render(<ServingTasksScreen />);
+
+    expect(getByText(/no saved task lists yet/)).toBeTruthy();
+    expect(getByText(/Use the Edit tab above/)).toBeTruthy();
+  });
+
+  it("hides the affordance from a non-leader", () => {
+    mockUser = { is_admin: false };
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, { taskTemplates: TEMPLATES });
+    const { queryByLabelText, getByText } = render(<ServingTasksScreen />);
+
+    expect(queryByLabelText("Add tasks from Sunday Production")).toBeNull();
+    // …but the diagnosis itself is still shown.
+    expect(getByText(NO_PLAN_TASKS_MESSAGE)).toBeTruthy();
+  });
+
+  it("hides the affordance offline (a plan-wide write with no dedupe key)", () => {
+    mockUser = { is_admin: true };
+    mockIsEffectivelyOffline = true;
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, { taskTemplates: TEMPLATES });
+    const { queryByLabelText } = render(<ServingTasksScreen />);
+
+    expect(queryByLabelText("Add tasks from Sunday Production")).toBeNull();
+  });
+
+  it("is not offered when the plan already has tasks", () => {
+    mockUser = { is_admin: true };
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
+      allTeams: [allTeamsRow(["task-1"])],
+      crew: [myCrewRow("Greeter")],
+      taskTemplates: TEMPLATES,
+    });
+    const { queryByLabelText } = render(<ServingTasksScreen />);
+
+    expect(queryByLabelText("Add tasks from Sunday Production")).toBeNull();
   });
 });
 
@@ -325,6 +588,10 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
           return AUTHOR_ROLES;
         case REF.listPlanTasks:
           return planTasks;
+        case REF.listTaskTemplates:
+          // These tests are about the Edit surface, not the empty-state
+          // template affordance — leave the group with no saved templates.
+          return [];
         default:
           return undefined;
       }
@@ -658,7 +925,7 @@ describe("ServingTasksScreen — whatsapp-shell skin", () => {
     mockQueries({ before: [personalTask()], during: [], after: [] });
     const { getByText, getAllByText } = render(<ServingTasksScreen />);
 
-    expect(getByText(NO_PRELOAD_MESSAGE)).toBeTruthy();
+    expect(getByText(NO_PLAN_TASKS_MESSAGE)).toBeTruthy();
     expect(getByText("Bring water bottle")).toBeTruthy();
     expect(getAllByText("Add my own task")).toHaveLength(3);
     expect(getByText("Mine")).toBeTruthy();

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -15,6 +15,7 @@ const REF = {
   listTeams: "api.functions.scheduling.teams.listTeams",
   listRoles: "api.functions.scheduling.roles.listRoles",
   listTaskTemplates: "api.functions.scheduling.taskTemplates.listTaskTemplates",
+  templateState: "api.functions.scheduling.planTemplates.getPlanTemplateState",
 };
 
 jest.mock("@services/api/convex", () => ({
@@ -56,6 +57,8 @@ jest.mock("@services/api/convex", () => ({
         },
         planTemplates: {
           setPlanTaskTemplate: "setPlanTaskTemplate",
+          getPlanTemplateState:
+            "api.functions.scheduling.planTemplates.getPlanTemplateState",
         },
       },
     },
@@ -248,6 +251,7 @@ function mockQueries(
     crew?: unknown;
     allTeams?: unknown;
     taskTemplates?: unknown;
+    templateState?: unknown;
   } = {},
 ) {
   mockQuery.mockImplementation((ref: string) => {
@@ -264,11 +268,19 @@ function mockQueries(
         return extra.allTeams ?? [];
       case REF.listTaskTemplates:
         return extra.taskTemplates ?? [];
+      case REF.templateState:
+        // Upcoming plan by default — a PAST plan can't be re-linked at all.
+        return extra.templateState ?? UPCOMING_PLAN;
       default:
         return undefined;
     }
   });
 }
+
+/** `getPlanTemplateState` — only `isPast` is read here. Hoisted for reference
+ *  stability across renders (see `AUTHOR_TEAMS` below for why that matters). */
+const UPCOMING_PLAN = { isPast: false };
+const PAST_PLAN = { isPast: true };
 
 const NO_PLAN_TASKS_MESSAGE = "This event has no tasks set up yet.";
 const NOT_ROSTERED_MESSAGE = "You're not on the roster for this event.";
@@ -487,6 +499,40 @@ describe("ServingTasksScreen — leader affordance on a task-less plan", () => {
     expect(getByText(/Use the Edit tab above/)).toBeTruthy();
   });
 
+  // `setPlanTaskTemplate` throws "Past events are frozen and cannot be
+  // re-linked." once `plan.eventDate` has passed — and `eventDate` is the FIRST
+  // SERVICE's start time, not a day bucket, while serving mode stays open until
+  // 4h after the last service. So for a 9:00 service every one of these rows
+  // failed with a raw ConvexError for the whole 09:00–13:00 at-the-venue window
+  // this affordance exists for. `createTask` has no such freeze, so the Edit tab
+  // really is the way through — say so instead of offering a guaranteed error.
+  it("offers the Edit tab instead of a guaranteed failure once the event has started", () => {
+    mockUser = { is_admin: true };
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
+      taskTemplates: TEMPLATES,
+      templateState: PAST_PLAN,
+    });
+    const { queryByLabelText, queryByText, getByText } = render(
+      <ServingTasksScreen />,
+    );
+
+    expect(queryByLabelText("Add tasks from Sunday Production")).toBeNull();
+    expect(queryByText("Sunday Production · 12 tasks")).toBeNull();
+    expect(getByText(/already started/)).toBeTruthy();
+    expect(getByText(/Use the Edit tab above/)).toBeTruthy();
+  });
+
+  it("still offers the templates while the event is upcoming", () => {
+    mockUser = { is_admin: true };
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
+      taskTemplates: TEMPLATES,
+      templateState: UPCOMING_PLAN,
+    });
+    const { getByLabelText } = render(<ServingTasksScreen />);
+
+    expect(getByLabelText("Add tasks from Sunday Production")).toBeTruthy();
+  });
+
   it("hides the affordance from a non-leader", () => {
     mockUser = { is_admin: false };
     mockQueries(EMPTY_MINE, DEFAULT_PLANS, { taskTemplates: TEMPLATES });
@@ -625,6 +671,8 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
           // These tests are about the Edit surface, not the empty-state
           // template affordance — leave the group with no saved templates.
           return [];
+        case REF.templateState:
+          return UPCOMING_PLAN;
         default:
           return undefined;
       }

--- a/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
@@ -141,25 +141,35 @@ describe("mineEmptyCopy", () => {
     expect(copy.hint).toContain("add your own tasks below");
   });
 
-  it("not-rostered names the rostering gap and quotes the plan's task count", () => {
+  // This state is essentially only reachable when the viewer's assignment is
+  // REMOVED or DECLINED while the screen is open — so "ask your team lead to
+  // add you to the roster" was wrong for whoever had just declined it.
+  it("not-rostered names both ways the assignment can vanish, and neither wrongly", () => {
     const copy = mineEmptyCopy(
       "not-rostered",
       facts({ planTaskCount: 7, myRoleNames: [] }),
     )!;
     expect(copy.title).toBe("You're not on the roster for this event.");
-    expect(copy.hint).toContain("7 tasks");
-    expect(copy.hint).toContain("add you to the roster");
+    expect(copy.hint).toContain("your assignment was removed, or you declined it");
+    expect(copy.hint).toContain("check with your team lead");
+    expect(copy.hint).not.toContain("add you to the roster");
   });
 
-  it("role-mismatch quotes the task count and names the roles actually held", () => {
+  // `planTaskCount` is PLAN-wide across every team, so leading the headline
+  // with it read as "5 tasks exist and you were skipped" to a volunteer whose
+  // OWN team authored none — pointing at a non-problem. The count stays (it is
+  // useful) but is explicitly scoped, and the actionable instruction is back.
+  it("role-mismatch scopes the count to all teams and names a next step", () => {
     const copy = mineEmptyCopy(
       "role-mismatch",
       facts({ planTaskCount: 5, myRoleNames: ["Greeter", "Usher"] }),
     )!;
     expect(copy.title).toBe(
-      "This event has 5 tasks, but none are assigned to your roles.",
+      "None of this event's tasks are assigned to your roles.",
     );
     expect(copy.hint).toContain("You're serving as Greeter and Usher.");
+    expect(copy.hint).toContain("Its 5 tasks — across all teams — are for other roles.");
+    expect(copy.hint).toContain("Ask your team lead to add tasks for your roles.");
   });
 
   it("role-mismatch uses the singular for one task and one role", () => {
@@ -168,9 +178,11 @@ describe("mineEmptyCopy", () => {
       facts({ planTaskCount: 1, myRoleNames: ["Greeter"] }),
     )!;
     expect(copy.title).toBe(
-      "This event has 1 task, but none are assigned to your role.",
+      "None of this event's tasks are assigned to your role.",
     );
     expect(copy.hint).toContain("You're serving as Greeter.");
+    expect(copy.hint).toContain("Its 1 task — across all teams — is for other roles.");
+    expect(copy.hint).toContain("Ask your team lead to add tasks for your role.");
   });
 
   it("role-mismatch points at Shared when the team has shared tasks", () => {

--- a/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
@@ -1,0 +1,181 @@
+import {
+  diagnoseMineEmpty,
+  mineEmptyCopy,
+  myRoleNamesFromCrew,
+  planTaskCountFromAllTeams,
+  type MineEmptyFacts,
+} from "../servingTaskEmptyState";
+
+/** Loaded, rostered, task-bearing baseline; each test overrides one fact. */
+function facts(overrides: Partial<MineEmptyFacts> = {}): MineEmptyFacts {
+  return {
+    planTaskCount: 4,
+    myRoleNames: ["Greeter"],
+    myTemplateTaskCount: 0,
+    sharedTaskCount: 0,
+    ...overrides,
+  };
+}
+
+describe("planTaskCountFromAllTeams", () => {
+  it("returns null while the query is unresolved", () => {
+    expect(planTaskCountFromAllTeams(undefined)).toBeNull();
+  });
+
+  it("returns 0 for a plan with no teams and no tasks", () => {
+    expect(planTaskCountFromAllTeams([])).toBe(0);
+    expect(planTaskCountFromAllTeams([{ tasks: [] }])).toBe(0);
+  });
+
+  it("counts a multi-team task ONCE (rows are per team, not per task)", () => {
+    // `getAllTeamsTasks` lists a task under every team it spans, so summing
+    // each team's `taskCount` would over-count. Distinct taskIds is the truth.
+    const count = planTaskCountFromAllTeams([
+      { tasks: [{ taskId: "t1" }, { taskId: "t2" }] },
+      { tasks: [{ taskId: "t1" }, { taskId: "t3" }] },
+    ]);
+    expect(count).toBe(3);
+  });
+});
+
+describe("myRoleNamesFromCrew", () => {
+  it("returns null while the query is unresolved", () => {
+    expect(myRoleNamesFromCrew(undefined)).toBeNull();
+  });
+
+  it("returns [] when the viewer holds no non-declined assignment", () => {
+    // `getCrewTasks` short-circuits to [] in exactly that case.
+    expect(myRoleNamesFromCrew([])).toEqual([]);
+  });
+
+  it("keeps only the viewer's own rows, de-duplicated, in order", () => {
+    const names = myRoleNamesFromCrew([
+      { isCurrentUser: true, roleName: "Greeter" },
+      { isCurrentUser: false, roleName: "Camera 1" },
+      { isCurrentUser: true, roleName: "Usher" },
+      { isCurrentUser: true, roleName: "Greeter" },
+    ]);
+    expect(names).toEqual(["Greeter", "Usher"]);
+  });
+});
+
+describe("diagnoseMineEmpty", () => {
+  it("has-tasks: the viewer has preloaded tasks, so nothing is explained", () => {
+    expect(diagnoseMineEmpty(facts({ myTemplateTaskCount: 2 }))).toBe(
+      "has-tasks",
+    );
+  });
+
+  it("has-tasks wins even before the other queries resolve", () => {
+    expect(
+      diagnoseMineEmpty(
+        facts({ myTemplateTaskCount: 1, planTaskCount: null, myRoleNames: null }),
+      ),
+    ).toBe("has-tasks");
+  });
+
+  it("loading: refuses to guess while the plan-wide count is unresolved", () => {
+    expect(diagnoseMineEmpty(facts({ planTaskCount: null }))).toBe("loading");
+  });
+
+  it("loading: refuses to guess while the viewer's roles are unresolved", () => {
+    expect(diagnoseMineEmpty(facts({ myRoleNames: null }))).toBe("loading");
+  });
+
+  it("no-plan-tasks: the plan has zero eventTasks rows", () => {
+    expect(diagnoseMineEmpty(facts({ planTaskCount: 0 }))).toBe(
+      "no-plan-tasks",
+    );
+  });
+
+  it("no-plan-tasks outranks not-rostered when both are true", () => {
+    // A freshly created plan is BOTH empty and (often) unrostered. The empty
+    // task list is the root cause: fixing the roster would change nothing.
+    expect(
+      diagnoseMineEmpty(facts({ planTaskCount: 0, myRoleNames: [] })),
+    ).toBe("no-plan-tasks");
+  });
+
+  it("not-rostered: tasks exist but the viewer holds no role on the plan", () => {
+    expect(diagnoseMineEmpty(facts({ myRoleNames: [] }))).toBe("not-rostered");
+  });
+
+  it("role-mismatch: tasks exist, the viewer has roles, none match", () => {
+    expect(diagnoseMineEmpty(facts())).toBe("role-mismatch");
+  });
+
+  it("role-mismatch covers the team-level-only plan (all tasks on Shared)", () => {
+    // Every task is team-level, so `getMyServingTasks` returns none while
+    // `getSharedTeamTasks` returns them all.
+    expect(
+      diagnoseMineEmpty(facts({ planTaskCount: 3, sharedTaskCount: 3 })),
+    ).toBe("role-mismatch");
+  });
+});
+
+describe("mineEmptyCopy", () => {
+  it("renders no notice for has-tasks or loading", () => {
+    expect(mineEmptyCopy("has-tasks", facts())).toBeNull();
+    expect(mineEmptyCopy("loading", facts())).toBeNull();
+  });
+
+  it("no-plan-tasks does NOT blame the team lead's configuration", () => {
+    const copy = mineEmptyCopy("no-plan-tasks", facts({ planTaskCount: 0 }))!;
+    expect(copy.title).toBe("This event has no tasks set up yet.");
+    expect(copy.hint).toContain("Nobody has added tasks to it");
+    expect(copy.hint).toContain("add your own tasks below");
+  });
+
+  it("not-rostered names the rostering gap and quotes the plan's task count", () => {
+    const copy = mineEmptyCopy(
+      "not-rostered",
+      facts({ planTaskCount: 7, myRoleNames: [] }),
+    )!;
+    expect(copy.title).toBe("You're not on the roster for this event.");
+    expect(copy.hint).toContain("7 tasks");
+    expect(copy.hint).toContain("add you to the roster");
+  });
+
+  it("role-mismatch quotes the task count and names the roles actually held", () => {
+    const copy = mineEmptyCopy(
+      "role-mismatch",
+      facts({ planTaskCount: 5, myRoleNames: ["Greeter", "Usher"] }),
+    )!;
+    expect(copy.title).toBe(
+      "This event has 5 tasks, but none are assigned to your roles.",
+    );
+    expect(copy.hint).toContain("You're serving as Greeter and Usher.");
+  });
+
+  it("role-mismatch uses the singular for one task and one role", () => {
+    const copy = mineEmptyCopy(
+      "role-mismatch",
+      facts({ planTaskCount: 1, myRoleNames: ["Greeter"] }),
+    )!;
+    expect(copy.title).toBe(
+      "This event has 1 task, but none are assigned to your role.",
+    );
+    expect(copy.hint).toContain("You're serving as Greeter.");
+  });
+
+  it("role-mismatch points at Shared when the team has shared tasks", () => {
+    const copy = mineEmptyCopy(
+      "role-mismatch",
+      facts({ planTaskCount: 5, sharedTaskCount: 3 }),
+    )!;
+    expect(copy.hint).toContain("Shared has 3 tasks for your whole team.");
+  });
+
+  it("role-mismatch points at All teams when there are no shared tasks", () => {
+    const copy = mineEmptyCopy("role-mismatch", facts({ sharedTaskCount: 0 }))!;
+    expect(copy.hint).toContain("Check All teams");
+  });
+
+  it("lists three or more roles with commas and a trailing 'and'", () => {
+    const copy = mineEmptyCopy(
+      "role-mismatch",
+      facts({ myRoleNames: ["Camera 1", "Greeter", "Usher"] }),
+    )!;
+    expect(copy.hint).toContain("You're serving as Camera 1, Greeter and Usher.");
+  });
+});

--- a/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
@@ -3,6 +3,7 @@ import {
   mineEmptyCopy,
   myRoleNamesFromCrew,
   planTaskCountFromAllTeams,
+  shouldOfferSharedJump,
   type MineEmptyFacts,
 } from "../servingTaskEmptyState";
 
@@ -80,6 +81,20 @@ describe("diagnoseMineEmpty", () => {
 
   it("loading: refuses to guess while the viewer's roles are unresolved", () => {
     expect(diagnoseMineEmpty(facts({ myRoleNames: null }))).toBe("loading");
+  });
+
+  // Shared was the one fact defaulted to 0 instead of treated as unloaded, so a
+  // `role-mismatch` viewer whose team DOES have shared tasks got the wrong hint
+  // and no "Open Shared" button — popping in on first paint, and (offline, with
+  // that section never cached) staying wrong for the whole session.
+  it("loading: refuses to guess while the shared count is unresolved", () => {
+    expect(diagnoseMineEmpty(facts({ sharedTaskCount: null }))).toBe("loading");
+  });
+
+  it("has-tasks still wins over an unresolved shared count", () => {
+    expect(
+      diagnoseMineEmpty(facts({ myTemplateTaskCount: 1, sharedTaskCount: null })),
+    ).toBe("has-tasks");
   });
 
   it("no-plan-tasks: the plan has zero eventTasks rows", () => {
@@ -177,5 +192,66 @@ describe("mineEmptyCopy", () => {
       facts({ myRoleNames: ["Camera 1", "Greeter", "Usher"] }),
     )!;
     expect(copy.hint).toContain("You're serving as Camera 1, Greeter and Usher.");
+  });
+
+  it("says nothing at all about Shared while its count is unresolved", () => {
+    const copy = mineEmptyCopy(
+      "role-mismatch",
+      facts({ sharedTaskCount: null }),
+    )!;
+    expect(copy.hint).not.toContain("Shared");
+    expect(copy.hint).not.toContain("All teams");
+  });
+});
+
+/**
+ * The jump is a POINTER, so it must only appear where Shared is a real answer.
+ * Offering it on `no-plan-tasks` let a stale-cache mix render "This event has no
+ * tasks set up yet." directly above "Open Shared (2)".
+ */
+describe("shouldOfferSharedJump", () => {
+  it("offers the jump on a role mismatch with shared tasks", () => {
+    expect(
+      shouldOfferSharedJump("role-mismatch", facts({ sharedTaskCount: 2 })),
+    ).toBe(true);
+  });
+
+  it("offers the jump to an unrostered viewer with shared tasks", () => {
+    expect(
+      shouldOfferSharedJump(
+        "not-rostered",
+        facts({ myRoleNames: [], sharedTaskCount: 2 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("NEVER offers it alongside 'this event has no tasks set up yet'", () => {
+    expect(
+      shouldOfferSharedJump(
+        "no-plan-tasks",
+        facts({ planTaskCount: 0, sharedTaskCount: 2 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("withholds it while the shared count is unresolved", () => {
+    expect(
+      shouldOfferSharedJump("role-mismatch", facts({ sharedTaskCount: null })),
+    ).toBe(false);
+  });
+
+  it("withholds it when the team has no shared tasks", () => {
+    expect(
+      shouldOfferSharedJump("role-mismatch", facts({ sharedTaskCount: 0 })),
+    ).toBe(false);
+  });
+
+  it("renders no jump for the states that render no notice", () => {
+    expect(
+      shouldOfferSharedJump("has-tasks", facts({ sharedTaskCount: 2 })),
+    ).toBe(false);
+    expect(shouldOfferSharedJump("loading", facts({ sharedTaskCount: 2 }))).toBe(
+      false,
+    );
   });
 });

--- a/apps/mobile/features/serving/utils/__tests__/taskAuthoring.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/taskAuthoring.test.ts
@@ -40,24 +40,32 @@ describe("canAuthorPlanTasks", () => {
 });
 
 describe("tasksForRole", () => {
+  const TEAM_1 = { roleId: "role-a", teamId: "team-1" };
+  const TEAM_1_B = { roleId: "role-b", teamId: "team-1" };
+
   const tasks: AuthorableTask[] = [
-    { roleIds: ["role-a"], segment: "before", sortOrder: 1 },
-    { roleIds: ["role-a"], segment: "before", sortOrder: 0 },
-    { roleIds: ["role-a", "role-b"], segment: "during", sortOrder: 0 },
-    { roleIds: ["role-b"], segment: "after", sortOrder: 0 },
-    { roleIds: [], segment: "before", sortOrder: 2 }, // team-level
+    { teamIds: ["team-1"], roleIds: ["role-a"], segment: "before", sortOrder: 1 },
+    { teamIds: ["team-1"], roleIds: ["role-a"], segment: "before", sortOrder: 0 },
+    {
+      teamIds: ["team-1"],
+      roleIds: ["role-a", "role-b"],
+      segment: "during",
+      sortOrder: 0,
+    },
+    { teamIds: ["team-1"], roleIds: ["role-b"], segment: "after", sortOrder: 0 },
+    { teamIds: ["team-1"], roleIds: [], segment: "before", sortOrder: 2 }, // team-level
   ];
 
-  it("returns the selected role's tasks (plus team-level), sorted by sortOrder", () => {
-    const result = tasksForRole(tasks, "role-a");
+  it("returns the selected role's tasks (plus its team's team-level), sorted by sortOrder", () => {
+    const result = tasksForRole(tasks, TEAM_1);
     expect(result.before.map((t) => t.sortOrder)).toEqual([0, 1, 2]);
     expect(result.during).toHaveLength(1);
     expect(result.after).toHaveLength(0);
   });
 
   it("includes a multi-role task under every role it lists", () => {
-    const a = tasksForRole(tasks, "role-a");
-    const b = tasksForRole(tasks, "role-b");
+    const a = tasksForRole(tasks, TEAM_1);
+    const b = tasksForRole(tasks, TEAM_1_B);
     expect(a.during).toHaveLength(1);
     expect(b.during).toHaveLength(1);
     expect(a.during[0]).toBe(b.during[0]);
@@ -67,9 +75,9 @@ describe("tasksForRole", () => {
   // the one place a leader could neither see nor fix them (they're excluded
   // from "Mine" by design and live only under the read-only Shared pill). The
   // UI labels them as whole-team so the role context stays honest.
-  it("includes team-level tasks (empty roleIds) under every role", () => {
-    const a = tasksForRole(tasks, "role-a");
-    const b = tasksForRole(tasks, "role-b");
+  it("includes team-level tasks (empty roleIds) under every role on that team", () => {
+    const a = tasksForRole(tasks, TEAM_1);
+    const b = tasksForRole(tasks, TEAM_1_B);
     expect(a.before.filter(isTeamLevelTask)).toHaveLength(1);
     expect(b.before.filter(isTeamLevelTask)).toHaveLength(1);
   });
@@ -80,21 +88,88 @@ describe("tasksForRole", () => {
   });
 
   it("still surfaces team-level tasks for a role with no tasks of its own", () => {
-    const result = tasksForRole(tasks, "role-nobody");
+    const result = tasksForRole(tasks, { roleId: "role-nobody", teamId: "team-1" });
     expect(result.before).toHaveLength(1);
     expect(result.before[0].roleIds).toEqual([]);
     expect(result.during).toEqual([]);
     expect(result.after).toEqual([]);
   });
+
+  // REGRESSION: `listPlanTasks` is PLAN-wide (every team) and the role catalog
+  // spans every team in the group, so a team-level task used to leak into
+  // another team's Edit list — captioned "Whole team", one tap from Delete.
+  describe("across teams", () => {
+    const multiTeam: AuthorableTask[] = [
+      // Worship's whole-team task.
+      { teamIds: ["team-worship"], roleIds: [], segment: "before", sortOrder: 0 },
+      // Kids' whole-team task.
+      { teamIds: ["team-kids"], roleIds: [], segment: "before", sortOrder: 1 },
+      // A task shared by both teams.
+      {
+        teamIds: ["team-worship", "team-kids"],
+        roleIds: [],
+        segment: "during",
+        sortOrder: 0,
+      },
+    ];
+
+    it("never shows another team's team-level task", () => {
+      const kids = tasksForRole(multiTeam, {
+        roleId: "role-checkin",
+        teamId: "team-kids",
+      });
+      expect(kids.before).toHaveLength(1);
+      expect(kids.before[0].teamIds).toEqual(["team-kids"]);
+
+      const worship = tasksForRole(multiTeam, {
+        roleId: "role-sound",
+        teamId: "team-worship",
+      });
+      expect(worship.before).toHaveLength(1);
+      expect(worship.before[0].teamIds).toEqual(["team-worship"]);
+    });
+
+    it("shows a task spanning both teams to each of them", () => {
+      const kids = tasksForRole(multiTeam, {
+        roleId: "role-checkin",
+        teamId: "team-kids",
+      });
+      const worship = tasksForRole(multiTeam, {
+        roleId: "role-sound",
+        teamId: "team-worship",
+      });
+      expect(kids.during).toHaveLength(1);
+      expect(worship.during).toHaveLength(1);
+      expect(kids.during[0]).toBe(worship.during[0]);
+    });
+
+    it("shows nothing team-level to a team that owns none", () => {
+      const other = tasksForRole(multiTeam, {
+        roleId: "role-usher",
+        teamId: "team-hospitality",
+      });
+      expect(other).toEqual({ before: [], during: [], after: [] });
+    });
+  });
 });
 
 describe("isTeamLevelTask", () => {
   it("is true only when the task names no role", () => {
-    expect(isTeamLevelTask({ roleIds: [], segment: "before", sortOrder: 0 })).toBe(
-      true,
-    );
     expect(
-      isTeamLevelTask({ roleIds: ["role-a"], segment: "before", sortOrder: 0 }),
+      isTeamLevelTask({
+        teamIds: ["team-1"],
+        roleIds: [],
+        segment: "before",
+        sortOrder: 0,
+      }),
+    ).toBe(true);
+    expect(
+      isTeamLevelTask({
+        teamIds: ["team-1"],
+        roleIds: ["role-a"],
+        segment: "before",
+        sortOrder: 0,
+      }),
     ).toBe(false);
   });
 });

--- a/apps/mobile/features/serving/utils/__tests__/taskAuthoring.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/taskAuthoring.test.ts
@@ -1,6 +1,7 @@
 import {
   buildRoleCatalog,
   canAuthorPlanTasks,
+  isTeamLevelTask,
   tasksForRole,
   type AuthorableTask,
 } from "../taskAuthoring";
@@ -47,9 +48,9 @@ describe("tasksForRole", () => {
     { roleIds: [], segment: "before", sortOrder: 2 }, // team-level
   ];
 
-  it("returns only tasks that include the selected role, sorted by sortOrder", () => {
+  it("returns the selected role's tasks (plus team-level), sorted by sortOrder", () => {
     const result = tasksForRole(tasks, "role-a");
-    expect(result.before.map((t) => t.sortOrder)).toEqual([0, 1]);
+    expect(result.before.map((t) => t.sortOrder)).toEqual([0, 1, 2]);
     expect(result.during).toHaveLength(1);
     expect(result.after).toHaveLength(0);
   });
@@ -62,9 +63,15 @@ describe("tasksForRole", () => {
     expect(a.during[0]).toBe(b.during[0]);
   });
 
-  it("excludes team-level tasks (empty roleIds) from every bucket", () => {
-    const result = tasksForRole(tasks, "role-a");
-    expect(result.before.some((t) => t.roleIds.length === 0)).toBe(false);
+  // Team-level tasks used to be filtered out here, which made the Edit surface
+  // the one place a leader could neither see nor fix them (they're excluded
+  // from "Mine" by design and live only under the read-only Shared pill). The
+  // UI labels them as whole-team so the role context stays honest.
+  it("includes team-level tasks (empty roleIds) under every role", () => {
+    const a = tasksForRole(tasks, "role-a");
+    const b = tasksForRole(tasks, "role-b");
+    expect(a.before.filter(isTeamLevelTask)).toHaveLength(1);
+    expect(b.before.filter(isTeamLevelTask)).toHaveLength(1);
   });
 
   it("returns all-empty buckets when no role is selected", () => {
@@ -72,9 +79,23 @@ describe("tasksForRole", () => {
     expect(result).toEqual({ before: [], during: [], after: [] });
   });
 
-  it("returns all-empty buckets for a role with no tasks", () => {
+  it("still surfaces team-level tasks for a role with no tasks of its own", () => {
     const result = tasksForRole(tasks, "role-nobody");
-    expect(result).toEqual({ before: [], during: [], after: [] });
+    expect(result.before).toHaveLength(1);
+    expect(result.before[0].roleIds).toEqual([]);
+    expect(result.during).toEqual([]);
+    expect(result.after).toEqual([]);
+  });
+});
+
+describe("isTeamLevelTask", () => {
+  it("is true only when the task names no role", () => {
+    expect(isTeamLevelTask({ roleIds: [], segment: "before", sortOrder: 0 })).toBe(
+      true,
+    );
+    expect(
+      isTeamLevelTask({ roleIds: ["role-a"], segment: "before", sortOrder: 0 }),
+    ).toBe(false);
   });
 });
 

--- a/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
+++ b/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
@@ -193,18 +193,39 @@ export function mineEmptyCopy(
         hint: "Nobody has added tasks to it, so there's nothing to show for any role. You can still add your own tasks below.",
       };
 
+    // Reachable essentially only when the viewer's assignment is REMOVED or
+    // DECLINED while this screen is open (serving eligibility is what put them
+    // here in the first place). "Ask your team lead to add you to the roster"
+    // was wrong for the second case — telling someone who has just declined to
+    // ask to be re-added. This wording is true either way.
     case "not-rostered":
       return {
         title: "You're not on the roster for this event.",
-        hint: `The event has ${pluralTasks(facts.planTaskCount ?? 0)}, but tasks follow roles and you don't hold one here. Ask your team lead to add you to the roster.`,
+        hint: "Tasks follow roles, and you don't hold one here — your assignment was removed, or you declined it. If that's not right, check with your team lead.",
       };
 
     case "role-mismatch": {
       const roles = facts.myRoleNames ?? [];
       const roleWord = roles.length === 1 ? "role" : "roles";
+      // `planTaskCount` is PLAN-wide, across every team. Leading with it read as
+      // "20 tasks exist and you were skipped" — for a Kids volunteer on a plan
+      // where Worship authored all 20 and Kids authored none, that points at a
+      // non-problem. Say "across all teams" out loud instead, and restore the
+      // one actionable instruction the old single-message copy had.
+      const planWide =
+        facts.planTaskCount === null
+          ? null
+          : `Its ${pluralTasks(facts.planTaskCount)} — across all teams — ${
+              facts.planTaskCount === 1 ? "is" : "are"
+            } for other roles.`;
       return {
-        title: `This event has ${pluralTasks(facts.planTaskCount ?? 0)}, but none are assigned to your ${roleWord}.`,
-        hint: [`You're serving as ${formatRoleList(roles)}.`, sharedHint]
+        title: `None of this event's tasks are assigned to your ${roleWord}.`,
+        hint: [
+          `You're serving as ${formatRoleList(roles)}.`,
+          planWide,
+          `Ask your team lead to add tasks for your ${roleWord}.`,
+          sharedHint,
+        ]
           .filter(Boolean)
           .join(" "),
       };

--- a/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
+++ b/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
@@ -56,8 +56,17 @@ export interface MineEmptyFacts {
   myRoleNames: string[] | null;
   /** Preloaded (non-personal) tasks in the viewer's own "Mine" list. */
   myTemplateTaskCount: number;
-  /** Team-level tasks the viewer can see on the "Shared" tab. */
-  sharedTaskCount: number;
+  /**
+   * Team-level tasks the viewer can see on the "Shared" tab.
+   *
+   * Nullable for the same reason the two above are: `getSharedTeamTasks` is
+   * `undefined` until it resolves, and offline it stays `undefined` whenever
+   * that section was never cached (the stale-cache read returns `null`). A
+   * defaulted `0` made the shared hint and the "Open Shared (N)" jump silently
+   * wrong — a pop-in on first paint, and permanently absent offline, which is
+   * exactly when that pointer is most useful.
+   */
+  sharedTaskCount: number | null;
 }
 
 /**
@@ -106,7 +115,9 @@ export function myRoleNamesFromCrew(
  *
  * Precedence, most-root-cause first:
  *  1. `has-tasks` — nothing to explain.
- *  2. `loading` — refuse to guess while the plan-wide or crew data is missing.
+ *  2. `loading` — refuse to guess while the plan-wide, crew, or shared data is
+ *     missing. Shared counts because the notice POINTS AT it; a defaulted 0
+ *     produced a confidently wrong hint that never corrected itself offline.
  *  3. `no-plan-tasks` — checked BEFORE rostering because it is the root cause
  *     when both are true: a plan with no tasks shows nothing to anybody, so
  *     fixing the roster wouldn't help, and telling a rostered leader "you're
@@ -117,7 +128,11 @@ export function myRoleNamesFromCrew(
  */
 export function diagnoseMineEmpty(facts: MineEmptyFacts): MineEmptyReason {
   if (facts.myTemplateTaskCount > 0) return "has-tasks";
-  if (facts.planTaskCount === null || facts.myRoleNames === null) {
+  if (
+    facts.planTaskCount === null ||
+    facts.myRoleNames === null ||
+    facts.sharedTaskCount === null
+  ) {
     return "loading";
   }
   if (facts.planTaskCount === 0) return "no-plan-tasks";
@@ -156,12 +171,16 @@ export function mineEmptyCopy(
   reason: MineEmptyReason,
   facts: MineEmptyFacts,
 ): MineEmptyCopy | null {
-  const planCount = facts.planTaskCount ?? 0;
   const shared = facts.sharedTaskCount;
+  // `null` = unresolved: say nothing about Shared rather than guess. (In
+  // practice `diagnoseMineEmpty` returns `loading` first; this keeps the copy
+  // honest for any caller.)
   const sharedHint =
-    shared > 0
-      ? `Shared has ${pluralTasks(shared)} for your whole team.`
-      : "Check All teams to see the rest of the event.";
+    shared === null
+      ? null
+      : shared > 0
+        ? `Shared has ${pluralTasks(shared)} for your whole team.`
+        : "Check All teams to see the rest of the event.";
 
   switch (reason) {
     case "has-tasks":
@@ -177,16 +196,34 @@ export function mineEmptyCopy(
     case "not-rostered":
       return {
         title: "You're not on the roster for this event.",
-        hint: `The event has ${pluralTasks(planCount)}, but tasks follow roles and you don't hold one here. Ask your team lead to add you to the roster.`,
+        hint: `The event has ${pluralTasks(facts.planTaskCount ?? 0)}, but tasks follow roles and you don't hold one here. Ask your team lead to add you to the roster.`,
       };
 
     case "role-mismatch": {
       const roles = facts.myRoleNames ?? [];
       const roleWord = roles.length === 1 ? "role" : "roles";
       return {
-        title: `This event has ${pluralTasks(planCount)}, but none are assigned to your ${roleWord}.`,
-        hint: `You're serving as ${formatRoleList(roles)}. ${sharedHint}`,
+        title: `This event has ${pluralTasks(facts.planTaskCount ?? 0)}, but none are assigned to your ${roleWord}.`,
+        hint: [`You're serving as ${formatRoleList(roles)}.`, sharedHint]
+          .filter(Boolean)
+          .join(" "),
       };
     }
   }
+}
+
+/**
+ * Whether the notice should offer its one-tap jump to the "Shared" tab.
+ *
+ * Only for the two states where whole-team tasks are a genuine next place to
+ * look. `no-plan-tasks` is excluded on purpose: a stale-cache mix (an empty
+ * all-teams snapshot next to a cached shared list) could otherwise render
+ * "This event has no tasks set up yet." directly above "Open Shared (2)".
+ */
+export function shouldOfferSharedJump(
+  reason: MineEmptyReason,
+  facts: MineEmptyFacts,
+): boolean {
+  if (reason !== "role-mismatch" && reason !== "not-rostered") return false;
+  return (facts.sharedTaskCount ?? 0) > 0;
 }

--- a/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
+++ b/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
@@ -1,0 +1,192 @@
+/**
+ * Why the serving-mode "Mine" tab is empty — and what to say about it.
+ *
+ * The Tasks tab used to render ONE message for every empty "Mine" list:
+ * "No preloaded task. Please contact your team lead to add tasks." That
+ * sentence implies tasks exist and are misconfigured, which is wrong in two of
+ * the three situations that actually produce it, and it gave a debugging
+ * engineer nothing to go on either. The three live causes are:
+ *
+ *  1. The plan has NO `eventTasks` rows at all. `createEventDraftImpl` makes
+ *     plans with no `taskTemplateId` and no tasks, and nothing backfills them —
+ *     tasks only appear when a leader links a task template
+ *     (`setPlanTaskTemplate`) or duplicates an event. So a freshly created
+ *     event is empty for EVERYONE, forever, until someone populates it.
+ *  2. The plan's tasks are TEAM-LEVEL (`roleIds: []`). `getMyServingTasks`
+ *     deliberately skips those — they live on the "Shared" tab — but the screen
+ *     opens on "Mine", so the viewer never sees them.
+ *  3. Role mismatch — tasks exist, but none of them name a role this viewer
+ *     holds on this plan.
+ *
+ * A fourth, rarer state is worth separating out: the viewer holds no
+ * non-declined role assignment on the plan at all. That's a ROSTERING gap, not
+ * a task-authoring gap, and a different person fixes it.
+ *
+ * Everything here is derived from the four queries the screen already runs —
+ * no new backend surface:
+ *   • plan-wide task count  ← `getAllTeamsTasks` (plan-wide; every task belongs
+ *     to >= 1 team, so a task appears under at least one team row)
+ *   • the viewer's roles    ← `getCrewTasks` (the `isCurrentUser` rows; the
+ *     query returns [] when the viewer has no non-declined assignment)
+ *   • shared task count     ← `getSharedTeamTasks`
+ *   • the viewer's own list ← `getMyServingTasks`
+ */
+
+/**
+ * Which empty-state story to tell. Precedence is deliberate — see
+ * `diagnoseMineEmpty`.
+ */
+export type MineEmptyReason =
+  /** The viewer has preloaded tasks; no notice belongs on screen. */
+  | "has-tasks"
+  /** Not enough data has loaded to say anything honest yet. */
+  | "loading"
+  /** The plan has zero tasks — nobody sees anything, for any role. */
+  | "no-plan-tasks"
+  /** The viewer holds no non-declined role on this plan (rostering gap). */
+  | "not-rostered"
+  /** Tasks exist; none name a role the viewer holds. */
+  | "role-mismatch";
+
+/** The facts `diagnoseMineEmpty` reasons over. `null` means "not loaded yet". */
+export interface MineEmptyFacts {
+  /** Distinct tasks on the whole plan (every team, every role). */
+  planTaskCount: number | null;
+  /** Names of the roles the viewer holds on this plan, in display order. */
+  myRoleNames: string[] | null;
+  /** Preloaded (non-personal) tasks in the viewer's own "Mine" list. */
+  myTemplateTaskCount: number;
+  /** Team-level tasks the viewer can see on the "Shared" tab. */
+  sharedTaskCount: number;
+}
+
+/**
+ * Distinct plan-wide task count from `getAllTeamsTasks`.
+ *
+ * A task that spans several teams is listed once per team, so the rows must be
+ * de-duplicated by `taskId` — `taskCount` summed across teams would over-count.
+ * Returns `null` while the query is unresolved.
+ */
+export function planTaskCountFromAllTeams(
+  teams: ReadonlyArray<{ tasks: ReadonlyArray<{ taskId: string }> }> | undefined,
+): number | null {
+  if (teams === undefined) return null;
+  const ids = new Set<string>();
+  for (const team of teams) {
+    for (const task of team.tasks) ids.add(task.taskId);
+  }
+  return ids.size;
+}
+
+/**
+ * The viewer's role names on this plan, from `getCrewTasks`.
+ *
+ * The crew list carries one row per (member, role) for every team the viewer is
+ * serving on, so the viewer's own rows name every role they hold. An empty
+ * result means the viewer has no non-declined assignment at all — `getCrewTasks`
+ * short-circuits to `[]` in that case. Returns `null` while unresolved.
+ */
+export function myRoleNamesFromCrew(
+  crew: ReadonlyArray<{ isCurrentUser: boolean; roleName: string }> | undefined,
+): string[] | null {
+  if (crew === undefined) return null;
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const member of crew) {
+    if (!member.isCurrentUser) continue;
+    if (seen.has(member.roleName)) continue;
+    seen.add(member.roleName);
+    names.push(member.roleName);
+  }
+  return names;
+}
+
+/**
+ * Classify why "Mine" is empty.
+ *
+ * Precedence, most-root-cause first:
+ *  1. `has-tasks` — nothing to explain.
+ *  2. `loading` — refuse to guess while the plan-wide or crew data is missing.
+ *  3. `no-plan-tasks` — checked BEFORE rostering because it is the root cause
+ *     when both are true: a plan with no tasks shows nothing to anybody, so
+ *     fixing the roster wouldn't help, and telling a rostered leader "you're
+ *     not on the roster" would send them after the wrong problem.
+ *  4. `not-rostered` — must precede `role-mismatch`, which would otherwise
+ *     claim "none of these tasks match your role" to someone holding no role.
+ *  5. `role-mismatch`.
+ */
+export function diagnoseMineEmpty(facts: MineEmptyFacts): MineEmptyReason {
+  if (facts.myTemplateTaskCount > 0) return "has-tasks";
+  if (facts.planTaskCount === null || facts.myRoleNames === null) {
+    return "loading";
+  }
+  if (facts.planTaskCount === 0) return "no-plan-tasks";
+  if (facts.myRoleNames.length === 0) return "not-rostered";
+  return "role-mismatch";
+}
+
+/** "Greeter", "Greeter and Usher", "Greeter, Usher and Camera 1". */
+function formatRoleList(names: readonly string[]): string {
+  if (names.length === 0) return "";
+  if (names.length === 1) return names[0];
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}
+
+/** "1 task" / "3 tasks". */
+function pluralTasks(n: number): string {
+  return n === 1 ? "1 task" : `${n} tasks`;
+}
+
+/** The copy shown for an empty "Mine" tab. */
+export interface MineEmptyCopy {
+  /** The headline — states plainly which situation the viewer is in. */
+  title: string;
+  /** Secondary line — where to look next, or who fixes it. */
+  hint: string;
+}
+
+/**
+ * The user-facing wording for a diagnosis. Returns `null` for the two states
+ * that render no notice at all (`has-tasks`, `loading`).
+ *
+ * Kept here rather than in the component so every string is unit-testable
+ * against the facts that produced it.
+ */
+export function mineEmptyCopy(
+  reason: MineEmptyReason,
+  facts: MineEmptyFacts,
+): MineEmptyCopy | null {
+  const planCount = facts.planTaskCount ?? 0;
+  const shared = facts.sharedTaskCount;
+  const sharedHint =
+    shared > 0
+      ? `Shared has ${pluralTasks(shared)} for your whole team.`
+      : "Check All teams to see the rest of the event.";
+
+  switch (reason) {
+    case "has-tasks":
+    case "loading":
+      return null;
+
+    case "no-plan-tasks":
+      return {
+        title: "This event has no tasks set up yet.",
+        hint: "Nobody has added tasks to it, so there's nothing to show for any role. You can still add your own tasks below.",
+      };
+
+    case "not-rostered":
+      return {
+        title: "You're not on the roster for this event.",
+        hint: `The event has ${pluralTasks(planCount)}, but tasks follow roles and you don't hold one here. Ask your team lead to add you to the roster.`,
+      };
+
+    case "role-mismatch": {
+      const roles = facts.myRoleNames ?? [];
+      const roleWord = roles.length === 1 ? "role" : "roles";
+      return {
+        title: `This event has ${pluralTasks(planCount)}, but none are assigned to your ${roleWord}.`,
+        hint: `You're serving as ${formatRoleList(roles)}. ${sharedHint}`,
+      };
+    }
+  }
+}

--- a/apps/mobile/features/serving/utils/taskAuthoring.ts
+++ b/apps/mobile/features/serving/utils/taskAuthoring.ts
@@ -42,15 +42,26 @@ export interface AuthorableTask {
   sortOrder: number;
 }
 
+/** True when a task belongs to the whole team rather than a single role. */
+export function isTeamLevelTask(task: AuthorableTask): boolean {
+  return task.roleIds.length === 0;
+}
+
 /**
  * Group a plan's tasks (as returned by `listPlanTasks`) into Before/During/
- * After buckets scoped to ONE role — the role the leader is currently
- * "viewing as" in the Edit surface, sorted within each bucket by `sortOrder`
- * (matching the plan-wide task order).
+ * After buckets for the role the leader is currently "viewing as" in the Edit
+ * surface, sorted within each bucket by `sortOrder` (matching the plan-wide
+ * task order).
  *
- * Team-level tasks (`roleIds` empty) are never included — those are the
- * whole team's Shared-tab tasks, not a single role's list, and stay out of
- * scope for this friction-removal surface (see the work order's non-goals).
+ * TEAM-LEVEL tasks (`roleIds` empty) are included in EVERY role's buckets.
+ * They aren't the selected role's tasks — they apply to the whole team, and
+ * the UI labels them as such — but excluding them made the Edit surface the
+ * one place a leader could neither see nor fix them: they're absent from
+ * "Mine" by design (`getMyServingTasks` skips them) and live only under the
+ * Shared pill, which has no authoring controls. A leader looking at Edit and
+ * seeing "No tasks yet for this role" on a plan whose tasks are all
+ * team-level was being told something false.
+ *
  * `roleId === null` (nothing selected yet, e.g. before the role catalog has
  * loaded) returns all-empty buckets.
  */
@@ -61,7 +72,9 @@ export function tasksForRole<T extends AuthorableTask>(
   const result: Record<Segment, T[]> = { before: [], during: [], after: [] };
   if (!roleId) return result;
   for (const task of tasks) {
-    if (task.roleIds.includes(roleId)) result[task.segment].push(task);
+    if (isTeamLevelTask(task) || task.roleIds.includes(roleId)) {
+      result[task.segment].push(task);
+    }
   }
   (Object.keys(result) as Segment[]).forEach((segment) => {
     result[segment] = [...result[segment]].sort(

--- a/apps/mobile/features/serving/utils/taskAuthoring.ts
+++ b/apps/mobile/features/serving/utils/taskAuthoring.ts
@@ -37,6 +37,8 @@ export function canAuthorPlanTasks(
 
 /** The slice of a `listPlanTasks` row that role-filtering needs. */
 export interface AuthorableTask {
+  /** Every team the task belongs to (`listPlanTasks` returns this). */
+  teamIds: readonly string[];
   roleIds: readonly string[];
   segment: Segment;
   sortOrder: number;
@@ -53,28 +55,36 @@ export function isTeamLevelTask(task: AuthorableTask): boolean {
  * surface, sorted within each bucket by `sortOrder` (matching the plan-wide
  * task order).
  *
- * TEAM-LEVEL tasks (`roleIds` empty) are included in EVERY role's buckets.
- * They aren't the selected role's tasks — they apply to the whole team, and
- * the UI labels them as such — but excluding them made the Edit surface the
- * one place a leader could neither see nor fix them: they're absent from
- * "Mine" by design (`getMyServingTasks` skips them) and live only under the
- * Shared pill, which has no authoring controls. A leader looking at Edit and
- * seeing "No tasks yet for this role" on a plan whose tasks are all
+ * TEAM-LEVEL tasks (`roleIds` empty) are included in the buckets of every role
+ * **on the same team**. They aren't the selected role's tasks — they apply to
+ * the whole team, and the UI labels them as such — but excluding them made the
+ * Edit surface the one place a leader could neither see nor fix them: they're
+ * absent from "Mine" by design (`getMyServingTasks` skips them) and live only
+ * under the Shared pill, which has no authoring controls. A leader looking at
+ * Edit and seeing "No tasks yet for this role" on a plan whose tasks are all
  * team-level was being told something false.
  *
- * `roleId === null` (nothing selected yet, e.g. before the role catalog has
+ * The TEAM check is not optional. Both inputs are wider than one team:
+ * `listPlanTasks({ planId })` returns every task on the plan across all teams,
+ * and `buildRoleCatalog` spans every team in the group. Without it, selecting
+ * (say) `Kids · Check-in` listed Worship's team-level "Sound check" captioned
+ * "Whole team — not just this role" — a lie — and a single tap could DELETE it
+ * (cascading its completions, and permanently unsyncing it from its template).
+ *
+ * `role === null` (nothing selected yet, e.g. before the role catalog has
  * loaded) returns all-empty buckets.
  */
 export function tasksForRole<T extends AuthorableTask>(
   tasks: readonly T[],
-  roleId: string | null,
+  role: { roleId: string; teamId: string } | null,
 ): Record<Segment, T[]> {
   const result: Record<Segment, T[]> = { before: [], during: [], after: [] };
-  if (!roleId) return result;
+  if (!role) return result;
   for (const task of tasks) {
-    if (isTeamLevelTask(task) || task.roleIds.includes(roleId)) {
-      result[task.segment].push(task);
-    }
+    const belongs = isTeamLevelTask(task)
+      ? task.teamIds.includes(role.teamId)
+      : task.roleIds.includes(role.roleId);
+    if (belongs) result[task.segment].push(task);
   }
   (Object.keys(result) as Segment[]).forEach((segment) => {
     result[segment] = [...result[segment]].sort(


### PR DESCRIPTION
A TD opened serving mode and saw no tasks. Follow-up to #688, which fixed opening an event *early* but never touched task *visibility* — a separate complaint from the same conversation.

## What was actually wrong

Three unrelated conditions all rendered the same message — *"No preloaded task. Please contact your team lead to add tasks."* That message is wrong in the most common case and actively misdirects: it implies tasks exist and are misconfigured, when usually the event simply has none.

A code trace ruled out the plumbing explanations. The Tasks tab **does** query correctly for a previewed future plan; an `unconfirmed` assignment does **not** suppress tasks (`eventTasks.ts:900` filters on `status !== "declined"`); and there is no time gate inside any of the four task queries. What remained:

1. **The plan has zero `eventTasks` rows.** `createEventDraftImpl` (`events.ts:91-103`) creates plans with no `taskTemplateId` and no tasks. Materialisation happens *only* in `setPlanTaskTemplate` when a leader explicitly links a template, or via `duplicateEvent`. Nothing backfills. A plan created fresh rather than duplicated has no tasks, permanently, until someone opens the rostering grid. "The template is there" is true of the group's template *library* — it says nothing about that plan.
2. **Tasks authored at team level** (`roleIds: []`) are skipped by `getMyServingTasks` (`eventTasks.ts:929`) and live only under the "Shared" pill. The screen opens on "Mine".
3. **Role mismatch** — the tasks' `roleIds` don't include the role the viewer holds on this plan.

## Changes

**A diagnostic empty state.** `utils/servingTaskEmptyState.ts` discriminates the cases from data the screen's four existing queries already carry — no new backend query. The states are `no-plan-tasks`, `role-mismatch` (says how many tasks the event has and names the role(s) you actually hold), `not-rostered` (you hold no non-declined assignment here at all — a rostering gap, not a task-authoring one), plus `has-tasks`/`loading`.

**A jump to Shared** when Mine is empty but Shared has tasks, so a team-level setup isn't a dead end.

**A leader path to populate an empty plan**, gated on `canAuthor && reason === "no-plan-tasks"`, using the existing `setPlanTaskTemplate` mutation. No new mutation. If the group has no templates it says so rather than dead-ending.

**Fixes a bug shipped in #688.** `tasksForRole` matched only `task.roleIds.includes(roleId)`, so the leader Edit surface could neither see nor fix team-level tasks. A leader couldn't even find them. Team-level tasks now appear under every role, labelled "Whole team — not just this role".

One test changed meaning as a result: `"excludes a team-level (no-role) task from every role's list"` became `"shows a team-level (no-role) task under every role, labelled whole-team"`. That test codified the bug — it was written alongside the Edit surface in #688 and locked the blind spot in as intended behaviour. Every other previously-failing test was fixed in the code, not the assertion; the test file is net +14/-4.

## Deliberately not done

**Templates are not auto-linked at plan creation.** That would silently change what every new event contains — a product decision about defaults, not a bug fix. This PR makes the current behaviour legible and one tap to resolve; it doesn't decide the default.

No task depth was added — no how-to authoring, training content, or attachments. A third-party tool is under evaluation for that.

## Verification

- `apps/mobile` — 222 suites / 2193 tests passed (incl. 23 new `servingTaskEmptyState` tests and 35 in `ServingTasksScreen`)
- `npx convex typecheck` — passed
- `check-navigator-screens` selftest + check — passed
- No dependencies changed; `pnpm-lock.yaml` untouched, so the native-safety gates don't apply

## Not verified

No device run. This is JS/render logic with no native view or dependency change, so ADR-013's risk factors don't apply — but CI is blind to native rendering by design, and the empty state is the whole point of the change, so it's worth a look on a staging OTA.

**Which of the three causes is hitting FOUNT specifically is still unconfirmed** — that needs live data (the plan's `taskTemplateId`, its `eventTasks` row count, and the reporter's `roleAssignments` for it). This PR makes the app answer that question itself instead of requiring a database query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168KrbHskjSAFjB6sSHgkXA

---
_Generated by [Claude Code](https://claude.ai/code/session_0168KrbHskjSAFjB6sSHgkXA)_