### PR TITLE
Show each role's own task count in the Edit tab, and fix the self-contradictory empty-state copy

### DIFF
--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -89,6 +89,7 @@ import {
   buildRoleCatalog,
   canAuthorPlanTasks,
   isTeamLevelTask,
+  roleTaskCounts,
   tasksForRole,
   type RoleCatalogEntry,
 } from "../utils/taskAuthoring";
@@ -2315,6 +2316,15 @@ function AuthorSection({
     [planTasks, selectedRole],
   );
 
+  // Badge numbers for the role pills. Deliberately NOT `bySegment`-derived:
+  // these count each role's OWN tasks, excluding the team-level ones
+  // `tasksForRole` folds in — see `roleTaskCounts`. A leader has to be able to
+  // spot the role with none WITHOUT tapping through every pill.
+  const countsByRoleId = useMemo(
+    () => roleTaskCounts(planTasks ?? [], roleCatalog),
+    [planTasks, roleCatalog],
+  );
+
   const [addingSegment, setAddingSegment] = useState<Segment | null>(null);
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
 
@@ -2351,6 +2361,7 @@ function AuthorSection({
           selectedRoleId={selectedRoleId}
           selectedRole={selectedRole}
           onSelectRole={setSelectedRoleId}
+          countsByRoleId={countsByRoleId}
           bySegment={bySegment}
           planId={planId}
           isEffectivelyOffline={isEffectivelyOffline}
@@ -2381,6 +2392,7 @@ function AuthorRoleAndSegments({
   selectedRoleId,
   selectedRole,
   onSelectRole,
+  countsByRoleId,
   bySegment,
   planId,
   isEffectivelyOffline,
@@ -2399,6 +2411,8 @@ function AuthorRoleAndSegments({
   selectedRoleId: string | null;
   selectedRole: RoleCatalogEntry | undefined;
   onSelectRole: (roleId: string) => void;
+  /** Each role's OWN task count (team-level excluded) — see `roleTaskCounts`. */
+  countsByRoleId: Record<string, number>;
   bySegment: Record<Segment, AuthorTask[]>;
   planId: Id<"eventPlans">;
   isEffectivelyOffline: boolean;
@@ -2426,13 +2440,20 @@ function AuthorRoleAndSegments({
       >
         {roleCatalog.map((role) => {
           const active = role.roleId === selectedRoleId;
+          const count = countsByRoleId[role.roleId] ?? 0;
+          // A role nobody has authored for is the thing a leader is scanning
+          // for, so it gets the warning tint rather than the quiet default —
+          // legible at a glance without tapping through every pill.
+          const empty = count === 0;
           return (
             <Pressable
               key={role.roleId}
               onPress={() => onSelectRole(role.roleId)}
               accessibilityRole="button"
               accessibilityState={{ selected: active }}
-              accessibilityLabel={`View and edit ${role.teamName} ${role.roleName} tasks`}
+              accessibilityLabel={`View and edit ${role.teamName} ${role.roleName} tasks, ${
+                empty ? "no tasks yet" : `${count} ${count === 1 ? "task" : "tasks"}`
+              }`}
               style={[
                 styles.pill,
                 wa && waStyles.pill,
@@ -2450,6 +2471,35 @@ function AuthorRoleAndSegments({
               >
                 {role.teamName} · {role.roleName}
               </Text>
+              <View
+                style={[
+                  styles.pillBadge,
+                  wa && waStyles.pillBadge,
+                  {
+                    backgroundColor: empty
+                      ? colors.warning
+                      : active
+                        ? colors.onAccent
+                        : colors.background,
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.pillBadgeText,
+                    wa && waStyles.pillBadgeText,
+                    {
+                      color: empty
+                        ? colors.onAccent
+                        : active
+                          ? primaryColor
+                          : colors.textTertiary,
+                    },
+                  ]}
+                >
+                  {count}
+                </Text>
+              </View>
             </Pressable>
           );
         })}

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -97,7 +97,7 @@ import {
   diagnoseMineEmpty,
   mineEmptyCopy,
   myRoleNamesFromCrew,
-  planTaskCountFromAllTeams,
+  planTaskCountsFromAllTeams,
   shouldOfferSharedJump,
   type MineEmptyFacts,
   type MineEmptyReason,
@@ -768,7 +768,7 @@ function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean
   // data these four queries already carry. See `servingTaskEmptyState.ts`.
   const mineFacts = useMemo(
     () => ({
-      planTaskCount: planTaskCountFromAllTeams(effAllTeams),
+      planTaskCounts: planTaskCountsFromAllTeams(effAllTeams),
       myRoleNames: myRoleNamesFromCrew(effCrew),
       myTemplateTaskCount,
       // `null`, not 0, while unresolved — offline this NEVER self-corrects when

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -89,6 +89,7 @@ import {
   buildRoleCatalog,
   canAuthorPlanTasks,
   isTeamLevelTask,
+  roleCoveredTaskCounts,
   roleTaskCounts,
   tasksForRole,
   type RoleCatalogEntry,
@@ -421,7 +422,7 @@ export function ServingTasksScreen() {
  * the parent — only the per-plan reconcile lives here.
  */
 function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean }) {
-  const { colors } = useTheme();
+  const { colors, isDark } = useTheme();
   const { primaryColor } = useCommunityTheme();
   const { user } = useAuth();
   const planId = plan.planId as Id<"eventPlans">;
@@ -1057,6 +1058,7 @@ function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean
             groupId={groupId}
             isEffectivelyOffline={isEffectivelyOffline}
             colors={colors}
+            isDark={isDark}
             primaryColor={primaryColor}
             wa={wa}
           />
@@ -2252,6 +2254,7 @@ function AuthorSection({
   groupId,
   isEffectivelyOffline,
   colors,
+  isDark,
   primaryColor,
   wa,
 }: {
@@ -2259,6 +2262,7 @@ function AuthorSection({
   groupId: Id<"groups">;
   isEffectivelyOffline: boolean;
   colors: ThemeColors;
+  isDark: boolean;
   primaryColor: string;
   wa: boolean;
 }) {
@@ -2325,6 +2329,15 @@ function AuthorSection({
     [planTasks, roleCatalog],
   );
 
+  // What the pill's WARNING tint is allowed to mean: nothing at all reaches a
+  // volunteer in this role. A role whose team authored everything at team level
+  // has an own-count of 0 but is fully covered — alarming on that told a leader
+  // their finished event was unauthored.
+  const coveredByRoleId = useMemo(
+    () => roleCoveredTaskCounts(planTasks ?? [], roleCatalog),
+    [planTasks, roleCatalog],
+  );
+
   const [addingSegment, setAddingSegment] = useState<Segment | null>(null);
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
 
@@ -2362,6 +2375,8 @@ function AuthorSection({
           selectedRole={selectedRole}
           onSelectRole={setSelectedRoleId}
           countsByRoleId={countsByRoleId}
+          coveredByRoleId={coveredByRoleId}
+          planHasTasks={planTasks.length > 0}
           bySegment={bySegment}
           planId={planId}
           isEffectivelyOffline={isEffectivelyOffline}
@@ -2373,6 +2388,7 @@ function AuthorSection({
           updateTask={updateTask}
           deleteTask={deleteTask}
           colors={colors}
+          isDark={isDark}
           primaryColor={primaryColor}
           wa={wa}
         />
@@ -2393,6 +2409,8 @@ function AuthorRoleAndSegments({
   selectedRole,
   onSelectRole,
   countsByRoleId,
+  coveredByRoleId,
+  planHasTasks,
   bySegment,
   planId,
   isEffectivelyOffline,
@@ -2404,6 +2422,7 @@ function AuthorRoleAndSegments({
   updateTask,
   deleteTask,
   colors,
+  isDark,
   primaryColor,
   wa,
 }: {
@@ -2413,6 +2432,10 @@ function AuthorRoleAndSegments({
   onSelectRole: (roleId: string) => void;
   /** Each role's OWN task count (team-level excluded) — see `roleTaskCounts`. */
   countsByRoleId: Record<string, number>;
+  /** Own + team-level, i.e. everything that reaches the role — the tint's input. */
+  coveredByRoleId: Record<string, number>;
+  /** False for a brand-new plan, where an all-orange row would be noise. */
+  planHasTasks: boolean;
   bySegment: Record<Segment, AuthorTask[]>;
   planId: Id<"eventPlans">;
   isEffectivelyOffline: boolean;
@@ -2427,9 +2450,15 @@ function AuthorRoleAndSegments({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   deleteTask: (args: any) => Promise<unknown>;
   colors: ThemeColors;
+  isDark: boolean;
   primaryColor: string;
   wa: boolean;
 }) {
+  // Dark ink for the warning badge. `colors.warning` is a mid-orange in every
+  // palette, so white on it measures ~2.1–2.6:1 — well under AA for 11pt/700
+  // text. These two tokens are the theme's dark ink in all four palettes
+  // (light/dark x default/Knicks), which lands at 6:1 or better on the orange.
+  const alarmInk = isDark ? colors.textInverse : colors.text;
   return (
     <>
       <ScrollView
@@ -2441,18 +2470,30 @@ function AuthorRoleAndSegments({
         {roleCatalog.map((role) => {
           const active = role.roleId === selectedRoleId;
           const count = countsByRoleId[role.roleId] ?? 0;
-          // A role nobody has authored for is the thing a leader is scanning
-          // for, so it gets the warning tint rather than the quiet default —
-          // legible at a glance without tapping through every pill.
-          const empty = count === 0;
+          const covered = coveredByRoleId[role.roleId] ?? 0;
+          // The tint is an ALARM, so it fires only when NOTHING reaches this
+          // role — not merely when the role has no tasks of its own. A team
+          // whose plan is written entirely as "Whole team" tasks is fully
+          // authored; tinting all of its roles told the leader the opposite.
+          // Suppressed entirely on a task-less plan: every role is uncovered
+          // there, and a wall of orange adds nothing to the empty-state notice
+          // and "Populate from template" already on screen.
+          const uncovered = planHasTasks && covered === 0;
           return (
             <Pressable
               key={role.roleId}
               onPress={() => onSelectRole(role.roleId)}
               accessibilityRole="button"
               accessibilityState={{ selected: active }}
-              accessibilityLabel={`View and edit ${role.teamName} ${role.roleName} tasks, ${
-                empty ? "no tasks yet" : `${count} ${count === 1 ? "task" : "tasks"}`
+              // The badge counts the role's OWN tasks, so the label has to say
+              // so: "no tasks yet" was an absolute claim that a screen reader
+              // then contradicted by reading out the team-level tasks in the
+              // list below. The team-level tally is spoken too, since it is
+              // the reason the number is 0 — and the reason there's no tint.
+              accessibilityLabel={`View and edit ${role.teamName} ${role.roleName} tasks, ${count} ${
+                count === 1 ? "task" : "tasks"
+              } of its own${
+                count === 0 && covered > 0 ? `, ${covered} for the whole team` : ""
               }`}
               style={[
                 styles.pill,
@@ -2475,13 +2516,24 @@ function AuthorRoleAndSegments({
                 style={[
                   styles.pillBadge,
                   wa && waStyles.pillBadge,
-                  {
-                    backgroundColor: empty
-                      ? colors.warning
-                      : active
-                        ? colors.onAccent
-                        : colors.background,
-                  },
+                  // A solid warning fill alone DISAPPEARS on the selected pill
+                  // whenever the community's primary color is orange-ish
+                  // (Knicks mode makes both `#F58426` exactly), leaving a bare
+                  // floating number. The dark-ink ring is what keeps the chip
+                  // readable as a chip against any pill background, in either
+                  // direction: where the fill matches the pill, the ring
+                  // contrasts; where the ring matches, the fill does.
+                  uncovered
+                    ? {
+                        backgroundColor: colors.warning,
+                        borderWidth: 1,
+                        borderColor: alarmInk,
+                      }
+                    : {
+                        backgroundColor: active
+                          ? colors.onAccent
+                          : colors.background,
+                      },
                 ]}
               >
                 <Text
@@ -2489,8 +2541,8 @@ function AuthorRoleAndSegments({
                     styles.pillBadgeText,
                     wa && waStyles.pillBadgeText,
                     {
-                      color: empty
-                        ? colors.onAccent
+                      color: uncovered
+                        ? alarmInk
                         : active
                           ? primaryColor
                           : colors.textTertiary,

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -189,8 +189,13 @@ const DEFAULT_PLANS: EligiblePlan[] = [
   { planId: "plan-1", title: "Sunday Gathering", startsAt: 0 },
 ];
 
-/** An `getAllTeamsTasks` row. Only `tasks[].taskId` is read for the count. */
-function allTeamsRow(taskIds: string[], teamId = "team-1") {
+/**
+ * An `getAllTeamsTasks` row. `tasks[].taskId` feeds the plan-wide count and
+ * `roleNames` decides the task's scope — EMPTY means team-level, exactly as the
+ * backend returns it — which the empty-state copy splits on. Defaults to
+ * role-scoped; pass `[]` for the all-team-level plan.
+ */
+function allTeamsRow(taskIds: string[], teamId = "team-1", roleNames = ["Camera"]) {
   return {
     teamId,
     teamName: "Hospitality",
@@ -201,7 +206,7 @@ function allTeamsRow(taskIds: string[], teamId = "team-1") {
       taskId,
       title: taskId,
       segment: "before",
-      roleNames: [],
+      roleNames,
       completed: false,
       howToType: "none",
     })),
@@ -392,17 +397,24 @@ describe("ServingTasksScreen — Shared discoverability from an empty Mine", () 
   afterEach(() => jest.clearAllMocks());
 
   it("advertises Shared and jumps to it when Mine is empty but Shared has tasks", () => {
+    // The premise of this whole describe: every task on the plan is TEAM-level,
+    // which is why Shared holds them all.
     mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
-      allTeams: [allTeamsRow(["task-1", "task-2"])],
+      allTeams: [allTeamsRow(["task-1", "task-2"], "team-1", [])],
       crew: [myCrewRow("Greeter")],
       shared: [
         sharedRow("task-1", "Unlock the building"),
         sharedRow("task-2", "Set the thermostat"),
       ],
     });
-    const { getByText, getByLabelText } = render(<ServingTasksScreen />);
+    const { getByText, getByLabelText, queryByText } = render(<ServingTasksScreen />);
 
     expect(getByText(/Shared has 2 tasks for your whole team\./)).toBeTruthy();
+    // …and the same notice must not call those very tasks somebody else's.
+    expect(queryByText(/are for other roles/)).toBeNull();
+    expect(
+      getByText("This event's tasks are for whole teams, not roles."),
+    ).toBeTruthy();
 
     fireEvent.press(getByLabelText("Open the Shared tab"));
 

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -796,7 +796,7 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     fireEvent.press(getByLabelText("Edit"));
     expect(getByText("Set up welcome table")).toBeTruthy();
 
-    fireEvent.press(getByLabelText("View and edit Hospitality Usher tasks"));
+    fireEvent.press(getByLabelText("View and edit Hospitality Usher tasks, no tasks yet"));
 
     expect(queryByText("Set up welcome table")).toBeNull();
     // All three segments (Before/During/After) are empty for the Usher role.
@@ -828,7 +828,7 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     expect(getAllByText("No tasks yet for this role.")).toHaveLength(2);
 
     // Still visible after switching to a role that owns no tasks of its own.
-    fireEvent.press(getByLabelText("View and edit Hospitality Usher tasks"));
+    fireEvent.press(getByLabelText("View and edit Hospitality Usher tasks, no tasks yet"));
     expect(getByText("Unlock the building")).toBeTruthy();
   });
 
@@ -865,7 +865,7 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     expect(getByText("Check-in table setup")).toBeTruthy();
     expect(queryByText("Sound check")).toBeNull();
 
-    fireEvent.press(getByLabelText("View and edit Worship Sound tasks"));
+    fireEvent.press(getByLabelText("View and edit Worship Sound tasks, no tasks yet"));
 
     expect(getByText("Sound check")).toBeTruthy();
     expect(queryByText("Check-in table setup")).toBeNull();
@@ -887,8 +887,88 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     fireEvent.press(getByLabelText("Edit"));
 
     expect(getByText("Clear the stage")).toBeTruthy();
-    fireEvent.press(getByLabelText("View and edit Worship Sound tasks"));
+    fireEvent.press(getByLabelText("View and edit Worship Sound tasks, no tasks yet"));
     expect(getByText("Clear the stage")).toBeTruthy();
+  });
+
+  // A leader had to tap every pill to find the role nobody had authored for.
+  // The badge counts each role's OWN tasks, so a gap is visible without tapping.
+  it("badges each role pill with its own task count", () => {
+    mockUser = { is_admin: true };
+    mockAuthorQueries([
+      {
+        _id: "task-1",
+        teamIds: ["team-1"],
+        roleIds: ["role-greeter"],
+        segment: "before",
+        title: "Set up welcome table",
+        sortOrder: 0,
+      },
+      {
+        _id: "task-2",
+        teamIds: ["team-1"],
+        roleIds: ["role-greeter"],
+        segment: "after",
+        title: "Pack down",
+        sortOrder: 1,
+      },
+    ]);
+    const { getByLabelText } = render(<ServingTasksScreen />);
+    fireEvent.press(getByLabelText("Edit"));
+
+    expect(getByLabelText("View and edit Hospitality Greeter tasks, 2 tasks")).toBeTruthy();
+    expect(
+      getByLabelText("View and edit Hospitality Usher tasks, no tasks yet"),
+    ).toBeTruthy();
+  });
+
+  // The badge must NOT reuse the body list's length. `tasksForRole` folds a
+  // team's team-level tasks into every role on that team, so a count derived
+  // from it would read "1" for Greeter AND Usher here — hiding the fact that
+  // neither role has a single task of its own, which is the one thing the
+  // badge exists to surface.
+  it("does not count a team-level task towards any role's badge", () => {
+    mockUser = { is_admin: true };
+    mockAuthorQueries([
+      {
+        _id: "task-shared",
+        teamIds: ["team-1"],
+        roleIds: [],
+        segment: "before",
+        title: "Unlock the building",
+        sortOrder: 0,
+      },
+    ]);
+    const { getByLabelText, getByText } = render(<ServingTasksScreen />);
+    fireEvent.press(getByLabelText("Edit"));
+
+    expect(
+      getByLabelText("View and edit Hospitality Greeter tasks, no tasks yet"),
+    ).toBeTruthy();
+    expect(
+      getByLabelText("View and edit Hospitality Usher tasks, no tasks yet"),
+    ).toBeTruthy();
+    // …while the body still shows it, captioned as whole-team.
+    expect(getByText("Unlock the building")).toBeTruthy();
+    expect(getByText("Whole team — not just this role")).toBeTruthy();
+  });
+
+  it("uses the singular in the badge label for exactly one task", () => {
+    mockUser = { is_admin: true };
+    mockAuthorQueries([
+      {
+        _id: "task-1",
+        teamIds: ["team-1"],
+        roleIds: ["role-usher"],
+        segment: "during",
+        title: "Count attendance",
+        sortOrder: 0,
+      },
+    ]);
+    const { getByLabelText } = render(<ServingTasksScreen />);
+    fireEvent.press(getByLabelText("Edit"));
+
+    expect(getByLabelText("View and edit Hospitality Usher tasks, 1 task")).toBeTruthy();
   });
 
   it("adds a task for the selected role via createTask", async () => {

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, fireEvent } from "@testing-library/react-native";
+import { render, fireEvent, within } from "@testing-library/react-native";
 import { ServingTasksScreen } from "../ServingTasksScreen";
 import { useAuthenticatedQuery, useAuthenticatedMutation } from "@services/api/convex";
 
@@ -83,16 +83,23 @@ jest.mock("@hooks/useTheme", () => ({
       surface: "#fafafa",
       border: "#e5e5e5",
       text: "#000",
+      textInverse: "#1a1a1a",
       textSecondary: "#666",
       textTertiary: "#999",
       error: "#c00",
+      warning: "#FF9500",
+      onAccent: "#ffffff",
     },
     isDark: false,
   }),
 }));
 
+// A community's brand color is arbitrary — the Edit surface's role pills use it
+// as the SELECTED pill's background, so tests flip it to pin what happens when
+// it collides with `colors.warning` (Knicks mode makes both `#F58426`).
+let mockPrimaryColor = "#D9A441";
 jest.mock("@hooks/useCommunityTheme", () => ({
-  useCommunityTheme: () => ({ primaryColor: "#D9A441" }),
+  useCommunityTheme: () => ({ primaryColor: mockPrimaryColor }),
 }));
 
 // The screen is restyled behind `whatsapp-shell`. Default the suite to
@@ -158,6 +165,21 @@ const mockQuery = useAuthenticatedQuery as jest.Mock;
 const mockMutation = useAuthenticatedMutation as jest.Mock;
 
 const EMPTY_MINE = { before: [], during: [], after: [] };
+
+/** Flattens a possibly-nested RN style prop into one object. */
+const flatten = (style: unknown): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  const walk = (node: unknown) => {
+    if (!node) return;
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    if (typeof node === "object") Object.assign(out, node);
+  };
+  walk(style);
+  return out;
+};
 
 function templateTask(overrides: Record<string, unknown> = {}) {
   return {
@@ -808,7 +830,9 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     fireEvent.press(getByLabelText("Edit"));
     expect(getByText("Set up welcome table")).toBeTruthy();
 
-    fireEvent.press(getByLabelText("View and edit Hospitality Usher tasks, no tasks yet"));
+    fireEvent.press(
+      getByLabelText("View and edit Hospitality Usher tasks, 0 tasks of its own"),
+    );
 
     expect(queryByText("Set up welcome table")).toBeNull();
     // All three segments (Before/During/After) are empty for the Usher role.
@@ -839,8 +863,14 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     // Only Before has the task; During/After stay empty.
     expect(getAllByText("No tasks yet for this role.")).toHaveLength(2);
 
-    // Still visible after switching to a role that owns no tasks of its own.
-    fireEvent.press(getByLabelText("View and edit Hospitality Usher tasks, no tasks yet"));
+    // Still visible after switching to a role that owns no tasks of its own —
+    // and the pill says exactly that, rather than "no tasks yet", which the
+    // list below would immediately contradict.
+    fireEvent.press(
+      getByLabelText(
+        "View and edit Hospitality Usher tasks, 0 tasks of its own, 1 for the whole team",
+      ),
+    );
     expect(getByText("Unlock the building")).toBeTruthy();
   });
 
@@ -877,7 +907,11 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     expect(getByText("Check-in table setup")).toBeTruthy();
     expect(queryByText("Sound check")).toBeNull();
 
-    fireEvent.press(getByLabelText("View and edit Worship Sound tasks, no tasks yet"));
+    fireEvent.press(
+      getByLabelText(
+        "View and edit Worship Sound tasks, 0 tasks of its own, 1 for the whole team",
+      ),
+    );
 
     expect(getByText("Sound check")).toBeTruthy();
     expect(queryByText("Check-in table setup")).toBeNull();
@@ -899,7 +933,11 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     fireEvent.press(getByLabelText("Edit"));
 
     expect(getByText("Clear the stage")).toBeTruthy();
-    fireEvent.press(getByLabelText("View and edit Worship Sound tasks, no tasks yet"));
+    fireEvent.press(
+      getByLabelText(
+        "View and edit Worship Sound tasks, 0 tasks of its own, 1 for the whole team",
+      ),
+    );
     expect(getByText("Clear the stage")).toBeTruthy();
   });
 
@@ -928,9 +966,11 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     const { getByLabelText } = render(<ServingTasksScreen />);
     fireEvent.press(getByLabelText("Edit"));
 
-    expect(getByLabelText("View and edit Hospitality Greeter tasks, 2 tasks")).toBeTruthy();
     expect(
-      getByLabelText("View and edit Hospitality Usher tasks, no tasks yet"),
+      getByLabelText("View and edit Hospitality Greeter tasks, 2 tasks of its own"),
+    ).toBeTruthy();
+    expect(
+      getByLabelText("View and edit Hospitality Usher tasks, 0 tasks of its own"),
     ).toBeTruthy();
   });
 
@@ -955,10 +995,14 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     fireEvent.press(getByLabelText("Edit"));
 
     expect(
-      getByLabelText("View and edit Hospitality Greeter tasks, no tasks yet"),
+      getByLabelText(
+        "View and edit Hospitality Greeter tasks, 0 tasks of its own, 1 for the whole team",
+      ),
     ).toBeTruthy();
     expect(
-      getByLabelText("View and edit Hospitality Usher tasks, no tasks yet"),
+      getByLabelText(
+        "View and edit Hospitality Usher tasks, 0 tasks of its own, 1 for the whole team",
+      ),
     ).toBeTruthy();
     // …while the body still shows it, captioned as whole-team.
     expect(getByText("Unlock the building")).toBeTruthy();
@@ -980,7 +1024,134 @@ describe("ServingTasksScreen — Edit surface (leader authoring)", () => {
     const { getByLabelText } = render(<ServingTasksScreen />);
     fireEvent.press(getByLabelText("Edit"));
 
-    expect(getByLabelText("View and edit Hospitality Usher tasks, 1 task")).toBeTruthy();
+    expect(
+      getByLabelText("View and edit Hospitality Usher tasks, 1 task of its own"),
+    ).toBeTruthy();
+  });
+
+  /**
+   * The pill badge's WARNING tint. It is an alarm, so it may only mean "nothing
+   * reaches a volunteer in this role" — never merely "this role has no tasks of
+   * its own", which is the normal shape of a plan authored at team level.
+   */
+  describe("role pill badge tint", () => {
+    /** The badge `<View>` wrapping a pill's count, plus its `<Text>`. */
+    const badgeOf = (pill: ReturnType<typeof within>, count: string) => {
+      const text = within(pill as never).getByText(count);
+      // `.parent` walks composite wrappers too (RN's `Text`), so climb to the
+      // nearest host View — the badge itself.
+      let view = text.parent;
+      while (view && view.type !== "View") view = view.parent;
+      return {
+        text: flatten(text.props.style),
+        view: flatten(view!.props.style),
+      };
+    };
+
+    it("does NOT alarm for a role whose team authored everything at team level", () => {
+      // The "Whole team" pattern: a Worship lead writes the entire plan as
+      // team-level tasks. Every role's own count is 0, but the event is fully
+      // authored — tinting the whole row told the leader the opposite.
+      mockUser = { is_admin: true };
+      mockAuthorQueries([
+        {
+          _id: "task-shared",
+          teamIds: ["team-1"],
+          roleIds: [],
+          segment: "before",
+          title: "Unlock the building",
+          sortOrder: 0,
+        },
+      ]);
+      const { getByLabelText } = render(<ServingTasksScreen />);
+      fireEvent.press(getByLabelText("Edit"));
+
+      const usher = getByLabelText(
+        "View and edit Hospitality Usher tasks, 0 tasks of its own, 1 for the whole team",
+      );
+      const badge = badgeOf(usher as never, "0");
+      expect(badge.view.backgroundColor).not.toBe("#FF9500");
+      expect(badge.view.borderWidth).toBeUndefined();
+    });
+
+    it("alarms for a role that nothing on the plan covers", () => {
+      mockUser = { is_admin: true };
+      mockAuthorQueries([
+        {
+          _id: "task-1",
+          teamIds: ["team-1"],
+          roleIds: ["role-greeter"],
+          segment: "before",
+          title: "Set up welcome table",
+          sortOrder: 0,
+        },
+      ]);
+      const { getByLabelText } = render(<ServingTasksScreen />);
+      fireEvent.press(getByLabelText("Edit"));
+
+      const usher = getByLabelText(
+        "View and edit Hospitality Usher tasks, 0 tasks of its own",
+      );
+      const badge = badgeOf(usher as never, "0");
+      expect(badge.view.backgroundColor).toBe("#FF9500");
+      // White on mid-orange measures ~2.2:1 — under AA for this 11pt/700 text.
+      expect(badge.text.color).not.toBe("#ffffff");
+      expect(badge.text.color).toBe("#000");
+    });
+
+    // Knicks mode sets `primaryColor` to the SAME `#F58426` as `colors.warning`,
+    // and any community may pick an orange brand color. The selected pill is
+    // filled with `primaryColor`, so a solid warning badge dissolved into it and
+    // left a bare floating number.
+    it("keeps the badge visible when the brand color IS the warning color", () => {
+      mockPrimaryColor = "#FF9500";
+      mockUser = { is_admin: true };
+      // Only Usher is authored, so the DEFAULT-selected first pill (Greeter) is
+      // both active and uncovered — the exact collision.
+      mockAuthorQueries([
+        {
+          _id: "task-1",
+          teamIds: ["team-1"],
+          roleIds: ["role-usher"],
+          segment: "before",
+          title: "Count attendance",
+          sortOrder: 0,
+        },
+      ]);
+      const { getByLabelText } = render(<ServingTasksScreen />);
+      fireEvent.press(getByLabelText("Edit"));
+
+      const greeter = getByLabelText(
+        "View and edit Hospitality Greeter tasks, 0 tasks of its own",
+      );
+      const pill = flatten(greeter.props.style);
+      const badge = badgeOf(greeter as never, "0");
+
+      // The premise: fill and pill background have collapsed to one color.
+      expect(pill.backgroundColor).toBe(badge.view.backgroundColor);
+      // …so the chip's edge is what keeps it a chip.
+      expect(badge.view.borderWidth).toBeGreaterThan(0);
+      expect(badge.view.borderColor).not.toBe(badge.view.backgroundColor);
+      expect(badge.view.borderColor).not.toBe(pill.backgroundColor);
+      mockPrimaryColor = "#D9A441";
+    });
+
+    // `createEventDraftImpl` makes task-less plans and Edit is where a leader
+    // lands to fix that — the empty-state notice and "Populate from template"
+    // already say so, so a whole row of orange is noise, not information.
+    it("leaves every pill quiet on a brand-new plan with no tasks at all", () => {
+      mockUser = { is_admin: true };
+      mockAuthorQueries([]);
+      const { getByLabelText } = render(<ServingTasksScreen />);
+      fireEvent.press(getByLabelText("Edit"));
+
+      for (const role of ["Greeter", "Usher"]) {
+        const pill = getByLabelText(
+          `View and edit Hospitality ${role} tasks, 0 tasks of its own`,
+        );
+        expect(badgeOf(pill as never, "0").view.backgroundColor).not.toBe("#FF9500");
+      }
+    });
   });
 
   it("adds a task for the selected role via createTask", async () => {
@@ -1095,21 +1266,6 @@ describe("ServingTasksScreen — whatsapp-shell skin", () => {
     mockWhatsappShell = false;
     jest.clearAllMocks();
   });
-
-  /** Flattens a possibly-nested RN style prop into one object. */
-  const flatten = (style: unknown): Record<string, unknown> => {
-    const out: Record<string, unknown> = {};
-    const walk = (node: unknown) => {
-      if (!node) return;
-      if (Array.isArray(node)) {
-        node.forEach(walk);
-        return;
-      }
-      if (typeof node === "object") Object.assign(out, node);
-    };
-    walk(style);
-    return out;
-  };
 
   const mockCrew = () => {
     mockQuery.mockImplementation((ref: string) => {

--- a/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
@@ -2,15 +2,24 @@ import {
   diagnoseMineEmpty,
   mineEmptyCopy,
   myRoleNamesFromCrew,
-  planTaskCountFromAllTeams,
+  planTaskCountsFromAllTeams,
   shouldOfferSharedJump,
   type MineEmptyFacts,
 } from "../servingTaskEmptyState";
 
-/** Loaded, rostered, task-bearing baseline; each test overrides one fact. */
+/** `total` tasks on the plan, `teamLevel` of which belong to whole teams. */
+function plan(total: number, teamLevel = 0) {
+  return { total, teamLevel };
+}
+
+/**
+ * Loaded, rostered, task-bearing baseline; each test overrides one fact. The
+ * default plan is entirely ROLE-scoped — an all-team-level plan is its own
+ * diagnosis (`team-level-only`), not a role mismatch.
+ */
 function facts(overrides: Partial<MineEmptyFacts> = {}): MineEmptyFacts {
   return {
-    planTaskCount: 4,
+    planTaskCounts: plan(4),
     myRoleNames: ["Greeter"],
     myTemplateTaskCount: 0,
     sharedTaskCount: 0,
@@ -18,24 +27,50 @@ function facts(overrides: Partial<MineEmptyFacts> = {}): MineEmptyFacts {
   };
 }
 
-describe("planTaskCountFromAllTeams", () => {
+/** A `getAllTeamsTasks` task row. Empty `roleNames` == team-level. */
+function row(taskId: string, roleNames: string[] = ["Greeter"]) {
+  return { taskId, roleNames };
+}
+
+describe("planTaskCountsFromAllTeams", () => {
   it("returns null while the query is unresolved", () => {
-    expect(planTaskCountFromAllTeams(undefined)).toBeNull();
+    expect(planTaskCountsFromAllTeams(undefined)).toBeNull();
   });
 
-  it("returns 0 for a plan with no teams and no tasks", () => {
-    expect(planTaskCountFromAllTeams([])).toBe(0);
-    expect(planTaskCountFromAllTeams([{ tasks: [] }])).toBe(0);
+  it("returns zeroes for a plan with no teams and no tasks", () => {
+    expect(planTaskCountsFromAllTeams([])).toEqual(plan(0));
+    expect(planTaskCountsFromAllTeams([{ tasks: [] }])).toEqual(plan(0));
   });
 
   it("counts a multi-team task ONCE (rows are per team, not per task)", () => {
     // `getAllTeamsTasks` lists a task under every team it spans, so summing
     // each team's `taskCount` would over-count. Distinct taskIds is the truth.
-    const count = planTaskCountFromAllTeams([
-      { tasks: [{ taskId: "t1" }, { taskId: "t2" }] },
-      { tasks: [{ taskId: "t1" }, { taskId: "t3" }] },
+    const counts = planTaskCountsFromAllTeams([
+      { tasks: [row("t1"), row("t2")] },
+      { tasks: [row("t1"), row("t3")] },
     ]);
-    expect(count).toBe(3);
+    expect(counts).toEqual(plan(3));
+  });
+
+  // Team-level tasks are counted INTO each team they span, with no roleNames
+  // (`eventTasks.ts`'s `roleIds.length === 0` branch). They are part of the
+  // total, so the copy needs them told apart from the role-scoped ones.
+  it("splits team-level tasks out of the total", () => {
+    const counts = planTaskCountsFromAllTeams([
+      { tasks: [row("t1", []), row("t2")] },
+      { tasks: [row("t1", []), row("t3", [])] },
+    ]);
+    expect(counts).toEqual(plan(3, 2));
+  });
+
+  it("treats a task as role-scoped when ANY team's row names a role", () => {
+    // A multi-team ROLE task carries only that team's roles in each row, so a
+    // team contributing none of them must not make the whole task team-level.
+    const counts = planTaskCountsFromAllTeams([
+      { tasks: [row("t1", [])] },
+      { tasks: [row("t1", ["Sound"])] },
+    ]);
+    expect(counts).toEqual(plan(1, 0));
   });
 });
 
@@ -70,13 +105,13 @@ describe("diagnoseMineEmpty", () => {
   it("has-tasks wins even before the other queries resolve", () => {
     expect(
       diagnoseMineEmpty(
-        facts({ myTemplateTaskCount: 1, planTaskCount: null, myRoleNames: null }),
+        facts({ myTemplateTaskCount: 1, planTaskCounts: null, myRoleNames: null }),
       ),
     ).toBe("has-tasks");
   });
 
   it("loading: refuses to guess while the plan-wide count is unresolved", () => {
-    expect(diagnoseMineEmpty(facts({ planTaskCount: null }))).toBe("loading");
+    expect(diagnoseMineEmpty(facts({ planTaskCounts: null }))).toBe("loading");
   });
 
   it("loading: refuses to guess while the viewer's roles are unresolved", () => {
@@ -98,7 +133,7 @@ describe("diagnoseMineEmpty", () => {
   });
 
   it("no-plan-tasks: the plan has zero eventTasks rows", () => {
-    expect(diagnoseMineEmpty(facts({ planTaskCount: 0 }))).toBe(
+    expect(diagnoseMineEmpty(facts({ planTaskCounts: plan(0) }))).toBe(
       "no-plan-tasks",
     );
   });
@@ -107,7 +142,7 @@ describe("diagnoseMineEmpty", () => {
     // A freshly created plan is BOTH empty and (often) unrostered. The empty
     // task list is the root cause: fixing the roster would change nothing.
     expect(
-      diagnoseMineEmpty(facts({ planTaskCount: 0, myRoleNames: [] })),
+      diagnoseMineEmpty(facts({ planTaskCounts: plan(0), myRoleNames: [] })),
     ).toBe("no-plan-tasks");
   });
 
@@ -119,12 +154,29 @@ describe("diagnoseMineEmpty", () => {
     expect(diagnoseMineEmpty(facts())).toBe("role-mismatch");
   });
 
-  it("role-mismatch covers the team-level-only plan (all tasks on Shared)", () => {
+  // Was `role-mismatch`, which then told the viewer the tasks were "for other
+  // roles" — false: a team-level task is for the viewer's OWN team, which the
+  // very next sentence ("Shared has 3 tasks for your whole team") said out loud.
+  it("team-level-only: every task on the plan belongs to a whole team", () => {
     // Every task is team-level, so `getMyServingTasks` returns none while
     // `getSharedTeamTasks` returns them all.
     expect(
-      diagnoseMineEmpty(facts({ planTaskCount: 3, sharedTaskCount: 3 })),
-    ).toBe("role-mismatch");
+      diagnoseMineEmpty(facts({ planTaskCounts: plan(3, 3), sharedTaskCount: 3 })),
+    ).toBe("team-level-only");
+  });
+
+  it("role-mismatch still wins when only SOME of the plan is team-level", () => {
+    expect(diagnoseMineEmpty(facts({ planTaskCounts: plan(3, 2) }))).toBe(
+      "role-mismatch",
+    );
+  });
+
+  // The team-level-only copy points at "Shared", which is empty for someone
+  // holding no role on any team here — so the rostering gap is the better story.
+  it("not-rostered outranks team-level-only", () => {
+    expect(
+      diagnoseMineEmpty(facts({ planTaskCounts: plan(3, 3), myRoleNames: [] })),
+    ).toBe("not-rostered");
   });
 });
 
@@ -135,7 +187,7 @@ describe("mineEmptyCopy", () => {
   });
 
   it("no-plan-tasks does NOT blame the team lead's configuration", () => {
-    const copy = mineEmptyCopy("no-plan-tasks", facts({ planTaskCount: 0 }))!;
+    const copy = mineEmptyCopy("no-plan-tasks", facts({ planTaskCounts: plan(0) }))!;
     expect(copy.title).toBe("This event has no tasks set up yet.");
     expect(copy.hint).toContain("Nobody has added tasks to it");
     expect(copy.hint).toContain("add your own tasks below");
@@ -147,7 +199,7 @@ describe("mineEmptyCopy", () => {
   it("not-rostered names both ways the assignment can vanish, and neither wrongly", () => {
     const copy = mineEmptyCopy(
       "not-rostered",
-      facts({ planTaskCount: 7, myRoleNames: [] }),
+      facts({ planTaskCounts: plan(7), myRoleNames: [] }),
     )!;
     expect(copy.title).toBe("You're not on the roster for this event.");
     expect(copy.hint).toContain("your assignment was removed, or you declined it");
@@ -162,7 +214,7 @@ describe("mineEmptyCopy", () => {
   it("role-mismatch scopes the count to all teams and names a next step", () => {
     const copy = mineEmptyCopy(
       "role-mismatch",
-      facts({ planTaskCount: 5, myRoleNames: ["Greeter", "Usher"] }),
+      facts({ planTaskCounts: plan(5), myRoleNames: ["Greeter", "Usher"] }),
     )!;
     expect(copy.title).toBe(
       "None of this event's tasks are assigned to your roles.",
@@ -177,7 +229,7 @@ describe("mineEmptyCopy", () => {
   it("role-mismatch uses the singular for one task and one role", () => {
     const copy = mineEmptyCopy(
       "role-mismatch",
-      facts({ planTaskCount: 1, myRoleNames: ["Greeter"] }),
+      facts({ planTaskCounts: plan(1), myRoleNames: ["Greeter"] }),
     )!;
     expect(copy.title).toBe(
       "None of this event's tasks are assigned to your role.",
@@ -194,6 +246,8 @@ describe("mineEmptyCopy", () => {
   // immediately before it, so it read as "Camera's 2 tasks are for other
   // roles" — self-contradictory. The subject is the EVENT, and it must be
   // spelled out; there is no arity of the role list at which "Its" is safe.
+  // (The plan here is entirely ROLE-scoped, which is the only shape for which
+  // "are for other roles" is a true sentence — see the team-level cases below.)
   it("never lets the plan-wide count read as the viewer's role's own tasks", () => {
     for (const myRoleNames of [
       ["Camera"],
@@ -202,7 +256,7 @@ describe("mineEmptyCopy", () => {
     ]) {
       const copy = mineEmptyCopy(
         "role-mismatch",
-        facts({ planTaskCount: 2, myRoleNames }),
+        facts({ planTaskCounts: plan(2), myRoleNames }),
       )!;
       expect(copy.hint).toContain(
         "This event's 2 tasks — across all teams — are for other roles.",
@@ -211,10 +265,81 @@ describe("mineEmptyCopy", () => {
     }
   });
 
+  // The reporter's real data: planTaskCount 2, roles ["Camera"], shared 2 — the
+  // two tasks were TEAM-level, so the old copy said "This event's 2 tasks —
+  // across all teams — are for other roles." one sentence before "Shared has 2
+  // tasks for your whole team." Both cannot be true of the same two tasks.
+  it("never calls team-level tasks 'for other roles'", () => {
+    const copy = mineEmptyCopy(
+      "team-level-only",
+      facts({
+        planTaskCounts: plan(2, 2),
+        myRoleNames: ["Camera"],
+        sharedTaskCount: 2,
+      }),
+    )!;
+    expect(copy.hint).not.toContain("for other roles");
+    expect(copy.hint).not.toContain("for another role");
+    expect(copy.title).toBe("This event's tasks are for whole teams, not roles.");
+    expect(copy.hint).toContain("You're serving as Camera.");
+    expect(copy.hint).toContain(
+      "All 2 of this event's tasks are for whole teams rather than single roles, so none of them are in Mine.",
+    );
+    expect(copy.hint).toContain("Shared has 2 tasks for your whole team.");
+    // Nobody is at fault here, so nobody is asked to fix anything.
+    expect(copy.hint).not.toContain("Ask your team lead");
+  });
+
+  it("uses the singular when the whole plan is one team-level task", () => {
+    const copy = mineEmptyCopy(
+      "team-level-only",
+      facts({ planTaskCounts: plan(1, 1), sharedTaskCount: 1 }),
+    )!;
+    expect(copy.hint).toContain(
+      "This event's only task is for a whole team rather than a single role, so it isn't in Mine.",
+    );
+  });
+
+  // Some role-scoped, some team-level: the sentence may claim only the
+  // role-scoped ones are for other roles, and must account for the rest.
+  it("role-mismatch splits a mixed plan instead of claiming all N are for other roles", () => {
+    const copy = mineEmptyCopy(
+      "role-mismatch",
+      facts({ planTaskCounts: plan(5, 2), myRoleNames: ["Camera"] }),
+    )!;
+    expect(copy.hint).toContain(
+      "Of this event's 5 tasks — across all teams — 3 are for other roles and 2 are for whole teams.",
+    );
+    expect(copy.hint).not.toContain("This event's 5 tasks — across all teams —");
+  });
+
+  it("uses singulars on each side of a mixed plan's split", () => {
+    const copy = mineEmptyCopy(
+      "role-mismatch",
+      facts({ planTaskCounts: plan(2, 1), myRoleNames: ["Camera"] }),
+    )!;
+    expect(copy.hint).toContain(
+      "Of this event's 2 tasks — across all teams — 1 is for another role and 1 is for a whole team.",
+    );
+  });
+
+  // The all-role-scoped plan keeps the plainer sentence — there is no team-level
+  // remainder to account for.
+  it("role-mismatch keeps the simple sentence when nothing is team-level", () => {
+    const copy = mineEmptyCopy(
+      "role-mismatch",
+      facts({ planTaskCounts: plan(3, 0), myRoleNames: ["Camera"] }),
+    )!;
+    expect(copy.hint).toContain(
+      "This event's 3 tasks — across all teams — are for other roles.",
+    );
+    expect(copy.hint).not.toContain("Of this event's");
+  });
+
   it("role-mismatch points at Shared when the team has shared tasks", () => {
     const copy = mineEmptyCopy(
       "role-mismatch",
-      facts({ planTaskCount: 5, sharedTaskCount: 3 }),
+      facts({ planTaskCounts: plan(5), sharedTaskCount: 3 }),
     )!;
     expect(copy.hint).toContain("Shared has 3 tasks for your whole team.");
   });
@@ -291,9 +416,18 @@ describe("shouldOfferSharedJump", () => {
     expect(
       shouldOfferSharedJump(
         "no-plan-tasks",
-        facts({ planTaskCount: 0, sharedTaskCount: 2 }),
+        facts({ planTaskCounts: plan(0), sharedTaskCount: 2 }),
       ),
     ).toBe(false);
+  });
+
+  it("offers the jump when the whole plan is team-level (Shared holds it all)", () => {
+    expect(
+      shouldOfferSharedJump(
+        "team-level-only",
+        facts({ planTaskCounts: plan(3, 3), sharedTaskCount: 3 }),
+      ),
+    ).toBe(true);
   });
 
   it("withholds it while the shared count is unresolved", () => {

--- a/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
@@ -168,7 +168,9 @@ describe("mineEmptyCopy", () => {
       "None of this event's tasks are assigned to your roles.",
     );
     expect(copy.hint).toContain("You're serving as Greeter and Usher.");
-    expect(copy.hint).toContain("Its 5 tasks — across all teams — are for other roles.");
+    expect(copy.hint).toContain(
+      "This event's 5 tasks — across all teams — are for other roles.",
+    );
     expect(copy.hint).toContain("Ask your team lead to add tasks for your roles.");
   });
 
@@ -181,8 +183,32 @@ describe("mineEmptyCopy", () => {
       "None of this event's tasks are assigned to your role.",
     );
     expect(copy.hint).toContain("You're serving as Greeter.");
-    expect(copy.hint).toContain("Its 1 task — across all teams — is for other roles.");
+    expect(copy.hint).toContain(
+      "This event's 1 task — across all teams — is for another role.",
+    );
     expect(copy.hint).toContain("Ask your team lead to add tasks for your role.");
+  });
+
+  // Shipped in #702 and seen live: "You're serving as Camera. Its 2 tasks —
+  // across all teams — are for other roles." "Its" attaches to the role named
+  // immediately before it, so it read as "Camera's 2 tasks are for other
+  // roles" — self-contradictory. The subject is the EVENT, and it must be
+  // spelled out; there is no arity of the role list at which "Its" is safe.
+  it("never lets the plan-wide count read as the viewer's role's own tasks", () => {
+    for (const myRoleNames of [
+      ["Camera"],
+      ["Camera", "Usher"],
+      ["Camera", "Usher", "Greeter"],
+    ]) {
+      const copy = mineEmptyCopy(
+        "role-mismatch",
+        facts({ planTaskCount: 2, myRoleNames }),
+      )!;
+      expect(copy.hint).toContain(
+        "This event's 2 tasks — across all teams — are for other roles.",
+      );
+      expect(copy.hint).not.toContain("Its ");
+    }
   });
 
   it("role-mismatch points at Shared when the team has shared tasks", () => {
@@ -204,6 +230,30 @@ describe("mineEmptyCopy", () => {
       facts({ myRoleNames: ["Camera 1", "Greeter", "Usher"] }),
     )!;
     expect(copy.hint).toContain("You're serving as Camera 1, Greeter and Usher.");
+  });
+
+  // `myRoleNamesFromCrew` returns EVERY role the viewer holds, so the copy has
+  // to name all of them — someone rostered for three things who is told
+  // "You're serving as Camera" reasonably doubts the whole message.
+  it.each([
+    [["Camera 1"], "Camera 1", "role"],
+    [["Camera 1", "Usher"], "Camera 1 and Usher", "roles"],
+    [["Camera 1", "Usher", "Greeter"], "Camera 1, Usher and Greeter", "roles"],
+    [
+      ["Camera 1", "Usher", "Greeter", "Drums"],
+      "Camera 1, Usher, Greeter and Drums",
+      "roles",
+    ],
+  ])("names all %# roles the viewer holds", (myRoleNames, joined, roleWord) => {
+    const copy = mineEmptyCopy("role-mismatch", facts({ myRoleNames }))!;
+    expect(copy.hint).toContain(`You're serving as ${joined}.`);
+    expect(copy.title).toBe(
+      `None of this event's tasks are assigned to your ${roleWord}.`,
+    );
+    expect(copy.hint).toContain(
+      `Ask your team lead to add tasks for your ${roleWord}.`,
+    );
+    for (const name of myRoleNames) expect(copy.hint).toContain(name);
   });
 
   it("says nothing at all about Shared while its count is unresolved", () => {

--- a/apps/mobile/features/serving/utils/__tests__/taskAuthoring.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/taskAuthoring.test.ts
@@ -2,6 +2,7 @@ import {
   buildRoleCatalog,
   canAuthorPlanTasks,
   isTeamLevelTask,
+  roleTaskCounts,
   tasksForRole,
   type AuthorableTask,
 } from "../taskAuthoring";
@@ -201,5 +202,84 @@ describe("buildRoleCatalog", () => {
 
   it("returns an empty catalog for no teams", () => {
     expect(buildRoleCatalog([], {})).toEqual([]);
+  });
+});
+
+describe("roleTaskCounts", () => {
+  const catalog = [
+    { roleId: "role-a" },
+    { roleId: "role-b" },
+    { roleId: "role-c" },
+  ];
+
+  it("counts each role's OWN tasks and gives an unauthored role 0", () => {
+    const tasks: AuthorableTask[] = [
+      { teamIds: ["team-1"], roleIds: ["role-a"], segment: "before", sortOrder: 0 },
+      { teamIds: ["team-1"], roleIds: ["role-a"], segment: "after", sortOrder: 1 },
+      { teamIds: ["team-1"], roleIds: ["role-b"], segment: "during", sortOrder: 0 },
+    ];
+    expect(roleTaskCounts(tasks, catalog)).toEqual({
+      "role-a": 2,
+      "role-b": 1,
+      "role-c": 0,
+    });
+  });
+
+  // The badge exists to make a gap visible. `tasksForRole` folds a team's
+  // team-level tasks into EVERY role on that team, so counting its output
+  // would put "1" on all four Worship roles and hide the very gap a manager is
+  // scanning for. Team-level tasks stay visible (captioned "Whole team") in
+  // the body — they just don't inflate the badge.
+  it("excludes team-level tasks, unlike tasksForRole", () => {
+    const tasks: AuthorableTask[] = [
+      { teamIds: ["team-1"], roleIds: [], segment: "before", sortOrder: 0 },
+      { teamIds: ["team-1"], roleIds: ["role-a"], segment: "before", sortOrder: 1 },
+    ];
+    expect(roleTaskCounts(tasks, catalog)).toEqual({
+      "role-a": 1,
+      "role-b": 0,
+      "role-c": 0,
+    });
+    // The body list for role-b is NOT empty — it shows the team-level task —
+    // which is exactly why the badge must not reuse this number.
+    expect(
+      tasksForRole(tasks, { roleId: "role-b", teamId: "team-1" }).before,
+    ).toHaveLength(1);
+  });
+
+  it("counts a multi-role task once for each role it names", () => {
+    const tasks: AuthorableTask[] = [
+      {
+        teamIds: ["team-1"],
+        roleIds: ["role-a", "role-b"],
+        segment: "during",
+        sortOrder: 0,
+      },
+    ];
+    expect(roleTaskCounts(tasks, catalog)).toEqual({
+      "role-a": 1,
+      "role-b": 1,
+      "role-c": 0,
+    });
+  });
+
+  it("ignores roles outside the catalog (another team's roles may not have loaded)", () => {
+    const tasks: AuthorableTask[] = [
+      { teamIds: ["team-2"], roleIds: ["role-z"], segment: "before", sortOrder: 0 },
+    ];
+    expect(roleTaskCounts(tasks, catalog)).toEqual({
+      "role-a": 0,
+      "role-b": 0,
+      "role-c": 0,
+    });
+  });
+
+  it("returns an entry per catalog role for an empty plan, and {} for an empty catalog", () => {
+    expect(roleTaskCounts([], catalog)).toEqual({
+      "role-a": 0,
+      "role-b": 0,
+      "role-c": 0,
+    });
+    expect(roleTaskCounts([], [])).toEqual({});
   });
 });

--- a/apps/mobile/features/serving/utils/__tests__/taskAuthoring.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/taskAuthoring.test.ts
@@ -2,6 +2,7 @@ import {
   buildRoleCatalog,
   canAuthorPlanTasks,
   isTeamLevelTask,
+  roleCoveredTaskCounts,
   roleTaskCounts,
   tasksForRole,
   type AuthorableTask,
@@ -281,5 +282,77 @@ describe("roleTaskCounts", () => {
       "role-c": 0,
     });
     expect(roleTaskCounts([], [])).toEqual({});
+  });
+});
+
+/**
+ * The count the WARNING tint is allowed to read. `roleTaskCounts` answers a
+ * different question and must never drive an alarm — a plan authored entirely
+ * as "Whole team" tasks is fully authored, but every role's own count is 0.
+ */
+describe("roleCoveredTaskCounts", () => {
+  const catalog = [
+    { roleId: "role-a", teamId: "team-1" },
+    { roleId: "role-b", teamId: "team-1" },
+    { roleId: "role-c", teamId: "team-2" },
+  ];
+
+  it("counts a team-level task for every role on ITS team, and no others", () => {
+    const tasks: AuthorableTask[] = [
+      { teamIds: ["team-1"], roleIds: [], segment: "before", sortOrder: 0 },
+    ];
+    // The badge number stays 0 for all three — that gap is real and worth
+    // showing — but nothing on team-1 is UNCOVERED, so nothing may alarm.
+    expect(roleTaskCounts(tasks, catalog)).toEqual({
+      "role-a": 0,
+      "role-b": 0,
+      "role-c": 0,
+    });
+    expect(roleCoveredTaskCounts(tasks, catalog)).toEqual({
+      "role-a": 1,
+      "role-b": 1,
+      "role-c": 0,
+    });
+  });
+
+  it("agrees with the length of the role's own body list", () => {
+    const tasks: AuthorableTask[] = [
+      { teamIds: ["team-1"], roleIds: [], segment: "before", sortOrder: 0 },
+      { teamIds: ["team-1"], roleIds: ["role-a"], segment: "during", sortOrder: 1 },
+      { teamIds: ["team-1"], roleIds: ["role-a"], segment: "after", sortOrder: 2 },
+    ];
+    const covered = roleCoveredTaskCounts(tasks, catalog);
+    for (const role of catalog) {
+      const buckets = tasksForRole(tasks, role);
+      const shown =
+        buckets.before.length + buckets.during.length + buckets.after.length;
+      expect(covered[role.roleId]).toBe(shown);
+    }
+    expect(covered["role-a"]).toBe(3);
+  });
+
+  it("counts a multi-team team-level task under every team it spans", () => {
+    const tasks: AuthorableTask[] = [
+      {
+        teamIds: ["team-1", "team-2"],
+        roleIds: [],
+        segment: "before",
+        sortOrder: 0,
+      },
+    ];
+    expect(roleCoveredTaskCounts(tasks, catalog)).toEqual({
+      "role-a": 1,
+      "role-b": 1,
+      "role-c": 1,
+    });
+  });
+
+  it("returns an entry per catalog role for an empty plan, and {} for an empty catalog", () => {
+    expect(roleCoveredTaskCounts([], catalog)).toEqual({
+      "role-a": 0,
+      "role-b": 0,
+      "role-c": 0,
+    });
+    expect(roleCoveredTaskCounts([], [])).toEqual({});
   });
 });

--- a/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
+++ b/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
@@ -45,13 +45,32 @@ export type MineEmptyReason =
   | "no-plan-tasks"
   /** The viewer holds no non-declined role on this plan (rostering gap). */
   | "not-rostered"
+  /**
+   * Every task on the plan is TEAM-LEVEL — cause #2 above. Nothing is missing
+   * and nothing is misassigned; the tasks simply live on "Shared". Split out of
+   * `role-mismatch`, which said they were "for other roles" — false, since
+   * team-level tasks are for the viewer's OWN team.
+   */
+  | "team-level-only"
   /** Tasks exist; none name a role the viewer holds. */
   | "role-mismatch";
 
+/**
+ * How a plan's tasks split. `total` is what "this event has N tasks" may claim;
+ * `teamLevel` is the part of it that belongs to whole TEAMS rather than roles,
+ * and therefore may never be described as being "for other roles".
+ */
+export interface PlanTaskCounts {
+  /** Distinct tasks on the whole plan (every team, every role). */
+  total: number;
+  /** Of `total`, the ones with no roles (`roleIds: []`) — see `teamLevel`. */
+  teamLevel: number;
+}
+
 /** The facts `diagnoseMineEmpty` reasons over. `null` means "not loaded yet". */
 export interface MineEmptyFacts {
-  /** Distinct tasks on the whole plan (every team, every role). */
-  planTaskCount: number | null;
+  /** The plan's task split, or `null` while `getAllTeamsTasks` is unresolved. */
+  planTaskCounts: PlanTaskCounts | null;
   /** Names of the roles the viewer holds on this plan, in display order. */
   myRoleNames: string[] | null;
   /** Preloaded (non-personal) tasks in the viewer's own "Mine" list. */
@@ -70,21 +89,42 @@ export interface MineEmptyFacts {
 }
 
 /**
- * Distinct plan-wide task count from `getAllTeamsTasks`.
+ * Distinct plan-wide task counts from `getAllTeamsTasks`, split by scope.
  *
  * A task that spans several teams is listed once per team, so the rows must be
  * de-duplicated by `taskId` — `taskCount` summed across teams would over-count.
  * Returns `null` while the query is unresolved.
+ *
+ * `getAllTeamsTasks` counts TEAM-LEVEL tasks into each team they span, with an
+ * empty `roleNames` (see the `roleIds.length === 0` branch in `eventTasks.ts`).
+ * They are therefore inside `total`, which is why the copy has to know how many
+ * of the total they are: a sentence about "this event's N tasks" that treats
+ * team-level ones as belonging to other roles contradicts itself.
+ *
+ * A role task that spans teams carries that team's roles in every row, so
+ * "team-level" is "no row names a role".
  */
-export function planTaskCountFromAllTeams(
-  teams: ReadonlyArray<{ tasks: ReadonlyArray<{ taskId: string }> }> | undefined,
-): number | null {
+export function planTaskCountsFromAllTeams(
+  teams:
+    | ReadonlyArray<{
+        tasks: ReadonlyArray<{ taskId: string; roleNames: readonly string[] }>;
+      }>
+    | undefined,
+): PlanTaskCounts | null {
   if (teams === undefined) return null;
-  const ids = new Set<string>();
+  const teamLevelById = new Map<string, boolean>();
   for (const team of teams) {
-    for (const task of team.tasks) ids.add(task.taskId);
+    for (const task of team.tasks) {
+      const teamLevel =
+        (teamLevelById.get(task.taskId) ?? true) && task.roleNames.length === 0;
+      teamLevelById.set(task.taskId, teamLevel);
+    }
   }
-  return ids.size;
+  let teamLevel = 0;
+  for (const isTeamLevel of teamLevelById.values()) {
+    if (isTeamLevel) teamLevel += 1;
+  }
+  return { total: teamLevelById.size, teamLevel };
 }
 
 /**
@@ -124,19 +164,26 @@ export function myRoleNamesFromCrew(
  *     not on the roster" would send them after the wrong problem.
  *  4. `not-rostered` — must precede `role-mismatch`, which would otherwise
  *     claim "none of these tasks match your role" to someone holding no role.
- *  5. `role-mismatch`.
+ *     It also precedes `team-level-only`, whose copy sends the viewer to
+ *     "Shared" — a tab that is empty for someone on no team at all.
+ *  5. `team-level-only` — nothing is misassigned, so this must be told apart
+ *     from `role-mismatch` before that one gets to blame other roles.
+ *  6. `role-mismatch`.
  */
 export function diagnoseMineEmpty(facts: MineEmptyFacts): MineEmptyReason {
   if (facts.myTemplateTaskCount > 0) return "has-tasks";
   if (
-    facts.planTaskCount === null ||
+    facts.planTaskCounts === null ||
     facts.myRoleNames === null ||
     facts.sharedTaskCount === null
   ) {
     return "loading";
   }
-  if (facts.planTaskCount === 0) return "no-plan-tasks";
+  if (facts.planTaskCounts.total === 0) return "no-plan-tasks";
   if (facts.myRoleNames.length === 0) return "not-rostered";
+  if (facts.planTaskCounts.teamLevel === facts.planTaskCounts.total) {
+    return "team-level-only";
+  }
   return "role-mismatch";
 }
 
@@ -204,10 +251,33 @@ export function mineEmptyCopy(
         hint: "Tasks follow roles, and you don't hold one here — your assignment was removed, or you declined it. If that's not right, check with your team lead.",
       };
 
+    // Nothing here is anybody's mistake: the plan is authored, just entirely at
+    // TEAM level. `role-mismatch` used to swallow this case and tell the viewer
+    // the tasks were "for other roles" — in the same breath as pointing them at
+    // "Shared … for your whole team", which is the opposite claim.
+    case "team-level-only": {
+      const roles = facts.myRoleNames ?? [];
+      const total = facts.planTaskCounts?.total ?? 0;
+      const scope =
+        total === 1
+          ? "This event's only task is for a whole team rather than a single role, so it isn't in Mine."
+          : `All ${total} of this event's tasks are for whole teams rather than single roles, so none of them are in Mine.`;
+      return {
+        title: "This event's tasks are for whole teams, not roles.",
+        hint: [
+          roles.length > 0 ? `You're serving as ${formatRoleList(roles)}.` : null,
+          scope,
+          sharedHint,
+        ]
+          .filter(Boolean)
+          .join(" "),
+      };
+    }
+
     case "role-mismatch": {
       const roles = facts.myRoleNames ?? [];
       const roleWord = roles.length === 1 ? "role" : "roles";
-      // `planTaskCount` is PLAN-wide, across every team. Leading with it read as
+      // The count is PLAN-wide, across every team. Leading with it read as
       // "20 tasks exist and you were skipped" — for a Kids volunteer on a plan
       // where Worship authored all 20 and Kids authored none, that points at a
       // non-problem. Say "across all teams" out loud instead, and restore the
@@ -217,14 +287,28 @@ export function mineEmptyCopy(
       // whose nearest antecedent is the ROLE named in the sentence before it —
       // so "You're serving as Camera. Its 2 tasks … are for other roles." read
       // as Camera's own tasks being for other roles, which contradicts itself.
+      //
+      // Only the ROLE-SCOPED tasks are for other roles. The team-level ones are
+      // for whole teams — the viewer's own included — so they get counted out
+      // loud and separately rather than folded into the "for other roles" claim
+      // (`diagnoseMineEmpty` has already peeled off the all-team-level plan, so
+      // `roleScoped` is at least 1 here).
+      const counts = facts.planTaskCounts;
+      const roleScoped = counts === null ? 0 : counts.total - counts.teamLevel;
       const planWide =
-        facts.planTaskCount === null
+        counts === null
           ? null
-          : `This event's ${pluralTasks(facts.planTaskCount)} — across all teams — ${
-              facts.planTaskCount === 1
-                ? "is for another role"
-                : "are for other roles"
-            }.`;
+          : counts.teamLevel === 0
+            ? `This event's ${pluralTasks(roleScoped)} — across all teams — ${
+                roleScoped === 1 ? "is for another role" : "are for other roles"
+              }.`
+            : `Of this event's ${pluralTasks(counts.total)} — across all teams — ${
+                roleScoped === 1 ? "1 is for another role" : `${roleScoped} are for other roles`
+              } and ${
+                counts.teamLevel === 1
+                  ? "1 is for a whole team"
+                  : `${counts.teamLevel} are for whole teams`
+              }.`;
       return {
         title: `None of this event's tasks are assigned to your ${roleWord}.`,
         hint: [
@@ -243,7 +327,7 @@ export function mineEmptyCopy(
 /**
  * Whether the notice should offer its one-tap jump to the "Shared" tab.
  *
- * Only for the two states where whole-team tasks are a genuine next place to
+ * Only for the states where whole-team tasks are a genuine next place to
  * look. `no-plan-tasks` is excluded on purpose: a stale-cache mix (an empty
  * all-teams snapshot next to a cached shared list) could otherwise render
  * "This event has no tasks set up yet." directly above "Open Shared (2)".
@@ -252,6 +336,12 @@ export function shouldOfferSharedJump(
   reason: MineEmptyReason,
   facts: MineEmptyFacts,
 ): boolean {
-  if (reason !== "role-mismatch" && reason !== "not-rostered") return false;
+  if (
+    reason !== "role-mismatch" &&
+    reason !== "not-rostered" &&
+    reason !== "team-level-only"
+  ) {
+    return false;
+  }
   return (facts.sharedTaskCount ?? 0) > 0;
 }

--- a/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
+++ b/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
@@ -212,12 +212,19 @@ export function mineEmptyCopy(
       // where Worship authored all 20 and Kids authored none, that points at a
       // non-problem. Say "across all teams" out loud instead, and restore the
       // one actionable instruction the old single-message copy had.
+      //
+      // The subject is spelled out as "This event's". It used to be "Its",
+      // whose nearest antecedent is the ROLE named in the sentence before it —
+      // so "You're serving as Camera. Its 2 tasks … are for other roles." read
+      // as Camera's own tasks being for other roles, which contradicts itself.
       const planWide =
         facts.planTaskCount === null
           ? null
-          : `Its ${pluralTasks(facts.planTaskCount)} — across all teams — ${
-              facts.planTaskCount === 1 ? "is" : "are"
-            } for other roles.`;
+          : `This event's ${pluralTasks(facts.planTaskCount)} — across all teams — ${
+              facts.planTaskCount === 1
+                ? "is for another role"
+                : "are for other roles"
+            }.`;
       return {
         title: `None of this event's tasks are assigned to your ${roleWord}.`,
         hint: [

--- a/apps/mobile/features/serving/utils/taskAuthoring.ts
+++ b/apps/mobile/features/serving/utils/taskAuthoring.ts
@@ -177,3 +177,35 @@ export function roleTaskCounts(
   }
   return counts;
 }
+
+/**
+ * How many tasks COVER each role — its own tasks PLUS the team-level ones that
+ * apply to it. This is `tasksForRole(...).length` per role, i.e. exactly what
+ * the body list shows once a pill is tapped. Keyed by `roleId`; every role in
+ * the catalog gets an entry.
+ *
+ * The distinction from `roleTaskCounts` is the whole point: that one answers
+ * "what has been authored FOR this role" (the badge NUMBER — a role with a big
+ * fat 0 is the gap a leader is scanning for), this one answers "does anything
+ * reach a volunteer in this role at all". They diverge exactly when a plan is
+ * authored at team level — the "Whole team" pattern — and conflating them made
+ * the pill announce "no tasks yet" for a role whose list then read out tasks.
+ * Only THIS count may drive an alarm, or a fully authored event reads as
+ * unauthored.
+ */
+export function roleCoveredTaskCounts(
+  tasks: readonly AuthorableTask[],
+  roleCatalog: readonly Pick<RoleCatalogEntry, "roleId" | "teamId">[],
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const role of roleCatalog) counts[role.roleId] = 0;
+  for (const task of tasks) {
+    for (const role of roleCatalog) {
+      const belongs = isTeamLevelTask(task)
+        ? task.teamIds.includes(role.teamId)
+        : task.roleIds.includes(role.roleId);
+      if (belongs) counts[role.roleId] += 1;
+    }
+  }
+  return counts;
+}

--- a/apps/mobile/features/serving/utils/taskAuthoring.ts
+++ b/apps/mobile/features/serving/utils/taskAuthoring.ts
@@ -142,3 +142,38 @@ export function buildRoleCatalog(
       a.roleName.localeCompare(b.roleName),
   );
 }
+
+/**
+ * How many tasks each role in the catalog has OF ITS OWN, for the badge on the
+ * Edit surface's role pills. Keyed by `roleId`; every role in the catalog gets
+ * an entry, so a role with none reads `0` rather than `undefined`.
+ *
+ * TEAM-LEVEL tasks (`roleIds: []`) are deliberately EXCLUDED — this count is
+ * NOT `tasksForRole(...).length`. That function folds a team's team-level tasks
+ * into every role on that team (on purpose — see its docblock), which is right
+ * for the body list but wrong for the badge: the whole point of the badge is
+ * spotting the role nobody has authored for. On a plan whose Worship team has
+ * one "Sound check" team-level task, a `tasksForRole`-based count would put
+ * "1" on Drums, Vocals, Bass and Keys alike and hide exactly the gap a manager
+ * is scanning for. Team-level tasks are still visible — and still captioned
+ * "Whole team" — in the body once a pill is selected.
+ *
+ * A task naming several roles counts once for each of them; that's real work
+ * for each of those roles.
+ */
+export function roleTaskCounts(
+  tasks: readonly AuthorableTask[],
+  roleCatalog: readonly Pick<RoleCatalogEntry, "roleId">[],
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const role of roleCatalog) counts[role.roleId] = 0;
+  for (const task of tasks) {
+    if (isTeamLevelTask(task)) continue;
+    for (const roleId of task.roleIds) {
+      // Ignore roles outside the catalog: `listPlanTasks` is plan-wide and can
+      // name a role on a team whose `listRoles` hasn't resolved yet.
+      if (roleId in counts) counts[roleId] += 1;
+    }
+  }
+  return counts;
+}


### PR DESCRIPTION
Two fixes from live device screenshots, both in serving mode.

## Role pills now carry a task count

A manager standing at the venue asked to "swipe through roles on the team and figure it out" — the point being to find the role nobody has written tasks for. Today the Edit tab's role pills show only `{team} · {role}`, so the only way to find an empty role is to tap all of them.

Each pill now shows a count badge, reusing the existing `SectionPills` badge styling rather than new chrome.

**The count is the role's OWN tasks, excluding team-level ones — and that distinction is the whole feature.** `tasksForRole` deliberately folds team-level tasks into every role on the same team, so a role with no work of its own still displays its team's tasks and does not look empty. A badge that counted those would read "1" on every Worship role and hide exactly the gap the manager is hunting for. `roleTaskCounts` skips `isTeamLevelTask` rows for this reason; the body still shows team-level tasks with their existing "Whole team — not just this role" caption, so nothing is hidden — it just isn't counted as the role's own.

This is the "figure it out" half of the request. Swiping is deliberately **not** in this PR — there's no pager library in `apps/mobile`, and adding `react-native-pager-view` would be a new native dependency subject to the whole ADR-013 gauntlet. The layout question (a horizontally-paging list has no intrinsic height inside the tab's existing vertical scroll) is a design decision still open.

## "Its 2 tasks" said the opposite of what it meant

Seen on a device:

> You're serving as Camera. **Its** 2 tasks — across all teams — are for other roles.

"Its" attaches to Camera, so it reads as *Camera's* 2 tasks being for other roles — self-contradictory. It meant the event's. Now spelled out as "This event's 2 tasks".

While there: the sentence named a single role even though `myRoleNamesFromCrew` returns an array, which is what made the reporter doubt whether they were rostered for several things. Role names now render through a `formatRoleList` helper, with unit tests for one, two, and three-or-more roles.

## Verification

- `apps/mobile` — 222 suites / 2225 tests passed (+13)
- ESLint on all changed files — clean
- No dependencies changed; native-safety gates not applicable

## Not verified

No device run. Pure TS/JSX, no native view or dependency change, so ADR-013's risk factors don't apply — but both changes are visual, so they're worth a look on a staging OTA.

Context: the reporter's Camera role genuinely has no tasks. `createDemoCommunity` seeds exactly two `eventTasks` per plan, both team-level, on Worship and Kids — Production gets none. The empty state was telling the truth; this PR makes that legible rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168KrbHskjSAFjB6sSHgkXA

---
_Generated by [Claude Code](https://claude.ai/code/session_0168KrbHskjSAFjB6sSHgkXA)_