### PR TITLE
Say which role rostered each serving task, and which plan you're looking at

### DIFF
--- a/apps/convex/__tests__/scheduling/eventTasks.test.ts
+++ b/apps/convex/__tests__/scheduling/eventTasks.test.ts
@@ -1366,3 +1366,264 @@ describe("unconfirmed volunteers reach serving-mode tasks/crew", () => {
     ).rejects.toThrow();
   });
 });
+
+/**
+ * Per-task provenance: WHICH of the viewer's roles put this task in their list.
+ *
+ * `getMyServingTasks` already unioned every role the viewer holds and matched
+ * tasks against the union — then dropped which role matched, so a volunteer
+ * holding two roles got one flat, unattributed list.
+ */
+describe("getMyServingTasks role provenance", () => {
+  /** A second team on the same group, with its own role, for the viewer. */
+  async function addSecondTeamRole(
+    t: ReturnType<typeof convexTest>,
+    world: Awaited<ReturnType<typeof buildSchedulingWorld>>,
+    planId: Id<"eventPlans">,
+    userId: Id<"users">,
+    teamName: string,
+    roleName: string,
+  ) {
+    return t.run(async (ctx: any) => {
+      const teamId = await ctx.db.insert("teams", {
+        groupId: world.groupId,
+        communityId: world.communityId,
+        name: teamName,
+        createdAt: Date.now(),
+        createdById: world.groupLeaderId,
+        updatedAt: Date.now(),
+      });
+      const roleId = await ctx.db.insert("teamRoles", {
+        teamId,
+        communityId: world.communityId,
+        name: roleName,
+        sortOrder: 0,
+        createdAt: Date.now(),
+        createdById: world.groupLeaderId,
+      });
+      const plan = await ctx.db.get(planId);
+      await ctx.db.insert("roleAssignments", {
+        planId,
+        teamId,
+        roleId,
+        userId,
+        eventDate: plan.eventDate,
+        status: "confirmed",
+        assignedById: world.groupLeaderId,
+        assignedAt: Date.now(),
+      });
+      return { teamId, roleId };
+    });
+  }
+
+  it("names the role and team that rostered each task", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const { planId } = await createEvent(t, world, leaderToken);
+    await assignAndConfirm(t, world, leaderToken, planId, world.channelMemberId);
+
+    await t.mutation(api.functions.scheduling.eventTasks.createTask, {
+      token: leaderToken,
+      planId,
+      teamIds: [world.teamId],
+      roleIds: [world.roleId],
+      segment: "before",
+      title: "Set up drums",
+      howToType: "none",
+    });
+
+    const mine = await t.query(
+      api.functions.scheduling.eventTasks.getMyServingTasks,
+      { token: memberToken, planId },
+    );
+    expect(mine.before[0].roles).toEqual([
+      {
+        roleId: world.roleId,
+        roleName: "Drums",
+        teamId: world.teamId,
+        teamName: "Worship Team",
+      },
+    ]);
+  });
+
+  it("attributes each task to the role it actually matched", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const { planId } = await createEvent(t, world, leaderToken);
+    await assignAndConfirm(t, world, leaderToken, planId, world.channelMemberId);
+    const second = await addSecondTeamRole(
+      t,
+      world,
+      planId,
+      world.channelMemberId,
+      "Production",
+      "Camera",
+    );
+
+    await t.mutation(api.functions.scheduling.eventTasks.createTask, {
+      token: leaderToken,
+      planId,
+      teamIds: [world.teamId],
+      roleIds: [world.roleId],
+      segment: "before",
+      title: "Set up drums",
+      howToType: "none",
+    });
+    await t.mutation(api.functions.scheduling.eventTasks.createTask, {
+      token: leaderToken,
+      planId,
+      teamIds: [second.teamId],
+      roleIds: [second.roleId],
+      segment: "before",
+      title: "Frame the stage",
+      howToType: "none",
+    });
+
+    const mine = await t.query(
+      api.functions.scheduling.eventTasks.getMyServingTasks,
+      { token: memberToken, planId },
+    );
+    const byTitle = Object.fromEntries(mine.before.map((x) => [x.title, x]));
+    expect(byTitle["Set up drums"].roles).toEqual([
+      {
+        roleId: world.roleId,
+        roleName: "Drums",
+        teamId: world.teamId,
+        teamName: "Worship Team",
+      },
+    ]);
+    expect(byTitle["Frame the stage"].roles).toEqual([
+      {
+        roleId: second.roleId,
+        roleName: "Camera",
+        teamId: second.teamId,
+        teamName: "Production",
+      },
+    ]);
+  });
+
+  it("reports EVERY held role a task matched, not just the first", async () => {
+    // `roleIds` is an array, so one task can be the viewer's twice over.
+    // Reporting one match would understate what they hold — the exact doubt
+    // this exists to settle.
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const { planId } = await createEvent(t, world, leaderToken);
+    await assignAndConfirm(t, world, leaderToken, planId, world.channelMemberId);
+    const second = await addSecondTeamRole(
+      t,
+      world,
+      planId,
+      world.channelMemberId,
+      "Production",
+      "Camera",
+    );
+
+    await t.mutation(api.functions.scheduling.eventTasks.createTask, {
+      token: leaderToken,
+      planId,
+      teamIds: [world.teamId, second.teamId],
+      roleIds: [world.roleId, second.roleId],
+      segment: "before",
+      title: "Sound check",
+      howToType: "none",
+    });
+
+    const mine = await t.query(
+      api.functions.scheduling.eventTasks.getMyServingTasks,
+      { token: memberToken, planId },
+    );
+    expect(mine.before[0].roles.map((r) => r.roleName)).toEqual([
+      "Drums",
+      "Camera",
+    ]);
+  });
+
+  it("omits the roles the viewer does NOT hold from a multi-role task", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const { planId } = await createEvent(t, world, leaderToken);
+    await assignAndConfirm(t, world, leaderToken, planId, world.channelMemberId);
+
+    // A second role on the plan that the viewer is NOT assigned to.
+    const otherRoleId = await t.run(async (ctx: any) =>
+      ctx.db.insert("teamRoles", {
+        teamId: world.teamId,
+        communityId: world.communityId,
+        name: "Bass",
+        sortOrder: 1,
+        createdAt: Date.now(),
+        createdById: world.groupLeaderId,
+      }),
+    );
+
+    await t.mutation(api.functions.scheduling.eventTasks.createTask, {
+      token: leaderToken,
+      planId,
+      teamIds: [world.teamId],
+      roleIds: [world.roleId, otherRoleId],
+      segment: "before",
+      title: "Tune up",
+      howToType: "none",
+    });
+
+    const mine = await t.query(
+      api.functions.scheduling.eventTasks.getMyServingTasks,
+      { token: memberToken, planId },
+    );
+    expect(mine.before[0].roles.map((r) => r.roleName)).toEqual(["Drums"]);
+  });
+
+  it("gives personal tasks no provenance — nobody rostered them", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const { planId } = await createEvent(t, world, leaderToken);
+    await assignAndConfirm(t, world, leaderToken, planId, world.channelMemberId);
+
+    await t.mutation(api.functions.scheduling.eventTasks.addPersonalTask, {
+      token: memberToken,
+      planId,
+      segment: "after",
+      title: "Pack up my sticks",
+    });
+
+    const mine = await t.query(
+      api.functions.scheduling.eventTasks.getMyServingTasks,
+      { token: memberToken, planId },
+    );
+    expect(mine.after[0].isPersonal).toBe(true);
+    expect(mine.after[0].roles).toEqual([]);
+  });
+
+  it("keeps the provenance on every expanded 'during' service time", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const memberToken = (await generateTokens(world.channelMemberId)).accessToken;
+    const { planId } = await createEvent(t, world, leaderToken);
+    await assignAndConfirm(t, world, leaderToken, planId, world.channelMemberId);
+
+    await t.mutation(api.functions.scheduling.eventTasks.createTask, {
+      token: leaderToken,
+      planId,
+      teamIds: [world.teamId],
+      roleIds: [world.roleId],
+      segment: "during",
+      title: "Play",
+      howToType: "none",
+    });
+
+    const mine = await t.query(
+      api.functions.scheduling.eventTasks.getMyServingTasks,
+      { token: memberToken, planId },
+    );
+    expect(mine.during).toHaveLength(2);
+    for (const row of mine.during) {
+      expect(row.roles.map((r) => r.roleName)).toEqual(["Drums"]);
+    }
+  });
+});

--- a/apps/convex/__tests__/scheduling/events.test.ts
+++ b/apps/convex/__tests__/scheduling/events.test.ts
@@ -627,3 +627,73 @@ describe("deleteEvent cascade", () => {
     expect(await activeSynced()).toHaveLength(0);
   });
 });
+
+/**
+ * The default plan title.
+ *
+ * Both no-title entry points ("Add date" on the roster grid, and quick-start)
+ * hardcoded the literal string "Untitled event plan", which shipped straight
+ * into serving mode's plan headers and read like missing data. The title now
+ * falls back to a GROUP-derived default — not a date-derived one, because both
+ * callers create the plan at a placeholder date the leader changes afterwards.
+ */
+describe("createEvent default title", () => {
+  it("derives a title from the group when none is given", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const eventDate = Date.now() + 7 * DAY;
+
+    const { planId } = await t.mutation(
+      api.functions.scheduling.events.createEvent,
+      {
+        token: leaderToken,
+        groupId: world.groupId,
+        eventDate,
+        times: [{ label: "9 AM", startsAt: eventDate }],
+      },
+    );
+
+    const plan = await t.run(async (ctx: any) => ctx.db.get(planId));
+    expect(plan.title).toBe("Brooklyn Campus event");
+  });
+
+  it("falls back for a whitespace-only title too", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const eventDate = Date.now() + 7 * DAY;
+
+    const { planId } = await t.mutation(
+      api.functions.scheduling.events.createEvent,
+      {
+        token: leaderToken,
+        groupId: world.groupId,
+        title: "   ",
+        eventDate,
+        times: [{ label: "9 AM", startsAt: eventDate }],
+      },
+    );
+
+    const plan = await t.run(async (ctx: any) => ctx.db.get(planId));
+    expect(plan.title).toBe("Brooklyn Campus event");
+  });
+
+  it("still honours an explicit title", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const eventDate = Date.now() + 7 * DAY;
+
+    const { planId } = await t.mutation(
+      api.functions.scheduling.events.createEvent,
+      {
+        token: leaderToken,
+        groupId: world.groupId,
+        title: "Christmas Eve",
+        eventDate,
+        times: [{ label: "9 AM", startsAt: eventDate }],
+      },
+    );
+
+    const plan = await t.run(async (ctx: any) => ctx.db.get(planId));
+    expect(plan.title).toBe("Christmas Eve");
+  });
+});

--- a/apps/convex/__tests__/scheduling/events.test.ts
+++ b/apps/convex/__tests__/scheduling/events.test.ts
@@ -657,25 +657,30 @@ describe("createEvent default title", () => {
     expect(plan.title).toBe("Brooklyn Campus event");
   });
 
-  it("falls back for a whitespace-only title too", async () => {
-    const { t, world } = await setupSchedulingWorld();
-    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
-    const eventDate = Date.now() + 7 * DAY;
+  // Omitting the title and submitting an empty one are different intents: the
+  // first is "Add date" (name it later), the second is a form the leader left
+  // blank. Only the first may be defaulted — defaulting the second would drop
+  // their input with no error for the client to surface, and `updateEvent`
+  // rejects a blank rename, so accepting one here would be incoherent.
+  it.each([["   "], [""]])(
+    "rejects an explicitly blank title (%j) rather than defaulting it",
+    async (title) => {
+      const { t, world } = await setupSchedulingWorld();
+      const leaderToken = (await generateTokens(world.groupLeaderId))
+        .accessToken;
+      const eventDate = Date.now() + 7 * DAY;
 
-    const { planId } = await t.mutation(
-      api.functions.scheduling.events.createEvent,
-      {
-        token: leaderToken,
-        groupId: world.groupId,
-        title: "   ",
-        eventDate,
-        times: [{ label: "9 AM", startsAt: eventDate }],
-      },
-    );
-
-    const plan = await t.run(async (ctx: any) => ctx.db.get(planId));
-    expect(plan.title).toBe("Brooklyn Campus event");
-  });
+      await expect(
+        t.mutation(api.functions.scheduling.events.createEvent, {
+          token: leaderToken,
+          groupId: world.groupId,
+          title,
+          eventDate,
+          times: [{ label: "9 AM", startsAt: eventDate }],
+        }),
+      ).rejects.toThrow("Event title cannot be empty");
+    },
+  );
 
   it("still honours an explicit title", async () => {
     const { t, world } = await setupSchedulingWorld();

--- a/apps/convex/__tests__/scheduling/quickStart.test.ts
+++ b/apps/convex/__tests__/scheduling/quickStart.test.ts
@@ -311,3 +311,22 @@ describe("quickStartRostering", () => {
     ).rejects.toThrow(ConvexError);
   });
 });
+
+describe("quickStartRostering plan title", () => {
+  // The bootstrap used to hardcode "Untitled event plan", which shipped through
+  // to serving mode's plan headers and read like missing data rather than an
+  // unnamed plan.
+  it("names the bootstrap plan after the group instead of 'Untitled event plan'", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const { groupId, leaderId } = await buildBareGroup(t, world.communityId);
+    const leaderToken = (await generateTokens(leaderId)).accessToken;
+
+    const { planId } = await t.mutation(
+      api.functions.scheduling.quickStart.quickStartRostering,
+      { token: leaderToken, groupId },
+    );
+
+    const plan = await t.run(async (ctx) => ctx.db.get(planId!));
+    expect(plan!.title).toBe("Fresh Campus event");
+  });
+});

--- a/apps/convex/__tests__/scheduling/serving.test.ts
+++ b/apps/convex/__tests__/scheduling/serving.test.ts
@@ -783,3 +783,104 @@ describe("getServingEligibility", () => {
     expect(res.plans).toEqual([]);
   });
 });
+
+/**
+ * Plan provenance — the group (and the viewer's teams) behind each plan.
+ *
+ * Two campuses on one Sunday used to render as two stacked sections whose
+ * headers were byte-identical, so a leader concluded the tasks they had just
+ * authored were missing — they had authored on one plan and been rostered on
+ * the other. The names were always one `ctx.db.get` away; they just weren't
+ * returned.
+ */
+describe("serving plan provenance", () => {
+  it("names the group and the viewer's teams on every eligible plan", async () => {
+    const { t, world } = await setup();
+    const memberTok = (await generateTokens(world.channelMemberId)).accessToken;
+    const today = Date.now();
+    const plan = await insertPlan(t, world, "Sunday Service", today);
+
+    const production = await insertTeam(t, world, "Production");
+    const camera = await insertRole(t, world, production, "Camera");
+
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+      eventDate: today,
+      status: "confirmed",
+    });
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: production,
+      roleId: camera,
+      userId: world.channelMemberId,
+      eventDate: today,
+      status: "confirmed",
+    });
+
+    const eligibility = await t.query(
+      api.functions.scheduling.serving.getServingEligibility,
+      { token: memberTok },
+    );
+    expect(eligibility.plans).toHaveLength(1);
+    expect(eligibility.plans[0].groupName).toBe("Brooklyn Campus");
+    // `teamNames` mirrors `teamIds` — the viewer's own teams, same order.
+    expect(eligibility.plans[0].teamNames).toEqual(
+      eligibility.plans[0].teamIds.map((id) =>
+        id === (production as string) ? "Production" : "Worship Team",
+      ),
+    );
+    expect([...eligibility.plans[0].teamNames].sort()).toEqual([
+      "Production",
+      "Worship Team",
+    ]);
+  });
+
+  it("names the group on a plan opened early to prepare", async () => {
+    const { t, world } = await setup();
+    const memberTok = (await generateTokens(world.channelMemberId)).accessToken;
+    const future = Date.now() + 7 * DAY;
+    const plan = await insertPlan(t, world, "Next Sunday", future);
+
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+      eventDate: future,
+      status: "confirmed",
+    });
+
+    const eligibility = await t.query(
+      api.functions.scheduling.serving.getServingEligibility,
+      { token: memberTok },
+    );
+    expect(eligibility.upcomingPlans).toHaveLength(1);
+    expect(eligibility.upcomingPlans[0].groupName).toBe("Brooklyn Campus");
+  });
+
+  it("names the group on every Team-roster plan section", async () => {
+    const { t, world } = await setup();
+    const memberTok = (await generateTokens(world.channelMemberId)).accessToken;
+    const today = Date.now();
+    const plan = await insertPlan(t, world, "Sunday Service", today);
+
+    await insertAssignment(t, world, {
+      planId: plan,
+      teamId: world.teamId,
+      roleId: world.roleId,
+      userId: world.channelMemberId,
+      eventDate: today,
+      status: "confirmed",
+    });
+
+    const roster = await t.query(
+      api.functions.scheduling.serving.getServingTeamRoster,
+      { token: memberTok },
+    );
+    expect(roster.plans).toHaveLength(1);
+    expect(roster.plans[0].groupName).toBe("Brooklyn Campus");
+  });
+});

--- a/apps/convex/functions/scheduling/eventTasks.ts
+++ b/apps/convex/functions/scheduling/eventTasks.ts
@@ -835,6 +835,19 @@ export const getPlanTaskReadiness = query({
   },
 });
 
+/**
+ * WHY a task is in the viewer's list: the (team, role) they hold that the task
+ * names. A task carries several `roleIds`, so a viewer holding two of them
+ * matches on both — hence an array, not a single pair. Order follows the task's
+ * own `roleIds`, so it is stable across reads.
+ */
+type ServingTaskProvenance = {
+  roleId: string;
+  roleName: string;
+  teamId: string;
+  teamName: string;
+};
+
 /** A serving-task item as returned to the current user, per segment. */
 type ServingTaskItem = {
   /** Unique per row — a "during" template task expands to one row per time. */
@@ -844,6 +857,11 @@ type ServingTaskItem = {
   title: string;
   segment: "before" | "during" | "after";
   isPersonal: boolean;
+  /**
+   * The viewer's own (team, role) pairs this task matched on. Empty for
+   * personal tasks — nobody rostered those, the viewer added them.
+   */
+  roles: ServingTaskProvenance[];
   howToType?: string;
   howToText?: string;
   howToUrl?: string;
@@ -868,6 +886,11 @@ type ServingTaskItem = {
  * "during" template tasks expand to one entry per service time (timeLabel set),
  * with `completed` resolved per (task, user, timeLabel). Personal "during"
  * tasks keep their own timeLabel.
+ *
+ * Every role task carries `roles` — the viewer's own (team, role) pairs it
+ * matched on — so a volunteer holding several roles can see which one rostered
+ * each task instead of one undifferentiated list. A task naming two of the
+ * viewer's roles reports BOTH.
  *
  * Auth: an active member of the plan's community.
  */
@@ -898,7 +921,29 @@ export const getMyServingTasks = query({
       .filter((q) => q.eq(q.field("userId"), userId))
       .collect();
     const myServing = myAssignments.filter((a) => a.status !== "declined");
-    const myRoleIds = new Set(myServing.map((a) => a.roleId as string));
+
+    // Role id → the (team, role) the viewer holds under it. Resolved once here
+    // so each matched task can say WHICH of the viewer's roles put it in their
+    // list — with two roles on the plan, "Set up chairs" alone doesn't say
+    // whether it came from Camera or Usher. A roleId belongs to exactly one
+    // team, so this map is 1:1; the team comes off the ASSIGNMENT (the same
+    // source `getCrewTasks` uses) rather than the role doc.
+    const myRoles = new Map<string, ServingTaskProvenance>();
+    for (const a of myServing) {
+      const roleId = a.roleId as string;
+      if (myRoles.has(roleId)) continue;
+      const [role, team] = await Promise.all([
+        ctx.db.get(a.roleId),
+        ctx.db.get(a.teamId),
+      ]);
+      myRoles.set(roleId, {
+        roleId,
+        roleName: role?.name ?? "Role",
+        teamId: a.teamId as string,
+        teamName: team?.name ?? "Team",
+      });
+    }
+    const myRoleIds = new Set(myRoles.keys());
 
     // (a) Assigned template tasks.
     const tasks = await ctx.db
@@ -927,12 +972,16 @@ export const getMyServingTasks = query({
       // their personal tasks).
       const roleIds = taskRoleIds(task);
       if (roleIds.length === 0) continue;
-      if (!roleIds.some((r) => myRoleIds.has(r as string))) continue;
+      const matchedRoles = roleIds
+        .filter((r) => myRoleIds.has(r as string))
+        .map((r) => myRoles.get(r as string)!);
+      if (matchedRoles.length === 0) continue;
 
       const base = {
         title: task.title,
         segment: task.segment,
         isPersonal: false as const,
+        roles: matchedRoles,
         howToType: task.howToType,
         howToText: task.howToText,
         howToUrl: task.howToUrl,
@@ -979,6 +1028,7 @@ export const getMyServingTasks = query({
         title: p.title,
         segment: p.segment,
         isPersonal: true,
+        roles: [],
         note: p.note,
         timeLabel: p.timeLabel,
         completed: p.completedAt !== undefined,

--- a/apps/convex/functions/scheduling/events.ts
+++ b/apps/convex/functions/scheduling/events.ts
@@ -65,6 +65,24 @@ const timeValidator = v.object({
 });
 
 /**
+ * The title a plan gets when its creator didn't name it.
+ *
+ * Both no-title entry points ("Add date" on the roster grid, and the
+ * quick-start bootstrap) used to hardcode the literal string "Untitled event
+ * plan", which shipped straight into serving mode's headers and read like
+ * missing data rather than an unnamed plan.
+ *
+ * Derived from the GROUP, not the date: both callers create the plan at a
+ * placeholder date the leader then changes in the editor, so a date-derived
+ * title would be actively wrong the moment they did. The date is rendered
+ * beside the title everywhere it matters anyway.
+ */
+export function defaultPlanTitle(groupName: string | undefined): string {
+  const name = (groupName ?? "").trim();
+  return name ? `${name} event` : "New event";
+}
+
+/**
  * Insert a `draft` event plan for a campus group. The shared implementation
  * behind the `createEvent` mutation, reused by `quickStartRostering`. Callers
  * MUST have already authorized the scheduler — this helper does no auth.
@@ -106,13 +124,17 @@ export async function createEventDraftImpl(
 /**
  * Create a dated event for a campus group. New events start in `draft`.
  *
+ * `title` is optional: the roster grid's "Add date" creates a plan the leader
+ * names later, so omitting it falls back to `defaultPlanTitle` rather than
+ * making the client invent a placeholder.
+ *
  * Auth: group leader or community admin.
  */
 export const createEvent = mutation({
   args: {
     token: v.string(),
     groupId: v.id("groups"),
-    title: v.string(),
+    title: v.optional(v.string()),
     eventDate: v.number(),
     times: v.array(timeValidator),
     notes: v.optional(v.string()),
@@ -125,7 +147,7 @@ export const createEvent = mutation({
     const planId = await createEventDraftImpl(ctx, {
       groupId: args.groupId,
       communityId: group.communityId,
-      title: args.title,
+      title: args.title?.trim() || defaultPlanTitle(group.name),
       eventDate: args.eventDate,
       times: args.times,
       createdById: userId,

--- a/apps/convex/functions/scheduling/events.ts
+++ b/apps/convex/functions/scheduling/events.ts
@@ -125,8 +125,11 @@ export async function createEventDraftImpl(
  * Create a dated event for a campus group. New events start in `draft`.
  *
  * `title` is optional: the roster grid's "Add date" creates a plan the leader
- * names later, so omitting it falls back to `defaultPlanTitle` rather than
- * making the client invent a placeholder.
+ * names later, so OMITTING it falls back to `defaultPlanTitle` rather than
+ * making the client invent a placeholder. Passing an explicit blank/whitespace
+ * title is a different thing entirely — a form the user left empty — and still
+ * throws, matching `updateEvent`. Silently renaming it to "<Group> event" would
+ * drop the leader's input with no client error path to notice it.
  *
  * Auth: group leader or community admin.
  */
@@ -147,7 +150,8 @@ export const createEvent = mutation({
     const planId = await createEventDraftImpl(ctx, {
       groupId: args.groupId,
       communityId: group.communityId,
-      title: args.title?.trim() || defaultPlanTitle(group.name),
+      title:
+        args.title === undefined ? defaultPlanTitle(group.name) : args.title,
       eventDate: args.eventDate,
       times: args.times,
       createdById: userId,

--- a/apps/convex/functions/scheduling/quickStart.ts
+++ b/apps/convex/functions/scheduling/quickStart.ts
@@ -30,7 +30,11 @@ import { mutation } from "../../_generated/server";
 import { requireAuth } from "../../lib/auth";
 import { requireGroupScheduler } from "./permissions";
 import { createServingTeamImpl } from "./teams";
-import { createEventDraftImpl, seedNeededRolesFromDefaultsImpl } from "./events";
+import {
+  createEventDraftImpl,
+  defaultPlanTitle,
+  seedNeededRolesFromDefaultsImpl,
+} from "./events";
 import { suggestStarterRolesForName } from "./starterRoles";
 
 /** Default starter team name — generic so any group fits; leader can rename. */
@@ -119,7 +123,7 @@ export const quickStartRostering = mutation({
     const planId = await createEventDraftImpl(ctx, {
       groupId: args.groupId,
       communityId: group.communityId,
-      title: "Untitled event plan",
+      title: defaultPlanTitle(group.name),
       eventDate,
       times: [{ label: "9:00 AM", startsAt: eventDate }],
       createdById: userId,

--- a/apps/convex/functions/scheduling/serving.ts
+++ b/apps/convex/functions/scheduling/serving.ts
@@ -161,14 +161,25 @@ async function servingChannelArrays(
   };
 }
 
-/** The client-facing shape of one plan the user can serve on. */
+/**
+ * The client-facing shape of one plan the user can serve on.
+ *
+ * `groupName` / `teamNames` exist purely so the serving surfaces can SAY which
+ * campus rostered the viewer. Two plans on the same morning otherwise render
+ * identical headers ("Untitled event plan · Sun, Aug 3 · 9:00 AM"), which is
+ * how a volunteer ends up believing their tasks vanished when they were really
+ * looking at the other plan's section. `teamNames` mirrors `teamIds` (the
+ * viewer's own teams on the plan), in the same order.
+ */
 type ServingPlan = {
   planId: string;
   groupId: string;
+  groupName: string;
   title: string;
   startsAt: number;
   endsAt: number;
   teamIds: string[];
+  teamNames: string[];
   teamChannelIds: string[];
   meetingChannelIds: string[];
 };
@@ -182,6 +193,7 @@ type ServingPlan = {
 type UpcomingServingPlan = {
   planId: string;
   groupId: string;
+  groupName: string;
   title: string;
   startsAt: number;
   endsAt: number;
@@ -252,6 +264,28 @@ export const getServingEligibility = query({
       return active;
     };
 
+    // Group / team display names, memoised for the same reason membership is:
+    // a volunteer's plans cluster into a handful of groups and teams, and this
+    // query is reactive.
+    const groupNames = new Map<string, string>();
+    const groupNameFor = async (groupId: Id<"groups">): Promise<string> => {
+      const key = groupId as string;
+      if (!groupNames.has(key)) {
+        const group = await ctx.db.get(groupId);
+        groupNames.set(key, group?.name ?? "");
+      }
+      return groupNames.get(key)!;
+    };
+    const teamNames = new Map<string, string>();
+    const teamNameFor = async (teamId: Id<"teams">): Promise<string> => {
+      const key = teamId as string;
+      if (!teamNames.has(key)) {
+        const team = await ctx.db.get(teamId);
+        teamNames.set(key, team?.name ?? "Team");
+      }
+      return teamNames.get(key)!;
+    };
+
     // Split first, membership-check second. The upcoming list is capped at
     // `UPCOMING_PLANS_LIMIT`, so checking membership in soonest-first order and
     // stopping at the cap bounds the work instead of only trimming the result.
@@ -288,6 +322,7 @@ export const getServingEligibility = query({
       upcoming.push({
         planId: plan._id as string,
         groupId: plan.groupId as string,
+        groupName: await groupNameFor(plan.groupId),
         title: plan.title,
         startsAt: planStartsAt(plan),
         endsAt: planEndsAt(plan),
@@ -332,10 +367,14 @@ export const getServingEligibility = query({
       entries.push({
         planId: plan._id as string,
         groupId: plan.groupId as string,
+        groupName: await groupNameFor(plan.groupId),
         title: plan.title,
         startsAt,
         endsAt,
         teamIds,
+        teamNames: await Promise.all(
+          teamIds.map((id) => teamNameFor(id as Id<"teams">)),
+        ),
         teamChannelIds,
         meetingChannelIds,
         autoEnter,
@@ -530,9 +569,14 @@ type ServingTeamColumn = {
   people: ServingTeamPerson[];
 };
 
-/** One plan section in the Team roster grid. */
+/**
+ * One plan section in the Team roster grid. `groupName` names the campus that
+ * rostered the viewer — without it two same-day plans stack as two identically
+ * headed sections. See `ServingPlan`.
+ */
 type ServingTeamPlan = {
   planId: string;
+  groupName: string;
   title: string;
   eventDate: number;
   teams: ServingTeamColumn[];
@@ -598,6 +642,12 @@ export const getServingTeamRoster = query({
     const teamCache = new Map<string, Doc<"teams"> | null>();
     const roleCache = new Map<string, Doc<"teamRoles"> | null>();
     const userCache = new Map<string, Doc<"users"> | null>();
+    const groupCache = new Map<string, Doc<"groups"> | null>();
+    const getGroupName = async (id: Id<"groups">): Promise<string> => {
+      const key = id as string;
+      if (!groupCache.has(key)) groupCache.set(key, await ctx.db.get(id));
+      return groupCache.get(key)?.name ?? "";
+    };
     const getTeam = async (id: string) => {
       if (!teamCache.has(id))
         teamCache.set(id, await ctx.db.get(id as Id<"teams">));
@@ -669,6 +719,7 @@ export const getServingTeamRoster = query({
 
       plans.push({
         planId: plan._id as string,
+        groupName: await getGroupName(plan.groupId),
         title: plan.title,
         eventDate: plan.eventDate,
         teams,

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -1293,6 +1293,9 @@ export function RosterGridScreen() {
   // Create a new draft plan at the neutral default date (next Sunday 9 AM, same
   // as the editor's default). The reactive rosterMatrix self-refreshes → a new
   // date column appears; the leader sets the real date in the plan editor.
+  // The title is left to the backend (`defaultPlanTitle`, derived from the
+  // group) — this used to send the literal "Untitled event plan", which shipped
+  // through to serving mode's plan headers and read like a bug.
   const handleAddDate = useCallback(async () => {
     if (creatingEvent) return;
     setCreatingEvent(true);
@@ -1300,7 +1303,6 @@ export function RosterGridScreen() {
       const date = nextSundayAtNine();
       await createEvent({
         groupId,
-        title: "Untitled event plan",
         eventDate: date.getTime(),
         times: [{ label: "9:00 AM", startsAt: date.getTime() }],
       });

--- a/apps/mobile/features/serving/components/ServingRunsheetScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingRunsheetScreen.tsx
@@ -33,13 +33,18 @@ import {
 import { PlanRunSheet } from "@features/leader-tools/components/NativeRunSheetView";
 import { useEventModeStore } from "@/stores/eventModeStore";
 import { useServingPlans } from "../hooks/useServingPlans";
+import { planSubtitle } from "../utils/servingProvenance";
 
 type ServingPlan = {
   planId: string;
   groupId: string;
+  /** The campus that rostered the viewer — the section header's subtitle. */
+  groupName?: string;
   title: string;
   startsAt: number;
   endsAt: number;
+  /** The viewer's own teams on this plan. */
+  teamNames?: string[];
 };
 
 type EligibilityResult = {
@@ -136,21 +141,37 @@ export function ServingRunsheetScreen() {
       {plans.map((plan) => (
         <View key={plan.planId} style={[styles.planSection, wa && waStyles.planSection]}>
           <View style={[styles.planHeader, wa && waStyles.planHeader]}>
-            <Text
-              style={[styles.planTitle, wa && waStyles.planTitle, { color: colors.text }]}
-              numberOfLines={1}
-            >
-              {plan.title}
-            </Text>
-            <Text
-              style={[
-                styles.planDate,
-                wa && waStyles.planDate,
-                { color: colors.textTertiary },
-              ]}
-            >
-              {formatPlanDate(plan.startsAt)}
-            </Text>
+            <View style={styles.planHeaderRow}>
+              <Text
+                style={[styles.planTitle, wa && waStyles.planTitle, { color: colors.text }]}
+                numberOfLines={1}
+              >
+                {plan.title}
+              </Text>
+              <Text
+                style={[
+                  styles.planDate,
+                  wa && waStyles.planDate,
+                  { color: colors.textTertiary },
+                ]}
+              >
+                {formatPlanDate(plan.startsAt)}
+              </Text>
+            </View>
+            {/* Which campus/teams this section is — without it two same-day
+                plans stack under identical headers. */}
+            {planSubtitle(plan.groupName, plan.teamNames) ? (
+              <Text
+                style={[
+                  styles.planGroup,
+                  wa && waStyles.planGroup,
+                  { color: colors.textSecondary },
+                ]}
+                numberOfLines={1}
+              >
+                {planSubtitle(plan.groupName, plan.teamNames)}
+              </Text>
+            ) : null}
           </View>
           <PlanRunSheet
             embedded
@@ -186,14 +207,13 @@ const styles = StyleSheet.create({
   emptyText: { fontSize: 15, textAlign: "center" },
   planSection: { paddingTop: 20 },
   planHeader: {
-    flexDirection: "row",
-    alignItems: "baseline",
-    gap: 8,
     paddingHorizontal: 16,
     marginBottom: 10,
   },
+  planHeaderRow: { flexDirection: "row", alignItems: "baseline", gap: 8 },
   planTitle: { fontSize: 16, fontWeight: "700", flexShrink: 1 },
   planDate: { fontSize: 13, fontWeight: "500" },
+  planGroup: { fontSize: 13, fontWeight: "600", marginTop: 2 },
 });
 
 /**
@@ -214,4 +234,5 @@ const waStyles = StyleSheet.create({
   },
   planTitle: { fontSize: WA_TYPE_SECTION_HEADER, fontWeight: WA_WEIGHT_SEMIBOLD },
   planDate: { fontSize: WA_TYPE_SUBTITLE, fontWeight: WA_WEIGHT_REGULAR },
+  planGroup: { fontSize: WA_TYPE_SUBTITLE, fontWeight: WA_WEIGHT_SEMIBOLD },
 });

--- a/apps/mobile/features/serving/components/ServingRunsheetScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingRunsheetScreen.tsx
@@ -138,7 +138,9 @@ export function ServingRunsheetScreen() {
         paddingBottom: insets.bottom + 24,
       }}
     >
-      {plans.map((plan) => (
+      {plans.map((plan) => {
+        const subtitle = planSubtitle(plan.groupName, plan.teamNames);
+        return (
         <View key={plan.planId} style={[styles.planSection, wa && waStyles.planSection]}>
           <View style={[styles.planHeader, wa && waStyles.planHeader]}>
             <View style={styles.planHeaderRow}>
@@ -160,7 +162,7 @@ export function ServingRunsheetScreen() {
             </View>
             {/* Which campus/teams this section is — without it two same-day
                 plans stack under identical headers. */}
-            {planSubtitle(plan.groupName, plan.teamNames) ? (
+            {subtitle ? (
               <Text
                 style={[
                   styles.planGroup,
@@ -169,7 +171,7 @@ export function ServingRunsheetScreen() {
                 ]}
                 numberOfLines={1}
               >
-                {planSubtitle(plan.groupName, plan.teamNames)}
+                {subtitle}
               </Text>
             ) : null}
           </View>
@@ -190,7 +192,8 @@ export function ServingRunsheetScreen() {
             }
           />
         </View>
-      ))}
+        );
+      })}
     </ScrollView>
   );
 }

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -95,6 +95,15 @@ import {
   type RoleCatalogEntry,
 } from "../utils/taskAuthoring";
 import {
+  formatSharedTaskTeams,
+  formatTaskProvenance,
+  heldRolePairs,
+  planSubtitle,
+  shouldShowTaskProvenance,
+  shouldShowTeamNames,
+  type RolePair,
+} from "../utils/servingProvenance";
+import {
   diagnoseMineEmpty,
   mineEmptyCopy,
   myRoleNamesFromCrew,
@@ -129,6 +138,12 @@ type ServingTask = {
   segment: Segment;
   isPersonal: boolean;
   completed: boolean;
+  /**
+   * The viewer's own (team, role) pairs this task matched on — the WHY of it
+   * being in their list. Empty for personal tasks. Only rendered when the
+   * viewer holds more than one pair; see `utils/servingProvenance.ts`.
+   */
+  roles?: RolePair[];
   timeLabel?: string | null;
   // Personal-only
   note?: string | null;
@@ -245,15 +260,18 @@ function notify(title: string, message: string) {
 
 /**
  * A `getServingEligibility` plan. Matches `CachedServingPlan` so the whole list
- * can be persisted for offline via `useCachedServingPlans` — the child section
- * only reads `planId`/`title`/`startsAt`.
+ * can be persisted for offline via `useCachedServingPlans`.
  */
 type EligiblePlan = {
   planId: string;
   groupId: string;
+  /** The campus that rostered the viewer — the plan header's subtitle. */
+  groupName?: string;
   title: string;
   startsAt: number;
   endsAt: number;
+  /** The viewer's own teams on this plan (mirrors the backend's `teamIds`). */
+  teamNames?: string[];
 };
 
 /**
@@ -763,6 +781,19 @@ function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean
   // personal tasks are the ones the user adds themselves.
   const myTemplateTaskCount = allTasks.filter((t) => !t.isPersonal).length;
 
+  // --- Provenance ------------------------------------------------------------
+  // Every (team, role) the viewer holds on THIS plan. Drives whether task rows
+  // name the role that rostered them at all — a single-role volunteer's list
+  // stays untouched. See `utils/servingProvenance.ts` for the rules.
+  // (Not memoised: `allTasks` is rebuilt every render anyway, and this is a
+  // handful of array passes over a list that is already being mapped to rows.)
+  const heldPairs = heldRolePairs(
+    effCrew,
+    allTasks.flatMap((t) => t.roles ?? []),
+  );
+  const showProvenance = shouldShowTaskProvenance(heldPairs);
+  const showTeamNames = shouldShowTeamNames(heldPairs);
+
   // WHY the "Mine" list is empty. Three unrelated causes used to share one
   // message ("No preloaded task. Please contact your team lead to add tasks.")
   // that was wrong for two of them; `diagnoseMineEmpty` tells them apart from
@@ -805,6 +836,7 @@ function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean
 
         <ServingHeader
           title={plan.title}
+          subtitle={planSubtitle(plan.groupName, plan.teamNames)}
           startsAt={plan.startsAt}
           done={overallDone}
           total={overallTotal}
@@ -918,6 +950,11 @@ function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean
                       <TaskRow
                         key={task.key}
                         task={task}
+                        provenance={
+                          showProvenance
+                            ? formatTaskProvenance(task.roles, showTeamNames)
+                            : null
+                        }
                         first={i === 0}
                         colors={colors}
                         primaryColor={primaryColor}
@@ -1018,6 +1055,7 @@ function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean
           <SharedSection
             tasks={effShared}
             optimistic={sharedOverlay}
+            heldPairs={heldPairs}
             colors={colors}
             primaryColor={primaryColor}
             onToggle={toggleShared}
@@ -1093,6 +1131,7 @@ function formatWhen(startsAt: number): string {
 
 function ServingHeader({
   title,
+  subtitle,
   startsAt,
   done,
   total,
@@ -1102,6 +1141,7 @@ function ServingHeader({
   wa,
 }: {
   title: string;
+  subtitle: string | null;
   startsAt?: number;
   done: number;
   total: number;
@@ -1119,6 +1159,18 @@ function ServingHeader({
       >
         {title}
       </Text>
+      {subtitle ? (
+        <Text
+          style={[
+            styles.headerSubtitle,
+            wa && waStyles.headerSubtitle,
+            { color: colors.textSecondary },
+          ]}
+          numberOfLines={2}
+        >
+          {subtitle}
+        </Text>
+      ) : null}
       {startsAt ? (
         <Text
           style={[
@@ -1168,6 +1220,12 @@ type ThemeColors = ReturnType<typeof useTheme>["colors"];
 
 interface TaskRowProps {
   task: ServingTask;
+  /**
+   * "Camera", or "Production · Camera" — which of the viewer's roles rostered
+   * this task. `null` means don't say (the single-role case, and every personal
+   * task); the row then renders exactly as it always has.
+   */
+  provenance: string | null;
   first: boolean;
   colors: ThemeColors;
   primaryColor: string;
@@ -1195,6 +1253,7 @@ const VIEWER_HOW_TO_ICONS: Record<
 
 function TaskRow({
   task,
+  provenance,
   first,
   colors,
   primaryColor,
@@ -1278,6 +1337,25 @@ function TaskRow({
               <Text style={[styles.taskMeta, wa && waStyles.taskMeta, { color: colors.textTertiary }]}>
                 Added by you
               </Text>
+            </View>
+          ) : provenance ? (
+            <View style={styles.taskMetaRow}>
+              <View style={styles.teamCue}>
+                <Ionicons
+                  name="person-circle-outline"
+                  size={12}
+                  color={colors.textTertiary}
+                />
+                <Text
+                  style={[
+                    styles.taskMeta,
+                    wa && waStyles.taskMeta,
+                    { color: colors.textTertiary },
+                  ]}
+                >
+                  {provenance}
+                </Text>
+              </View>
             </View>
           ) : null}
 
@@ -1592,6 +1670,7 @@ function SectionPills({
 function SharedSection({
   tasks,
   optimistic,
+  heldPairs,
   colors,
   primaryColor,
   onToggle,
@@ -1600,6 +1679,8 @@ function SharedSection({
 }: {
   tasks: SharedTask[] | undefined;
   optimistic: Record<string, boolean>;
+  /** The viewer's (team, role) pairs — decides whether teams get named. */
+  heldPairs: RolePair[];
   colors: ThemeColors;
   primaryColor: string;
   onToggle: (taskId: string, next: boolean) => void;
@@ -1667,6 +1748,7 @@ function SharedSection({
                 <SharedTaskRow
                   key={task.taskId}
                   task={task}
+                  teamLabel={formatSharedTaskTeams(task.teamNames, heldPairs)}
                   completed={stateOf(task)}
                   first={i === 0}
                   colors={colors}
@@ -1686,6 +1768,7 @@ function SharedSection({
 
 function SharedTaskRow({
   task,
+  teamLabel,
   completed,
   first,
   colors,
@@ -1695,6 +1778,12 @@ function SharedTaskRow({
   onOpenHowTo,
 }: {
   task: SharedTask;
+  /**
+   * The task's own team name(s), or `null` when the viewer is on a single team
+   * and naming it would be noise — the row then reads plain "Team task", as it
+   * always has.
+   */
+  teamLabel: string | null;
   completed: boolean;
   first: boolean;
   colors: ThemeColors;
@@ -1761,7 +1850,7 @@ function SharedTaskRow({
             <View style={styles.teamCue}>
               <Ionicons name="people" size={12} color={colors.textTertiary} />
               <Text style={[styles.taskMeta, wa && waStyles.taskMeta, { color: colors.textTertiary }]}>
-                Team task
+                {teamLabel ? `${teamLabel} team task` : "Team task"}
               </Text>
             </View>
             {completed && task.completedByName ? (
@@ -3317,6 +3406,7 @@ const styles = StyleSheet.create({
   // Header
   header: { paddingHorizontal: 16, marginBottom: 20 },
   headerTitle: { fontSize: 26, fontWeight: "700", letterSpacing: -0.4 },
+  headerSubtitle: { fontSize: 14, fontWeight: "600", marginTop: 4 },
   headerWhen: { fontSize: 14, marginTop: 4 },
   readiness: { marginTop: 16, gap: 8 },
   readinessLabelRow: {
@@ -3557,6 +3647,11 @@ const waStyles = StyleSheet.create({
     fontSize: WA_TYPE_HEADER_BLOCK,
     fontWeight: WA_WEIGHT_BOLD,
     letterSpacing: 0,
+  },
+  headerSubtitle: {
+    fontSize: WA_TYPE_SUBTITLE,
+    fontWeight: WA_WEIGHT_SEMIBOLD,
+    marginTop: 6,
   },
   headerWhen: { fontSize: WA_TYPE_SUBTITLE, marginTop: 6 },
   readinessLabel: { fontSize: WA_TYPE_SUBTITLE, fontWeight: WA_WEIGHT_REGULAR },

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -782,15 +782,14 @@ function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean
   const myTemplateTaskCount = allTasks.filter((t) => !t.isPersonal).length;
 
   // --- Provenance ------------------------------------------------------------
-  // Every (team, role) the viewer holds on THIS plan. Drives whether task rows
-  // name the role that rostered them at all — a single-role volunteer's list
-  // stays untouched. See `utils/servingProvenance.ts` for the rules.
+  // Every (team, role) the viewer holds on THIS plan, from the crew rows alone —
+  // the only complete source. `null` until they resolve (offline: until the
+  // cached copy loads), which suppresses every label rather than deciding from
+  // the task rows, whose roles are a subset that can only under-report. See
+  // `utils/servingProvenance.ts` for why that matters here specifically.
   // (Not memoised: `allTasks` is rebuilt every render anyway, and this is a
   // handful of array passes over a list that is already being mapped to rows.)
-  const heldPairs = heldRolePairs(
-    effCrew,
-    allTasks.flatMap((t) => t.roles ?? []),
-  );
+  const heldPairs = heldRolePairs(effCrew);
   const showProvenance = shouldShowTaskProvenance(heldPairs);
   const showTeamNames = shouldShowTeamNames(heldPairs);
 

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -1345,12 +1345,18 @@ function TaskRow({
                   size={12}
                   color={colors.textTertiary}
                 />
+                {/* Capped like the plan title (1 line) and the header
+                    subtitle (2): two roles across two teams reads
+                    "Production · Camera & Usher, Hospitality · Greeter", which
+                    with real team names wraps several lines deep on EVERY row
+                    of the checklist. */}
                 <Text
                   style={[
                     styles.taskMeta,
                     wa && waStyles.taskMeta,
                     { color: colors.textTertiary },
                   ]}
+                  numberOfLines={2}
                 >
                   {provenance}
                 </Text>
@@ -1848,7 +1854,12 @@ function SharedTaskRow({
           <View style={styles.taskMetaRow}>
             <View style={styles.teamCue}>
               <Ionicons name="people" size={12} color={colors.textTertiary} />
-              <Text style={[styles.taskMeta, wa && waStyles.taskMeta, { color: colors.textTertiary }]}>
+              {/* Capped for the same reason as the Mine rows' provenance: a
+                  shared task names every team it spans. */}
+              <Text
+                style={[styles.taskMeta, wa && waStyles.taskMeta, { color: colors.textTertiary }]}
+                numberOfLines={2}
+              >
                 {teamLabel ? `${teamLabel} team task` : "Team task"}
               </Text>
             </View>

--- a/apps/mobile/features/serving/components/ServingTeamScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTeamScreen.tsx
@@ -55,6 +55,7 @@ import {
 } from "@components/ui/ActionMenuSheet";
 import { useStartDirectMessage } from "@features/chat/hooks/useStartDirectMessage";
 import { useEventModeStore } from "@/stores/eventModeStore";
+import { planSubtitle } from "../utils/servingProvenance";
 
 /** The person shape returned per team by `getServingTeamRoster`. */
 type RosterPerson = {
@@ -225,21 +226,37 @@ export function ServingTeamScreen() {
           {plans.map((plan) => (
             <View key={plan.planId} style={[styles.planSection, wa && waStyles.planSection]}>
               <View style={[styles.planHeader, wa && waStyles.planHeader]}>
-                <Text
-                  style={[styles.planTitle, wa && waStyles.planTitle, { color: colors.text }]}
-                  numberOfLines={1}
-                >
-                  {plan.title}
-                </Text>
-                <Text
-                  style={[
-                    styles.planDate,
-                    wa && waStyles.planDate,
-                    { color: colors.textTertiary },
-                  ]}
-                >
-                  {formatPlanDate(plan.eventDate)}
-                </Text>
+                <View style={styles.planHeaderRow}>
+                  <Text
+                    style={[styles.planTitle, wa && waStyles.planTitle, { color: colors.text }]}
+                    numberOfLines={1}
+                  >
+                    {plan.title}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.planDate,
+                      wa && waStyles.planDate,
+                      { color: colors.textTertiary },
+                    ]}
+                  >
+                    {formatPlanDate(plan.eventDate)}
+                  </Text>
+                </View>
+                {/* Which campus this section belongs to — two same-day plans
+                    otherwise stack under identical headers. */}
+                {planSubtitle(plan.groupName) ? (
+                  <Text
+                    style={[
+                      styles.planGroup,
+                      wa && waStyles.planGroup,
+                      { color: colors.textSecondary },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {planSubtitle(plan.groupName)}
+                  </Text>
+                ) : null}
               </View>
 
               {plan.teams.length === 0 ? (
@@ -460,14 +477,13 @@ const styles = StyleSheet.create({
   emptyText: { fontSize: 15, textAlign: "center" },
   planSection: { paddingTop: 20 },
   planHeader: {
-    flexDirection: "row",
-    alignItems: "baseline",
-    gap: 8,
     paddingHorizontal: 16,
     marginBottom: 10,
   },
+  planHeaderRow: { flexDirection: "row", alignItems: "baseline", gap: 8 },
   planTitle: { fontSize: 16, fontWeight: "700", flexShrink: 1 },
   planDate: { fontSize: 13, fontWeight: "500" },
+  planGroup: { fontSize: 13, fontWeight: "600", marginTop: 2 },
   planEmpty: { fontSize: 13, paddingHorizontal: 16, paddingBottom: 8 },
   teamsRow: { paddingHorizontal: 16, gap: 12 },
   teamColumn: { width: TEAM_COL_WIDTH, gap: 8 },
@@ -530,6 +546,7 @@ const waStyles = StyleSheet.create({
   // §2 landing section header: ~20pt semibold, sentence case.
   planTitle: { fontSize: WA_TYPE_SECTION_HEADER, fontWeight: WA_WEIGHT_SEMIBOLD },
   planDate: { fontSize: WA_TYPE_SUBTITLE, fontWeight: WA_WEIGHT_REGULAR },
+  planGroup: { fontSize: WA_TYPE_SUBTITLE, fontWeight: WA_WEIGHT_SEMIBOLD },
   planEmpty: { fontSize: WA_TYPE_SUBTITLE, paddingHorizontal: WA_GROUP_MARGIN },
 
   // Type grew (names 14 -> 17pt, roles 12 -> 13pt), so the column widens to

--- a/apps/mobile/features/serving/components/ServingTeamScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTeamScreen.tsx
@@ -223,7 +223,9 @@ export function ServingTeamScreen() {
         <ScrollView
           contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
         >
-          {plans.map((plan) => (
+          {plans.map((plan) => {
+            const subtitle = planSubtitle(plan.groupName);
+            return (
             <View key={plan.planId} style={[styles.planSection, wa && waStyles.planSection]}>
               <View style={[styles.planHeader, wa && waStyles.planHeader]}>
                 <View style={styles.planHeaderRow}>
@@ -245,7 +247,7 @@ export function ServingTeamScreen() {
                 </View>
                 {/* Which campus this section belongs to — two same-day plans
                     otherwise stack under identical headers. */}
-                {planSubtitle(plan.groupName) ? (
+                {subtitle ? (
                   <Text
                     style={[
                       styles.planGroup,
@@ -254,7 +256,7 @@ export function ServingTeamScreen() {
                     ]}
                     numberOfLines={1}
                   >
-                    {planSubtitle(plan.groupName)}
+                    {subtitle}
                   </Text>
                 ) : null}
               </View>
@@ -328,7 +330,8 @@ export function ServingTeamScreen() {
                 </ScrollView>
               )}
             </View>
-          ))}
+            );
+          })}
         </ScrollView>
       )}
 

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -1603,6 +1603,40 @@ describe("ServingTasksScreen — task provenance (Mine)", () => {
     expect(getByText("Production · Camera")).toBeTruthy();
   });
 
+  it("caps the label's height so a long one can't push the list around", () => {
+    // "Production · Camera & Usher, Hospitality · Greeter" with real team names
+    // wraps several lines deep, on every row — the plan title and the header
+    // subtitle are both capped for the same reason.
+    mockQueries(
+      {
+        before: [
+          templateTask({
+            roles: [rolePair("Camera", PRODUCTION), rolePair("Sound", PRODUCTION)],
+          }),
+          templateTask({
+            key: "t2",
+            taskId: "task-2",
+            title: "Greet at the door",
+            roles: [rolePair("Greeter")],
+          }),
+        ],
+        during: [],
+        after: [],
+      },
+      DEFAULT_PLANS,
+      {
+        crew: [
+          myCrewRow("Camera", PRODUCTION),
+          myCrewRow("Sound", PRODUCTION),
+          myCrewRow("Greeter"),
+        ],
+      },
+    );
+    const { getByText } = render(<ServingTasksScreen />);
+
+    expect(getByText("Production · Camera & Sound").props.numberOfLines).toBe(2);
+  });
+
   it("adds no chrome for two DISTINCT roles that share a name on one team", () => {
     // Nothing stops a team defining "Camera" twice (`createRole` only rejects
     // an empty name). Both rows would be stamped with an identical bare

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -1553,9 +1553,12 @@ describe("ServingTasksScreen — task provenance (Mine)", () => {
     expect(getByText("Production · Camera")).toBeTruthy();
   });
 
-  it("still labels rows when the crew section never resolved (offline)", () => {
-    // The task `roles` alone carry enough to decide, so a venue with no signal
-    // and no cached crew list doesn't silently lose the labels.
+  it("labels NOTHING until the crew section resolves", () => {
+    // The two sections are independent subscriptions and the tasks usually win
+    // the race. Deciding from them would render an unlabelled list and then
+    // grow a meta line on EVERY row a beat later — a full-list reflow on a
+    // checklist of toggle Pressables, where a tap already in flight lands on
+    // the neighbouring task's checkbox.
     mockQueries(
       {
         before: [
@@ -1573,10 +1576,31 @@ describe("ServingTasksScreen — task provenance (Mine)", () => {
       DEFAULT_PLANS,
       { crew: undefined },
     );
+    const { getByText, queryByText } = render(<ServingTasksScreen />);
+
+    expect(getByText("Set up chairs")).toBeTruthy();
+    expect(queryByText("Production · Camera")).toBeNull();
+    expect(queryByText("Hospitality · Greeter")).toBeNull();
+  });
+
+  it("labels rows for a role the plan has no tasks for", () => {
+    // The viewer holds Camera AND Usher; the plan only has Camera tasks. Only
+    // the crew rows know about Usher — the task roles are a strict subset — so
+    // reading them would call this a single-role volunteer and drop the labels.
+    // That degradation would bite hardest offline, at the venue, which is
+    // exactly where "which roster is this from?" gets asked.
+    mockQueries(
+      {
+        before: [templateTask({ roles: [rolePair("Camera", PRODUCTION)] })],
+        during: [],
+        after: [],
+      },
+      DEFAULT_PLANS,
+      { crew: [myCrewRow("Camera", PRODUCTION), myCrewRow("Usher")] },
+    );
     const { getByText } = render(<ServingTasksScreen />);
 
     expect(getByText("Production · Camera")).toBeTruthy();
-    expect(getByText("Hospitality · Greeter")).toBeTruthy();
   });
 
   it("keeps the labels under the whatsapp-shell flag", () => {

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -205,7 +205,13 @@ function personalTask(overrides: Record<string, unknown> = {}) {
   };
 }
 
-type EligiblePlan = { planId: string; title: string; startsAt: number };
+type EligiblePlan = {
+  planId: string;
+  title: string;
+  startsAt: number;
+  groupName?: string;
+  teamNames?: string[];
+};
 
 const DEFAULT_PLANS: EligiblePlan[] = [
   { planId: "plan-1", title: "Sunday Gathering", startsAt: 0 },
@@ -236,14 +242,21 @@ function allTeamsRow(taskIds: string[], teamId = "team-1", roleNames = ["Camera"
 }
 
 /** A `getCrewTasks` row for the viewer themself (they hold `roleName`). */
-function myCrewRow(roleName: string) {
+function myCrewRow(
+  roleName: string,
+  team: { teamId: string; teamName: string } = {
+    teamId: "team-1",
+    teamName: "Hospitality",
+  },
+) {
   return {
     userId: "user-1",
     name: "Alex",
-    roleId: `role-${roleName}`,
+    // Role ids are team-scoped, so two teams' same-named roles differ.
+    roleId: `${team.teamId}:${roleName}`,
     roleName,
-    teamId: "team-1",
-    teamName: "Hospitality",
+    teamId: team.teamId,
+    teamName: team.teamName,
     isCurrentUser: true,
     status: "confirmed",
     done: 0,
@@ -251,6 +264,24 @@ function myCrewRow(roleName: string) {
     tasks: [],
   };
 }
+
+/** The `roles` provenance `getMyServingTasks` now attaches to a role task. */
+function rolePair(
+  roleName: string,
+  team: { teamId: string; teamName: string } = {
+    teamId: "team-1",
+    teamName: "Hospitality",
+  },
+) {
+  return {
+    roleId: `${team.teamId}:${roleName}`,
+    roleName,
+    teamId: team.teamId,
+    teamName: team.teamName,
+  };
+}
+
+const PRODUCTION = { teamId: "team-prod", teamName: "Production" };
 
 /** A `getSharedTeamTasks` row (team-level task, Shared pill only). */
 function sharedRow(taskId: string, title: string) {
@@ -1381,5 +1412,312 @@ describe("ServingTasksScreen — whatsapp-shell skin", () => {
     expect(getByText("Shared")).toBeTruthy();
     expect(getByText("Crew")).toBeTruthy();
     expect(getByText("All teams")).toBeTruthy();
+  });
+});
+
+/**
+ * Provenance: what rostered me, and which of my roles each task belongs to.
+ *
+ * Multi-plan / multi-role rendering already worked — the queries just threw
+ * away WHICH role matched, so a volunteer holding two roles (or serving two
+ * campuses on one morning) got a flat, unattributed list under headers that
+ * read identically. These pin the labels AND — just as importantly — that the
+ * single-role volunteer's list is untouched.
+ */
+describe("ServingTasksScreen — task provenance (Mine)", () => {
+  beforeEach(() => {
+    mockIsServingMode = true;
+    mockWhatsappShell = false;
+  });
+  afterEach(() => jest.clearAllMocks());
+
+  it("adds NO role chrome for a volunteer holding a single role", () => {
+    mockQueries(
+      {
+        before: [templateTask({ roles: [rolePair("Greeter")] })],
+        during: [],
+        after: [],
+      },
+      DEFAULT_PLANS,
+      { crew: [myCrewRow("Greeter")] },
+    );
+    const { getByText, queryByText } = render(<ServingTasksScreen />);
+
+    expect(getByText("Set up chairs")).toBeTruthy();
+    // The row's only meta line stays absent — nothing to disambiguate.
+    expect(queryByText("Greeter")).toBeNull();
+    expect(queryByText("Hospitality · Greeter")).toBeNull();
+  });
+
+  it("names the role once the viewer holds two on the SAME team", () => {
+    mockQueries(
+      {
+        before: [
+          templateTask({ roles: [rolePair("Greeter")] }),
+          templateTask({
+            key: "t2",
+            taskId: "task-2",
+            title: "Count the offering",
+            roles: [rolePair("Usher")],
+          }),
+        ],
+        during: [],
+        after: [],
+      },
+      DEFAULT_PLANS,
+      { crew: [myCrewRow("Greeter"), myCrewRow("Usher")] },
+    );
+    const { getByText, queryByText } = render(<ServingTasksScreen />);
+
+    expect(getByText("Greeter")).toBeTruthy();
+    expect(getByText("Usher")).toBeTruthy();
+    // One team => naming it would be pure noise.
+    expect(queryByText("Hospitality · Greeter")).toBeNull();
+  });
+
+  it("leads with the team once the viewer is on two teams", () => {
+    mockQueries(
+      {
+        before: [
+          templateTask({ roles: [rolePair("Camera", PRODUCTION)] }),
+          templateTask({
+            key: "t2",
+            taskId: "task-2",
+            title: "Greet at the door",
+            roles: [rolePair("Greeter")],
+          }),
+        ],
+        during: [],
+        after: [],
+      },
+      DEFAULT_PLANS,
+      {
+        crew: [myCrewRow("Camera", PRODUCTION), myCrewRow("Greeter")],
+      },
+    );
+    const { getByText } = render(<ServingTasksScreen />);
+
+    expect(getByText("Production · Camera")).toBeTruthy();
+    expect(getByText("Hospitality · Greeter")).toBeTruthy();
+  });
+
+  it("shows EVERY role a task matched, not just the first", () => {
+    // A task carries several roleIds; a viewer can hold more than one of them.
+    mockQueries(
+      {
+        before: [
+          templateTask({
+            roles: [rolePair("Camera", PRODUCTION), rolePair("Sound", PRODUCTION)],
+          }),
+          templateTask({
+            key: "t2",
+            taskId: "task-2",
+            title: "Greet at the door",
+            roles: [rolePair("Greeter")],
+          }),
+        ],
+        during: [],
+        after: [],
+      },
+      DEFAULT_PLANS,
+      {
+        crew: [
+          myCrewRow("Camera", PRODUCTION),
+          myCrewRow("Sound", PRODUCTION),
+          myCrewRow("Greeter"),
+        ],
+      },
+    );
+    const { getByText } = render(<ServingTasksScreen />);
+
+    expect(getByText("Production · Camera & Sound")).toBeTruthy();
+  });
+
+  it("leaves a personal task's 'Added by you' marker alone", () => {
+    mockQueries(
+      {
+        before: [
+          personalTask(),
+          templateTask({ roles: [rolePair("Camera", PRODUCTION)] }),
+        ],
+        during: [],
+        after: [],
+      },
+      DEFAULT_PLANS,
+      { crew: [myCrewRow("Camera", PRODUCTION), myCrewRow("Greeter")] },
+    );
+    const { getByText } = render(<ServingTasksScreen />);
+
+    // Nobody rostered a personal task, so it keeps its own marker only.
+    expect(getByText("Added by you")).toBeTruthy();
+    expect(getByText("Production · Camera")).toBeTruthy();
+  });
+
+  it("still labels rows when the crew section never resolved (offline)", () => {
+    // The task `roles` alone carry enough to decide, so a venue with no signal
+    // and no cached crew list doesn't silently lose the labels.
+    mockQueries(
+      {
+        before: [
+          templateTask({ roles: [rolePair("Camera", PRODUCTION)] }),
+          templateTask({
+            key: "t2",
+            taskId: "task-2",
+            title: "Greet at the door",
+            roles: [rolePair("Greeter")],
+          }),
+        ],
+        during: [],
+        after: [],
+      },
+      DEFAULT_PLANS,
+      { crew: undefined },
+    );
+    const { getByText } = render(<ServingTasksScreen />);
+
+    expect(getByText("Production · Camera")).toBeTruthy();
+    expect(getByText("Hospitality · Greeter")).toBeTruthy();
+  });
+
+  it("keeps the labels under the whatsapp-shell flag", () => {
+    mockWhatsappShell = true;
+    mockQueries(
+      {
+        before: [
+          templateTask({ roles: [rolePair("Camera", PRODUCTION)] }),
+          templateTask({
+            key: "t2",
+            taskId: "task-2",
+            title: "Greet at the door",
+            roles: [rolePair("Greeter")],
+          }),
+        ],
+        during: [],
+        after: [],
+      },
+      DEFAULT_PLANS,
+      { crew: [myCrewRow("Camera", PRODUCTION), myCrewRow("Greeter")] },
+    );
+    const { getByText } = render(<ServingTasksScreen />);
+
+    expect(getByText("Production · Camera")).toBeTruthy();
+    expect(getByText("Hospitality · Greeter")).toBeTruthy();
+  });
+});
+
+/**
+ * The Shared tab already received `teamNames` from the backend and rendered the
+ * literal string "Team task" instead. Same conditional rule as above: name the
+ * team only when the viewer is on more than one.
+ */
+describe("ServingTasksScreen — shared task team names", () => {
+  beforeEach(() => {
+    mockIsServingMode = true;
+    mockWhatsappShell = false;
+  });
+  afterEach(() => jest.clearAllMocks());
+
+  it("keeps the plain 'Team task' cue for a viewer on one team", () => {
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
+      shared: [sharedRow("shared-1", "Stack the chairs")],
+      crew: [myCrewRow("Greeter")],
+    });
+    const { getByText, getByLabelText, queryByText } = render(
+      <ServingTasksScreen />,
+    );
+    fireEvent.press(getByLabelText("Shared"));
+
+    expect(getByText("Team task")).toBeTruthy();
+    expect(queryByText("Hospitality team task")).toBeNull();
+  });
+
+  it("names the task's team once the viewer is on more than one", () => {
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
+      shared: [sharedRow("shared-1", "Stack the chairs")],
+      crew: [myCrewRow("Greeter"), myCrewRow("Camera", PRODUCTION)],
+    });
+    const { getByText, getByLabelText, queryByText } = render(
+      <ServingTasksScreen />,
+    );
+    fireEvent.press(getByLabelText("Shared"));
+
+    expect(getByText("Hospitality team task")).toBeTruthy();
+    expect(queryByText("Team task")).toBeNull();
+  });
+
+  it("names every team a multi-team shared task spans", () => {
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS, {
+      shared: [
+        {
+          ...sharedRow("shared-1", "Stack the chairs"),
+          teamIds: ["team-1", "team-prod"],
+          teamNames: ["Hospitality", "Production"],
+        },
+      ],
+      crew: [myCrewRow("Greeter"), myCrewRow("Camera", PRODUCTION)],
+    });
+    const { getByText, getByLabelText } = render(<ServingTasksScreen />);
+    fireEvent.press(getByLabelText("Shared"));
+
+    expect(getByText("Hospitality, Production team task")).toBeTruthy();
+  });
+});
+
+/**
+ * Plan headers. Three same-day plans used to stack as three sections headed by
+ * byte-identical strings, which is how a leader concluded their own authored
+ * tasks had vanished: they authored on one plan and were rostered on another.
+ */
+describe("ServingTasksScreen — plan header provenance", () => {
+  beforeEach(() => {
+    mockIsServingMode = true;
+    mockWhatsappShell = false;
+  });
+  afterEach(() => jest.clearAllMocks());
+
+  it("names the group that rostered the viewer under the plan title", () => {
+    mockQueries(EMPTY_MINE, [
+      {
+        planId: "plan-1",
+        title: "Sunday Gathering",
+        startsAt: 0,
+        groupName: "FOUNT Brooklyn",
+        teamNames: ["Production"],
+      },
+    ]);
+    const { getByText } = render(<ServingTasksScreen />);
+
+    expect(getByText("FOUNT Brooklyn · Production")).toBeTruthy();
+  });
+
+  it("tells two identically-titled same-day plans apart", () => {
+    mockQueries(EMPTY_MINE, [
+      {
+        planId: "plan-1",
+        title: "Sunday Gathering",
+        startsAt: 0,
+        groupName: "FOUNT Brooklyn",
+      },
+      {
+        planId: "plan-2",
+        title: "Sunday Gathering",
+        startsAt: 0,
+        groupName: "FOUNT Manhattan",
+      },
+    ]);
+    const { getByText, getAllByText } = render(<ServingTasksScreen />);
+
+    expect(getAllByText("Sunday Gathering")).toHaveLength(2);
+    expect(getByText("FOUNT Brooklyn")).toBeTruthy();
+    expect(getByText("FOUNT Manhattan")).toBeTruthy();
+  });
+
+  it("renders no subtitle when an older offline cache has no group name", () => {
+    mockQueries(EMPTY_MINE, DEFAULT_PLANS);
+    const { getByText, queryByText } = render(<ServingTasksScreen />);
+
+    expect(getByText("Sunday Gathering")).toBeTruthy();
+    expect(queryByText("undefined")).toBeNull();
+    expect(queryByText("")).toBeNull();
   });
 });

--- a/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTasksScreen.test.tsx
@@ -1603,6 +1603,32 @@ describe("ServingTasksScreen — task provenance (Mine)", () => {
     expect(getByText("Production · Camera")).toBeTruthy();
   });
 
+  it("adds no chrome for two DISTINCT roles that share a name on one team", () => {
+    // Nothing stops a team defining "Camera" twice (`createRole` only rejects
+    // an empty name). Both rows would be stamped with an identical bare
+    // "Camera" — noise that resolves nothing — so the gate has to count role
+    // NAMES per team, not raw pairs.
+    mockQueries(
+      {
+        before: [templateTask({ roles: [rolePair("Camera", PRODUCTION)] })],
+        during: [],
+        after: [],
+      },
+      DEFAULT_PLANS,
+      {
+        crew: [
+          { ...myCrewRow("Camera", PRODUCTION), roleId: "team-prod:camera-a" },
+          { ...myCrewRow("Camera", PRODUCTION), roleId: "team-prod:camera-b" },
+        ],
+      },
+    );
+    const { getByText, queryByText } = render(<ServingTasksScreen />);
+
+    expect(getByText("Set up chairs")).toBeTruthy();
+    expect(queryByText("Camera")).toBeNull();
+    expect(queryByText("Production · Camera")).toBeNull();
+  });
+
   it("keeps the labels under the whatsapp-shell flag", () => {
     mockWhatsappShell = true;
     mockQueries(

--- a/apps/mobile/features/serving/components/__tests__/ServingTeamScreen.test.tsx
+++ b/apps/mobile/features/serving/components/__tests__/ServingTeamScreen.test.tsx
@@ -183,3 +183,41 @@ describe("ServingTeamScreen — whatsapp-shell skin", () => {
     expect(getByLabelText("Back")).toBeTruthy();
   });
 });
+
+/**
+ * Two same-day plans used to stack as two sections headed by identical
+ * strings ("Untitled event plan · Sun, Aug 3"), giving a volunteer no way to
+ * tell which campus rostered them.
+ */
+describe("ServingTeamScreen — plan header provenance", () => {
+  it("names the group under the plan title", () => {
+    (useAuthenticatedQuery as jest.Mock).mockReturnValue({
+      plans: [{ ...ROSTER.plans[0], groupName: "FOUNT Brooklyn" }],
+    });
+    const { getByText } = render(<ServingTeamScreen />);
+    expect(getByText("FOUNT Brooklyn")).toBeTruthy();
+  });
+
+  it("tells two identically-titled same-day plans apart", () => {
+    (useAuthenticatedQuery as jest.Mock).mockReturnValue({
+      plans: [
+        { ...ROSTER.plans[0], groupName: "FOUNT Brooklyn" },
+        {
+          ...ROSTER.plans[0],
+          planId: "plan-2",
+          groupName: "FOUNT Manhattan",
+        },
+      ],
+    });
+    const { getAllByText, getByText } = render(<ServingTeamScreen />);
+    expect(getAllByText("Sunday Gathering")).toHaveLength(2);
+    expect(getByText("FOUNT Brooklyn")).toBeTruthy();
+    expect(getByText("FOUNT Manhattan")).toBeTruthy();
+  });
+
+  it("renders no subtitle when the plan carries no group name", () => {
+    const { getByText, queryByText } = render(<ServingTeamScreen />);
+    expect(getByText("Sunday Gathering")).toBeTruthy();
+    expect(queryByText("undefined")).toBeNull();
+  });
+});

--- a/apps/mobile/features/serving/utils/__tests__/servingProvenance.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/servingProvenance.test.ts
@@ -1,0 +1,170 @@
+import {
+  distinctRolePairs,
+  formatSharedTaskTeams,
+  formatTaskProvenance,
+  heldRolePairs,
+  planSubtitle,
+  shouldShowTaskProvenance,
+  shouldShowTeamNames,
+  type RolePair,
+} from "../servingProvenance";
+
+/** A (team, role) the viewer holds. Role ids are team-scoped. */
+function pair(
+  roleName: string,
+  teamName = "Hospitality",
+  teamId = "team-hosp",
+): RolePair {
+  return { roleId: `${teamId}:${roleName}`, roleName, teamId, teamName };
+}
+
+const CAMERA_PROD = pair("Camera", "Production", "team-prod");
+const SOUND_PROD = pair("Sound", "Production", "team-prod");
+const GREETER_HOSP = pair("Greeter");
+/** Same NAME as CAMERA_PROD, different team — the collision that must survive. */
+const CAMERA_HOSP = pair("Camera");
+
+describe("planSubtitle", () => {
+  it("is null with no group name — nothing empty should render", () => {
+    expect(planSubtitle(undefined)).toBeNull();
+    expect(planSubtitle("")).toBeNull();
+    expect(planSubtitle("   ")).toBeNull();
+  });
+
+  it("names the group that rostered the viewer", () => {
+    expect(planSubtitle("FOUNT Brooklyn")).toBe("FOUNT Brooklyn");
+  });
+
+  it("appends the viewer's teams on that plan when known", () => {
+    expect(planSubtitle("FOUNT Brooklyn", ["Production", "Hospitality"])).toBe(
+      "FOUNT Brooklyn · Production, Hospitality",
+    );
+  });
+
+  it("ignores empty team names rather than trailing a separator", () => {
+    expect(planSubtitle("FOUNT Brooklyn", ["", ""])).toBe("FOUNT Brooklyn");
+  });
+});
+
+describe("distinctRolePairs", () => {
+  it("keeps first-seen order and drops exact repeats", () => {
+    expect(
+      distinctRolePairs([CAMERA_PROD, GREETER_HOSP, CAMERA_PROD]),
+    ).toEqual([CAMERA_PROD, GREETER_HOSP]);
+  });
+
+  it("does NOT collapse the same role name on two different teams", () => {
+    expect(distinctRolePairs([CAMERA_PROD, CAMERA_HOSP])).toHaveLength(2);
+  });
+});
+
+describe("heldRolePairs", () => {
+  it("is empty when neither source has resolved", () => {
+    expect(heldRolePairs(undefined, undefined)).toEqual([]);
+  });
+
+  it("keeps only the viewer's own crew rows", () => {
+    const crew = [
+      { ...CAMERA_PROD, isCurrentUser: true },
+      { ...SOUND_PROD, isCurrentUser: false },
+    ];
+    expect(heldRolePairs(crew, undefined)).toEqual([CAMERA_PROD]);
+  });
+
+  it("unions the crew rows with the roles the tasks matched on", () => {
+    // Offline, whichever section was cached is enough to decide — so the two
+    // sources are unioned rather than one being preferred.
+    const crew = [{ ...CAMERA_PROD, isCurrentUser: true }];
+    expect(heldRolePairs(crew, [CAMERA_PROD, GREETER_HOSP])).toEqual([
+      CAMERA_PROD,
+      GREETER_HOSP,
+    ]);
+  });
+});
+
+describe("shouldShowTaskProvenance / shouldShowTeamNames", () => {
+  it("says nothing for the single-role volunteer", () => {
+    expect(shouldShowTaskProvenance([CAMERA_PROD])).toBe(false);
+    expect(shouldShowTaskProvenance([])).toBe(false);
+  });
+
+  it("labels rows once the viewer holds two pairs", () => {
+    expect(shouldShowTaskProvenance([CAMERA_PROD, SOUND_PROD])).toBe(true);
+  });
+
+  it("omits team names while the viewer is on one team", () => {
+    expect(shouldShowTeamNames([CAMERA_PROD, SOUND_PROD])).toBe(false);
+  });
+
+  it("names teams once the viewer spans two", () => {
+    expect(shouldShowTeamNames([CAMERA_PROD, GREETER_HOSP])).toBe(true);
+  });
+});
+
+describe("formatTaskProvenance", () => {
+  it("is null when the task matched no role of the viewer's (personal task)", () => {
+    expect(formatTaskProvenance([], false)).toBeNull();
+    expect(formatTaskProvenance(undefined, true)).toBeNull();
+  });
+
+  it("names just the role when the viewer is on one team", () => {
+    expect(formatTaskProvenance([CAMERA_PROD], false)).toBe("Camera");
+  });
+
+  it("names every role a task matched, not just the first", () => {
+    // `roleIds` is an array, so one task can be the viewer's twice over.
+    // Showing only the first would recreate the doubt this exists to remove.
+    expect(formatTaskProvenance([CAMERA_PROD, SOUND_PROD], false)).toBe(
+      "Camera & Sound",
+    );
+  });
+
+  it("leads with the team when the viewer spans several", () => {
+    expect(formatTaskProvenance([CAMERA_PROD], true)).toBe(
+      "Production · Camera",
+    );
+  });
+
+  it("groups multiple matches under their teams", () => {
+    expect(
+      formatTaskProvenance([CAMERA_PROD, SOUND_PROD, GREETER_HOSP], true),
+    ).toBe("Production · Camera & Sound, Hospitality · Greeter");
+  });
+
+  it("tells two same-named roles on different teams apart", () => {
+    expect(formatTaskProvenance([CAMERA_PROD, CAMERA_HOSP], true)).toBe(
+      "Production · Camera, Hospitality · Camera",
+    );
+  });
+});
+
+describe("formatSharedTaskTeams", () => {
+  it("is null while the viewer is on a single team — 'Team task' is enough", () => {
+    expect(formatSharedTaskTeams(["Production"], [CAMERA_PROD])).toBeNull();
+    expect(
+      formatSharedTaskTeams(["Production"], [CAMERA_PROD, SOUND_PROD]),
+    ).toBeNull();
+  });
+
+  it("names the task's own team once the viewer is on more than one", () => {
+    expect(
+      formatSharedTaskTeams(["Production"], [CAMERA_PROD, GREETER_HOSP]),
+    ).toBe("Production");
+  });
+
+  it("names every team a multi-team shared task spans", () => {
+    expect(
+      formatSharedTaskTeams(
+        ["Production", "Hospitality"],
+        [CAMERA_PROD, GREETER_HOSP],
+      ),
+    ).toBe("Production, Hospitality");
+  });
+
+  it("is null when the task carries no team names at all", () => {
+    expect(formatSharedTaskTeams([], [CAMERA_PROD, GREETER_HOSP])).toBeNull();
+    expect(
+      formatSharedTaskTeams(undefined, [CAMERA_PROD, GREETER_HOSP]),
+    ).toBeNull();
+  });
+});

--- a/apps/mobile/features/serving/utils/__tests__/servingProvenance.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/servingProvenance.test.ts
@@ -102,6 +102,20 @@ describe("shouldShowTaskProvenance / shouldShowTeamNames", () => {
     expect(shouldShowTaskProvenance([CAMERA_PROD, SOUND_PROD])).toBe(true);
   });
 
+  it("stays quiet for two same-named roles on ONE team", () => {
+    // Both would render the identical bare label "Camera" (the team is not
+    // named — the viewer is on one team), so stamping it under every row
+    // resolves nothing.
+    const dupe: RolePair = { ...CAMERA_PROD, roleId: "team-prod:Camera-2" };
+    expect(shouldShowTaskProvenance([CAMERA_PROD, dupe])).toBe(false);
+  });
+
+  it("still labels two same-named roles on DIFFERENT teams", () => {
+    // Here the labels differ ("Production · Camera" vs "Hospitality · Camera"),
+    // so they do tell the rows apart.
+    expect(shouldShowTaskProvenance([CAMERA_PROD, CAMERA_HOSP])).toBe(true);
+  });
+
   it("omits team names while the viewer is on one team", () => {
     expect(shouldShowTeamNames([CAMERA_PROD, SOUND_PROD])).toBe(false);
   });

--- a/apps/mobile/features/serving/utils/__tests__/servingProvenance.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/servingProvenance.test.ts
@@ -59,8 +59,10 @@ describe("distinctRolePairs", () => {
 });
 
 describe("heldRolePairs", () => {
-  it("is empty when neither source has resolved", () => {
-    expect(heldRolePairs(undefined, undefined)).toEqual([]);
+  it("is null — not empty — while the crew rows are unresolved", () => {
+    // The distinction is the whole point: `[]` would mean "holds nothing" and
+    // is a decision; `null` means "don't decide yet".
+    expect(heldRolePairs(undefined)).toBeNull();
   });
 
   it("keeps only the viewer's own crew rows", () => {
@@ -68,17 +70,17 @@ describe("heldRolePairs", () => {
       { ...CAMERA_PROD, isCurrentUser: true },
       { ...SOUND_PROD, isCurrentUser: false },
     ];
-    expect(heldRolePairs(crew, undefined)).toEqual([CAMERA_PROD]);
+    expect(heldRolePairs(crew)).toEqual([CAMERA_PROD]);
   });
 
-  it("unions the crew rows with the roles the tasks matched on", () => {
-    // Offline, whichever section was cached is enough to decide — so the two
-    // sources are unioned rather than one being preferred.
-    const crew = [{ ...CAMERA_PROD, isCurrentUser: true }];
-    expect(heldRolePairs(crew, [CAMERA_PROD, GREETER_HOSP])).toEqual([
-      CAMERA_PROD,
-      GREETER_HOSP,
-    ]);
+  it("reports every role the viewer holds, including task-less ones", () => {
+    // getCrewTasks emits a row per (member, role) even when that role has zero
+    // tasks on the plan — which is why it, and not the task rows, is the source.
+    const crew = [
+      { ...CAMERA_PROD, isCurrentUser: true },
+      { ...GREETER_HOSP, isCurrentUser: true },
+    ];
+    expect(heldRolePairs(crew)).toEqual([CAMERA_PROD, GREETER_HOSP]);
   });
 });
 
@@ -86,6 +88,14 @@ describe("shouldShowTaskProvenance / shouldShowTeamNames", () => {
   it("says nothing for the single-role volunteer", () => {
     expect(shouldShowTaskProvenance([CAMERA_PROD])).toBe(false);
     expect(shouldShowTaskProvenance([])).toBe(false);
+  });
+
+  it("says nothing while the crew rows are unresolved", () => {
+    // Otherwise the labels pop in when the second subscription lands and reflow
+    // every row of a checklist whose rows are tap targets — and offline, where
+    // "crew" may never have been cached, they would stay wrongly absent.
+    expect(shouldShowTaskProvenance(null)).toBe(false);
+    expect(shouldShowTeamNames(null)).toBe(false);
   });
 
   it("labels rows once the viewer holds two pairs", () => {
@@ -159,6 +169,10 @@ describe("formatSharedTaskTeams", () => {
         [CAMERA_PROD, GREETER_HOSP],
       ),
     ).toBe("Production, Hospitality");
+  });
+
+  it("is null while the crew rows are unresolved — plain 'Team task' stands", () => {
+    expect(formatSharedTaskTeams(["Production"], null)).toBeNull();
   });
 
   it("is null when the task carries no team names at all", () => {

--- a/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
@@ -74,6 +74,25 @@ describe("planTaskCountsFromAllTeams", () => {
   });
 });
 
+/**
+ * A `getCrewTasks` row for the viewer. Role ids are team-scoped, so the id is
+ * derived from (team, role) — two teams with a "Camera" are two distinct roles.
+ */
+function crewRow(
+  roleName: string,
+  team: { teamId: string; teamName: string } = {
+    teamId: "team-1",
+    teamName: "Hospitality",
+  },
+) {
+  return {
+    isCurrentUser: true as boolean,
+    roleId: `${team.teamId}:${roleName}`,
+    roleName,
+    ...team,
+  };
+}
+
 describe("myRoleNamesFromCrew", () => {
   it("returns null while the query is unresolved", () => {
     expect(myRoleNamesFromCrew(undefined)).toBeNull();
@@ -86,12 +105,42 @@ describe("myRoleNamesFromCrew", () => {
 
   it("keeps only the viewer's own rows, de-duplicated, in order", () => {
     const names = myRoleNamesFromCrew([
-      { isCurrentUser: true, roleName: "Greeter" },
-      { isCurrentUser: false, roleName: "Camera 1" },
-      { isCurrentUser: true, roleName: "Usher" },
-      { isCurrentUser: true, roleName: "Greeter" },
+      crewRow("Greeter"),
+      { ...crewRow("Camera 1"), isCurrentUser: false },
+      crewRow("Usher"),
+      crewRow("Greeter"),
     ]);
     expect(names).toEqual(["Greeter", "Usher"]);
+  });
+
+  // The de-dupe key used to be the role NAME alone, so two teams that each
+  // define a "Camera" collapsed to one entry and the copy said "You're serving
+  // as Camera" to someone holding both — understating the roster, which is the
+  // very doubt this sentence exists to settle.
+  it("keeps a role name held on two different teams as two entries", () => {
+    const names = myRoleNamesFromCrew([
+      crewRow("Camera", { teamId: "team-prod", teamName: "Production" }),
+      crewRow("Camera", { teamId: "team-hosp", teamName: "Hospitality" }),
+    ]);
+    expect(names).toEqual(["Camera (Production)", "Camera (Hospitality)"]);
+  });
+
+  it("leaves unambiguous role names unqualified alongside a colliding one", () => {
+    const names = myRoleNamesFromCrew([
+      crewRow("Camera", { teamId: "team-prod", teamName: "Production" }),
+      crewRow("Camera", { teamId: "team-hosp", teamName: "Hospitality" }),
+      crewRow("Greeter", { teamId: "team-hosp", teamName: "Hospitality" }),
+    ]);
+    expect(names).toEqual([
+      "Camera (Production)",
+      "Camera (Hospitality)",
+      "Greeter",
+    ]);
+  });
+
+  it("still collapses the SAME role on the same team (a double-written row)", () => {
+    const names = myRoleNamesFromCrew([crewRow("Camera"), crewRow("Camera")]);
+    expect(names).toEqual(["Camera"]);
   });
 });
 

--- a/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
+++ b/apps/mobile/features/serving/utils/__tests__/servingTaskEmptyState.test.ts
@@ -142,6 +142,19 @@ describe("myRoleNamesFromCrew", () => {
     const names = myRoleNamesFromCrew([crewRow("Camera"), crewRow("Camera")]);
     expect(names).toEqual(["Camera"]);
   });
+
+  // `createRole` only rejects an empty name, so ONE team can hold two distinct
+  // roles both called "Camera". They are two pairs, but they qualify to the
+  // same string — printed per-pair the copy read "You're serving as Camera and
+  // Camera." De-duping on the display string collapses them without touching
+  // the cross-team case above, where the team qualifier makes them differ.
+  it("collapses two DISTINCT roles sharing a name on ONE team", () => {
+    const names = myRoleNamesFromCrew([
+      { ...crewRow("Camera"), roleId: "team-1:camera-a" },
+      { ...crewRow("Camera"), roleId: "team-1:camera-b" },
+    ]);
+    expect(names).toEqual(["Camera"]);
+  });
 });
 
 describe("diagnoseMineEmpty", () => {

--- a/apps/mobile/features/serving/utils/servingProvenance.ts
+++ b/apps/mobile/features/serving/utils/servingProvenance.ts
@@ -1,0 +1,189 @@
+/**
+ * Serving-mode provenance: WHO rostered the viewer, and which of their roles
+ * put each task in front of them.
+ *
+ * Multi-plan and multi-role rendering already worked — every same-day plan gets
+ * its own section, and a task matching any role the viewer holds appears in
+ * "Mine". What was missing is the answer to "why am I looking at this?": the
+ * matched role and its team were computed server-side and thrown away, so a
+ * volunteer holding Camera on Production AND Greeter on Hospitality saw one
+ * flat, unattributed list.
+ *
+ * Everything here is deliberately CONDITIONAL. The overwhelming majority of
+ * volunteers hold exactly one (team, role) pair on a plan, and for them every
+ * row would carry the same label — pure noise. So the rules are:
+ *
+ *   • Label a task row only when the viewer holds MORE THAN ONE distinct
+ *     (team, role) pair on the plan (`shouldShowTaskProvenance`).
+ *   • Name the TEAM only when those pairs span more than one team
+ *     (`shouldShowTeamNames`). Two roles on a single team need only the role
+ *     names to be told apart.
+ *
+ * The pairs are read from the queries the Tasks screen already runs — the
+ * viewer's own `getCrewTasks` rows (what they HOLD) unioned with the `roles`
+ * each `getMyServingTasks` item now carries (what they were MATCHED on). The
+ * union matters offline: whichever of the two sections has a cached copy is
+ * enough to decide, and the crew list alone would also miss a role whose
+ * assignment resolves but whose crew row hasn't loaded.
+ */
+
+/**
+ * The provenance line under a plan's title: "FOUNT Brooklyn", or
+ * "FOUNT Brooklyn · Production" when the viewer's teams on that plan are known.
+ *
+ * Every serving tab stacks one section per same-day plan, and their headers
+ * used to be byte-identical ("Untitled event plan · Sun, Aug 3 · 9:00 AM") —
+ * which is how a leader concluded the tasks they had just authored were
+ * missing: they authored on one plan and were rostered on another. Returns
+ * `null` when there is no group name (an offline cache written by an older
+ * build), so nothing empty renders.
+ */
+export function planSubtitle(
+  groupName: string | undefined,
+  teamNames?: ReadonlyArray<string>,
+): string | null {
+  const group = (groupName ?? "").trim();
+  if (!group) return null;
+  const teams = (teamNames ?? []).filter(Boolean);
+  return teams.length > 0 ? `${group} · ${teams.join(", ")}` : group;
+}
+
+/** One (team, role) the viewer holds — the unit of serving provenance. */
+export interface RolePair {
+  roleId: string;
+  roleName: string;
+  teamId: string;
+  teamName: string;
+}
+
+/** Identity of a pair. Role ids are team-scoped, but both are kept so two teams
+ *  that happen to share a role NAME never collapse into one. */
+const pairKey = (p: RolePair): string => `${p.teamId}::${p.roleId}`;
+
+/** Distinct pairs in first-seen order. */
+export function distinctRolePairs(
+  pairs: ReadonlyArray<RolePair>,
+): RolePair[] {
+  const seen = new Set<string>();
+  const out: RolePair[] = [];
+  for (const p of pairs) {
+    const key = pairKey(p);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Every (team, role) pair the viewer holds on a plan, from the two sources the
+ * Tasks screen already has. Either may be `undefined` (unresolved, or never
+ * cached offline) — the union of what IS available is used.
+ */
+export function heldRolePairs(
+  crew: ReadonlyArray<{ isCurrentUser: boolean } & RolePair> | undefined,
+  taskRoles: ReadonlyArray<RolePair> | undefined,
+): RolePair[] {
+  const pairs: RolePair[] = [];
+  for (const row of crew ?? []) {
+    if (!row.isCurrentUser) continue;
+    // Projected, not spread: a crew row carries a member's whole card, and
+    // leaking that through would make two structurally different objects for
+    // the same pair.
+    pairs.push({
+      roleId: row.roleId,
+      roleName: row.roleName,
+      teamId: row.teamId,
+      teamName: row.teamName,
+    });
+  }
+  for (const role of taskRoles ?? []) {
+    pairs.push({
+      roleId: role.roleId,
+      roleName: role.roleName,
+      teamId: role.teamId,
+      teamName: role.teamName,
+    });
+  }
+  return distinctRolePairs(pairs);
+}
+
+/**
+ * Whether task rows should say which role they came from. False for the
+ * single-role volunteer — their list stays exactly as clean as it was.
+ */
+export function shouldShowTaskProvenance(
+  heldPairs: ReadonlyArray<RolePair>,
+): boolean {
+  return heldPairs.length > 1;
+}
+
+/** Whether the team needs naming too — only when the viewer spans >1 team. */
+export function shouldShowTeamNames(
+  heldPairs: ReadonlyArray<RolePair>,
+): boolean {
+  return new Set(heldPairs.map((p) => p.teamId)).size > 1;
+}
+
+/** "Camera", "Camera & Usher", "Camera, Usher & Greeter". */
+function joinRoleNames(names: ReadonlyArray<string>): string {
+  if (names.length <= 1) return names[0] ?? "";
+  return `${names.slice(0, -1).join(", ")} & ${names[names.length - 1]}`;
+}
+
+/**
+ * The provenance label for one task row, or `null` when there is nothing worth
+ * saying (no matched roles — e.g. a personal task the viewer added themselves).
+ *
+ * A task names several roles, so the viewer can match on more than one; ALL
+ * matches are shown rather than an arbitrary first, because "this task is yours
+ * twice over" is the honest reading and hiding a match would recreate the very
+ * doubt this exists to remove.
+ *
+ * Team-first when `includeTeam`, since the team is the coarser question:
+ *   "Production · Camera & Usher, Hospitality · Greeter"
+ * Role-only otherwise:
+ *   "Camera & Usher"
+ */
+export function formatTaskProvenance(
+  roles: ReadonlyArray<RolePair> | undefined,
+  includeTeam: boolean,
+): string | null {
+  const pairs = distinctRolePairs(roles ?? []);
+  if (pairs.length === 0) return null;
+
+  if (!includeTeam) {
+    const names: string[] = [];
+    for (const p of pairs) if (!names.includes(p.roleName)) names.push(p.roleName);
+    return joinRoleNames(names);
+  }
+
+  // Group by team, preserving first-seen order of both teams and roles.
+  const byTeam = new Map<string, { teamName: string; roleNames: string[] }>();
+  for (const p of pairs) {
+    const entry =
+      byTeam.get(p.teamId) ??
+      byTeam.set(p.teamId, { teamName: p.teamName, roleNames: [] }).get(p.teamId)!;
+    if (!entry.roleNames.includes(p.roleName)) entry.roleNames.push(p.roleName);
+  }
+  return [...byTeam.values()]
+    .map((t) => `${t.teamName} · ${joinRoleNames(t.roleNames)}`)
+    .join(", ");
+}
+
+/**
+ * The label for a whole-team ("Shared") task, or `null` when the viewer is on a
+ * single team and naming it would only add chrome.
+ *
+ * `teamNames` are the task's OWN teams (a team-level task can span several),
+ * which is the provenance question being answered — not the viewer's teams.
+ */
+export function formatSharedTaskTeams(
+  teamNames: ReadonlyArray<string> | undefined,
+  heldPairs: ReadonlyArray<RolePair>,
+): string | null {
+  if (!shouldShowTeamNames(heldPairs)) return null;
+  const names = (teamNames ?? []).filter(Boolean);
+  if (names.length === 0) return null;
+  return names.join(", ");
+}

--- a/apps/mobile/features/serving/utils/servingProvenance.ts
+++ b/apps/mobile/features/serving/utils/servingProvenance.ts
@@ -19,12 +19,28 @@
  *     (`shouldShowTeamNames`). Two roles on a single team need only the role
  *     names to be told apart.
  *
- * The pairs are read from the queries the Tasks screen already runs — the
- * viewer's own `getCrewTasks` rows (what they HOLD) unioned with the `roles`
- * each `getMyServingTasks` item now carries (what they were MATCHED on). The
- * union matters offline: whichever of the two sections has a cached copy is
- * enough to decide, and the crew list alone would also miss a role whose
- * assignment resolves but whose crew row hasn't loaded.
+ * The pairs come from ONE source: the viewer's own `getCrewTasks` rows. That is
+ * the only complete answer to "what do I hold on this plan?" — it emits a row
+ * per (member, role) even for roles with zero tasks. The `roles` on each
+ * `getMyServingTasks` item are a strict SUBSET (a role with no matching task
+ * can never appear there), so unioning them in can never add a pair the crew
+ * rows lack, but reading them WITHOUT the crew rows silently under-reports:
+ * a viewer holding Camera + Usher on a Camera-only plan looks single-role and
+ * every row loses its label.
+ *
+ * So the decision is deliberately all-or-nothing on the crew rows resolving
+ * (`heldRolePairs` returns `null` until they do, and every rule below reads
+ * `null` as "say nothing"):
+ *
+ *   • Two independent subscriptions meant the tasks usually landed first, and
+ *     the labels then popped in a beat later — a full-list layout shift on a
+ *     checklist of toggle `Pressable`s, where a tap already in flight lands on
+ *     the neighbouring task's checkbox.
+ *   • Offline the two sections are cached by separate effects, so `"mine"`
+ *     could be present with `"crew"` missing. Deciding from the subset there
+ *     would make the labels LEAST reliable at the venue — exactly where the
+ *     volunteer is asking which roster a task came from. Unlabelled is honest;
+ *     wrongly-unlabelled-because-we-guessed is not.
  */
 
 /**
@@ -76,16 +92,19 @@ export function distinctRolePairs(
 }
 
 /**
- * Every (team, role) pair the viewer holds on a plan, from the two sources the
- * Tasks screen already has. Either may be `undefined` (unresolved, or never
- * cached offline) — the union of what IS available is used.
+ * Every (team, role) pair the viewer holds on a plan, from their own
+ * `getCrewTasks` rows — the one complete source (see the module header).
+ *
+ * `null` means "not known yet": the query hasn't resolved and, offline, no
+ * cached copy exists. Callers must render no provenance at all in that state
+ * rather than deciding from the task rows, which can only under-report.
  */
 export function heldRolePairs(
   crew: ReadonlyArray<{ isCurrentUser: boolean } & RolePair> | undefined,
-  taskRoles: ReadonlyArray<RolePair> | undefined,
-): RolePair[] {
+): RolePair[] | null {
+  if (crew === undefined) return null;
   const pairs: RolePair[] = [];
-  for (const row of crew ?? []) {
+  for (const row of crew) {
     if (!row.isCurrentUser) continue;
     // Projected, not spread: a crew row carries a member's whole card, and
     // leaking that through would make two structurally different objects for
@@ -97,31 +116,27 @@ export function heldRolePairs(
       teamName: row.teamName,
     });
   }
-  for (const role of taskRoles ?? []) {
-    pairs.push({
-      roleId: role.roleId,
-      roleName: role.roleName,
-      teamId: role.teamId,
-      teamName: role.teamName,
-    });
-  }
   return distinctRolePairs(pairs);
 }
 
 /**
  * Whether task rows should say which role they came from. False for the
- * single-role volunteer — their list stays exactly as clean as it was.
+ * single-role volunteer — their list stays exactly as clean as it was — and
+ * false while `heldPairs` is `null` (unresolved), so the answer never flips
+ * mid-scroll.
  */
 export function shouldShowTaskProvenance(
-  heldPairs: ReadonlyArray<RolePair>,
+  heldPairs: ReadonlyArray<RolePair> | null,
 ): boolean {
+  if (!heldPairs) return false;
   return heldPairs.length > 1;
 }
 
 /** Whether the team needs naming too — only when the viewer spans >1 team. */
 export function shouldShowTeamNames(
-  heldPairs: ReadonlyArray<RolePair>,
+  heldPairs: ReadonlyArray<RolePair> | null,
 ): boolean {
+  if (!heldPairs) return false;
   return new Set(heldPairs.map((p) => p.teamId)).size > 1;
 }
 
@@ -177,10 +192,11 @@ export function formatTaskProvenance(
  *
  * `teamNames` are the task's OWN teams (a team-level task can span several),
  * which is the provenance question being answered — not the viewer's teams.
+ * `null` heldPairs (unresolved) means the plain "Team task" copy stands.
  */
 export function formatSharedTaskTeams(
   teamNames: ReadonlyArray<string> | undefined,
-  heldPairs: ReadonlyArray<RolePair>,
+  heldPairs: ReadonlyArray<RolePair> | null,
 ): string | null {
   if (!shouldShowTeamNames(heldPairs)) return null;
   const names = (teamNames ?? []).filter(Boolean);

--- a/apps/mobile/features/serving/utils/servingProvenance.ts
+++ b/apps/mobile/features/serving/utils/servingProvenance.ts
@@ -124,12 +124,18 @@ export function heldRolePairs(
  * single-role volunteer — their list stays exactly as clean as it was — and
  * false while `heldPairs` is `null` (unresolved), so the answer never flips
  * mid-scroll.
+ *
+ * Counted by (team, role NAME), not by pair: nothing stops ONE team defining
+ * two roles both called "Camera", and stamping an identical "Camera" under
+ * every row resolves nothing — it is noise dressed as an explanation. Two
+ * TEAMS with a same-named role still count as two, because the label then
+ * names the team and the rows really do read differently.
  */
 export function shouldShowTaskProvenance(
   heldPairs: ReadonlyArray<RolePair> | null,
 ): boolean {
   if (!heldPairs) return false;
-  return heldPairs.length > 1;
+  return new Set(heldPairs.map((p) => `${p.teamId}::${p.roleName}`)).size > 1;
 }
 
 /** Whether the team needs naming too — only when the viewer spans >1 team. */

--- a/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
+++ b/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
@@ -142,6 +142,14 @@ export function planTaskCountsFromAllTeams(
  * ("did I miss a roster?") this copy exists to settle. When a role name DOES
  * appear on more than one team, it is qualified with its team ("Camera
  * (Production)"); unambiguous names stay bare so the common case reads clean.
+ *
+ * The final de-dupe is on the resulting DISPLAY STRING, not the pair. Nothing
+ * stops ONE team defining two roles both called "Camera" (`createRole` only
+ * rejects an empty name), and those two pairs qualify to the same bare
+ * "Camera" — printed per-pair that reads "You're serving as Camera and
+ * Camera." Collapsing identical strings keeps the cross-team case intact (the
+ * team qualifier makes those strings differ) while an unsayable duplicate says
+ * itself once.
  */
 export function myRoleNamesFromCrew(
   crew: ReadonlyArray<{ isCurrentUser: boolean } & RolePair> | undefined,
@@ -156,11 +164,15 @@ export function myRoleNamesFromCrew(
     teamsPerName.set(p.roleName, teams);
   }
 
-  return pairs.map((p) =>
-    (teamsPerName.get(p.roleName)?.size ?? 0) > 1
-      ? `${p.roleName} (${p.teamName})`
-      : p.roleName,
-  );
+  const names: string[] = [];
+  for (const p of pairs) {
+    const name =
+      (teamsPerName.get(p.roleName)?.size ?? 0) > 1
+        ? `${p.roleName} (${p.teamName})`
+        : p.roleName;
+    if (!names.includes(name)) names.push(name);
+  }
+  return names;
 }
 
 /**

--- a/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
+++ b/apps/mobile/features/serving/utils/servingTaskEmptyState.ts
@@ -31,6 +31,7 @@
  *   • shared task count     ← `getSharedTeamTasks`
  *   • the viewer's own list ← `getMyServingTasks`
  */
+import { distinctRolePairs, type RolePair } from "./servingProvenance";
 
 /**
  * Which empty-state story to tell. Precedence is deliberate — see
@@ -134,20 +135,32 @@ export function planTaskCountsFromAllTeams(
  * serving on, so the viewer's own rows name every role they hold. An empty
  * result means the viewer has no non-declined assignment at all — `getCrewTasks`
  * short-circuits to `[]` in that case. Returns `null` while unresolved.
+ *
+ * De-duped by (team, role), NOT by role name. Two teams may each define a role
+ * called "Camera"; collapsing them told a volunteer holding both "You're
+ * serving as Camera" — understating what they hold, which is exactly the doubt
+ * ("did I miss a roster?") this copy exists to settle. When a role name DOES
+ * appear on more than one team, it is qualified with its team ("Camera
+ * (Production)"); unambiguous names stay bare so the common case reads clean.
  */
 export function myRoleNamesFromCrew(
-  crew: ReadonlyArray<{ isCurrentUser: boolean; roleName: string }> | undefined,
+  crew: ReadonlyArray<{ isCurrentUser: boolean } & RolePair> | undefined,
 ): string[] | null {
   if (crew === undefined) return null;
-  const seen = new Set<string>();
-  const names: string[] = [];
-  for (const member of crew) {
-    if (!member.isCurrentUser) continue;
-    if (seen.has(member.roleName)) continue;
-    seen.add(member.roleName);
-    names.push(member.roleName);
+  const pairs = distinctRolePairs(crew.filter((m) => m.isCurrentUser));
+
+  const teamsPerName = new Map<string, Set<string>>();
+  for (const p of pairs) {
+    const teams = teamsPerName.get(p.roleName) ?? new Set<string>();
+    teams.add(p.teamId);
+    teamsPerName.set(p.roleName, teams);
   }
-  return names;
+
+  return pairs.map((p) =>
+    (teamsPerName.get(p.roleName)?.size ?? 0) > 1
+      ? `${p.roleName} (${p.teamName})`
+      : p.roleName,
+  );
 }
 
 /**

--- a/apps/mobile/stores/servingPlansCache.ts
+++ b/apps/mobile/stores/servingPlansCache.ts
@@ -20,9 +20,18 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 export interface CachedServingPlan {
   planId: string;
   groupId: string;
+  /**
+   * The group that rostered the viewer. Cached alongside the rest because the
+   * plan headers read it — offline, two same-day plans would otherwise fall
+   * back to identical headers, the exact ambiguity it exists to remove.
+   * Optional so a cache written by an older build still rehydrates.
+   */
+  groupName?: string;
   title: string;
   startsAt: number;
   endsAt: number;
+  /** The viewer's own teams on this plan. Same optionality rationale. */
+  teamNames?: string[];
 }
 
 interface ServingPlansCacheState {


### PR DESCRIPTION
From a product owner holding several roles: *"it should be clear what group rostered me and what tasks belong to what when I have multiple."*

## The gap was provenance, not aggregation

Multi-plan already worked — `getServingEligibility` returns **every** same-day plan the viewer is rostered on, and all three serving tabs already render one section per plan. Nothing was being dropped.

What was missing: `ServingTaskItem` carried no role, team, or group. `getMyServingTasks` unions every role the viewer holds, matches a task against that set, then **discards which role matched**. So someone holding Camera on Production and Greeter on Hospitality got one flat "Mine" list with no way to tell the two apart.

Shared tasks were worse: `SharedTeamTaskItem` has always returned `teamNames` over the wire, and the client threw them away to print the literal string "Team task".

## Changes

**Per-task role and team.** `ServingTaskItem` gains `roles` — every matched (roleName, teamName) pair, not a first-wins pick, since `roleIds` is an array and a task can legitimately match two of the viewer's roles.

**Shown only when it disambiguates.** Two independent gates off the viewer's distinct `(teamId, roleId)` pairs: label rows at all only when they hold more than one pair; name the *team* only when those pairs span more than one team. A two-role/one-team volunteer sees `Camera` / `Sound`, not `Production · Camera`. A single-role volunteer's list is byte-identical to before — there's a test asserting exactly that, because most users hold one role and extra chrome would be pure noise.

**Which plan is this?** `ServingPlan` gains `groupName`/`teamNames`, rendered as a subtitle in the Tasks, Runsheet and Team headers. Three same-date plans previously rendered three stacked sections with identical headers — *"Untitled event plan · Sun, Aug 3 · 9:00 AM"* — with nothing to tell them apart. That is exactly how the original report happened: tasks authored on one plan, rostered on another, no way to see the mismatch.

**Stop shipping "Untitled event plan".** Both creation sites now derive a title from the group. Deliberately **not** date-derived: both paths create the plan at a placeholder date the leader changes within minutes, so a date-based title would be actively wrong almost immediately. Existing plans are untouched.

**Two teams with the same role name no longer collapse.** `myRoleNamesFromCrew` de-duped on `roleName` alone, so a viewer holding "Camera" on two teams saw one entry — understating what they hold, which is precisely the doubt that prompted this. Now keyed on `(teamId, roleId)`, qualifying a name with its team only when that name really appears on more than one team.

## Deliberately out of scope

**Duplicate-plan prevention.** Nothing at any level — schema, backend, or UI — stops several plans existing on one date, and "Add date" uses a deterministic `nextSundayAtNine()` with no idempotency, so tapping twice yields two identical plans. This PR makes existing duplicates *distinguishable*; it does not stop them being created. That guard belongs in its own change.

Also not here: the WA migration of the run sheet, and role swiping in the Edit tab.

## Verification

- `apps/convex` — 163 files / 2874 tests passed; `npx convex typecheck` clean
- `apps/mobile` — 223 suites / 2285 tests passed (+42)
- ESLint clean on all changed files; `tsc` shows zero errors in `features/serving`, `features/scheduling`, `stores`
- `check-navigator-screens` selftest + check passed
- No dependencies changed; native-safety gates not applicable
- Flag-off parity test still passes; a flag-on test asserts the new labels survive

## Not verified

No device run. Pure JS text/layout in existing nodes, no native or dependency change, so ADR-013's hazards don't apply — but the new header subtitle's spacing has only been checked through the test renderer, not on a screen.

One convex full-suite run failed a single test that could not be identified before two subsequent runs came back green. Consistent with the known `event-checkin` flake under parallel load, but reported rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168KrbHskjSAFjB6sSHgkXA

---
_Generated by [Claude Code](https://claude.ai/code/session_0168KrbHskjSAFjB6sSHgkXA)_