### PR TITLE
Stop a group silently collecting several plans on one date

### DIFF
--- a/apps/convex/__tests__/scheduling/assignments.test.ts
+++ b/apps/convex/__tests__/scheduling/assignments.test.ts
@@ -339,6 +339,8 @@ describe("double-booking detection", () => {
         times: [{ label: "9 AM", startsAt: eventDate }],
       })
     ).planId;
+    // A second plan on an already-planned day is the deliberate multi-service
+    // case, so it needs the explicit opt-in the duplicate-date guard requires.
     const planB = (
       await t.mutation(api.functions.scheduling.events.createEvent, {
         token: leaderToken,
@@ -346,6 +348,7 @@ describe("double-booking detection", () => {
         title: "11 AM Service",
         eventDate,
         times: [{ label: "11 AM", startsAt: eventDate }],
+        allowSameDay: true,
       })
     ).planId;
 
@@ -401,6 +404,7 @@ describe("double-booking detection", () => {
         title: "11 AM Service",
         eventDate: midday,
         times: [{ label: "11 AM", startsAt: midday }],
+        allowSameDay: true,
       })
     ).planId;
 

--- a/apps/convex/__tests__/scheduling/duplicatePlanDate.test.ts
+++ b/apps/convex/__tests__/scheduling/duplicatePlanDate.test.ts
@@ -1,0 +1,454 @@
+/**
+ * Duplicate-plan-date guard.
+ *
+ * A group used to be able to accumulate any number of indistinguishable plans
+ * on one date — the roster grid's "Add date" and the quick-start both default
+ * to a DETERMINISTIC "next Sunday 9 AM", so a second tap produced a byte-
+ * identical second plan. That is how a leader ended up authoring tasks on one
+ * Aug 2 plan while being rostered on a different Aug 2 plan.
+ *
+ * The guard is a typed `DUPLICATE_PLAN_DATE` ConvexError, not silent
+ * idempotency: two services on one Sunday (9 AM + 11 AM) is normal, so the
+ * deliberate case must stay reachable via `allowSameDay: true`.
+ *
+ * "Same day" is the COMMUNITY-LOCAL day, not a UTC bucket — the boundary cases
+ * below are the whole reason `lib/localDay.ts` exists.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { ConvexError } from "convex/values";
+import { convexTest } from "convex-test";
+import schema from "../../schema";
+import { modules } from "../../test.setup";
+import { generateTokens } from "../../lib/auth";
+import { api } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import { buildSchedulingWorld } from "./fixtures";
+
+let activeHandle: ReturnType<typeof convexTest> | null = null;
+
+afterEach(async () => {
+  if (activeHandle) {
+    await activeHandle.finishInProgressScheduledFunctions();
+    activeHandle = null;
+  }
+});
+
+async function setupSchedulingWorld() {
+  const t = convexTest(schema, modules);
+  activeHandle = t;
+  const world = await buildSchedulingWorld(t);
+  return { t, world };
+}
+
+const DAY = 86400000;
+
+/**
+ * Fixed instants around Sunday 2 Aug 2026 in America/New_York (EDT, UTC-4) —
+ * the fixture community's default zone. Chosen so the UTC-bucket answer and
+ * the local-day answer DISAGREE in both directions:
+ *
+ *   SUN_9AM   13:00Z Sun 2 Aug — Sun 2 Aug ET
+ *   SUN_11AM  15:00Z Sun 2 Aug — Sun 2 Aug ET  (same local day, same UTC day)
+ *   SAT_11PM  03:00Z Sun 2 Aug — Sat 1 Aug ET  (same UTC day, DIFFERENT local day)
+ *   SUN_9PM   01:00Z Mon 3 Aug — Sun 2 Aug ET  (DIFFERENT UTC day, same local day)
+ */
+const SUN_9AM = Date.UTC(2026, 7, 2, 13, 0);
+const SUN_11AM = Date.UTC(2026, 7, 2, 15, 0);
+const SAT_11PM = Date.UTC(2026, 7, 2, 3, 0);
+const SUN_9PM = Date.UTC(2026, 7, 3, 1, 0);
+
+/**
+ * Assert a thrown value is the typed duplicate-date error, and return its data.
+ *
+ * `convex-test` hands `ConvexError.data` back as the JSON string it wired over,
+ * where a real client would have already deserialized it into the object — so
+ * parse when we're given a string.
+ */
+function expectDuplicateError(e: unknown): Record<string, unknown> {
+  expect(e).toBeInstanceOf(ConvexError);
+  const raw = (e as ConvexError<Record<string, unknown> | string>).data;
+  const data = (
+    typeof raw === "string" ? JSON.parse(raw) : raw
+  ) as Record<string, unknown>;
+  expect(data.code).toBe("DUPLICATE_PLAN_DATE");
+  return data;
+}
+
+async function createPlan(
+  t: ReturnType<typeof convexTest>,
+  token: string,
+  groupId: Id<"groups">,
+  title: string,
+  eventDate: number,
+  allowSameDay?: boolean,
+) {
+  return t.mutation(api.functions.scheduling.events.createEvent, {
+    token,
+    groupId,
+    title,
+    eventDate,
+    times: [{ label: "9 AM", startsAt: eventDate }],
+    ...(allowSameDay === undefined ? {} : { allowSameDay }),
+  });
+}
+
+describe("createEvent duplicate-date guard", () => {
+  it("rejects a second plan on the same local day with a typed error", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const { planId } = await createPlan(
+      t,
+      token,
+      world.groupId,
+      "Sunday Service",
+      SUN_9AM,
+    );
+
+    let thrown: unknown;
+    try {
+      await createPlan(t, token, world.groupId, "Sunday Service", SUN_11AM);
+    } catch (e) {
+      thrown = e;
+    }
+    const data = expectDuplicateError(thrown);
+    // The client needs enough to offer "open the one you have".
+    expect(data.existingPlanId).toBe(planId);
+    expect(data.existingPlanTitle).toBe("Sunday Service");
+    expect(data.existingEventDate).toBe(SUN_9AM);
+    expect(data.existingCount).toBe(1);
+    expect(data.dayLabel).toBe("Sun, Aug 2");
+    expect(String(data.message)).toContain("Sun, Aug 2");
+
+    // Nothing was written.
+    const plans = await t.run(async (ctx) =>
+      ctx.db
+        .query("eventPlans")
+        .withIndex("by_group", (q) => q.eq("groupId", world.groupId))
+        .collect(),
+    );
+    expect(plans).toHaveLength(1);
+  });
+
+  it("allows a deliberate second service on the same Sunday via allowSameDay", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const { planId: first } = await createPlan(
+      t,
+      token,
+      world.groupId,
+      "9 AM Service",
+      SUN_9AM,
+    );
+    const { planId: second } = await createPlan(
+      t,
+      token,
+      world.groupId,
+      "11 AM Service",
+      SUN_11AM,
+      true,
+    );
+    expect(second).not.toBe(first);
+
+    const plans = await t.run(async (ctx) =>
+      ctx.db
+        .query("eventPlans")
+        .withIndex("by_group", (q) => q.eq("groupId", world.groupId))
+        .collect(),
+    );
+    expect(plans).toHaveLength(2);
+  });
+
+  it("treats Sat 11 PM and Sun 9 AM local as different days (a UTC bucket would not)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // Both are 2 Aug in UTC; in ET one is Saturday night, the other Sunday.
+    expect(new Date(SAT_11PM).getUTCDate()).toBe(new Date(SUN_9AM).getUTCDate());
+
+    await createPlan(t, token, world.groupId, "Saturday Night", SAT_11PM);
+    await expect(
+      createPlan(t, token, world.groupId, "Sunday Morning", SUN_9AM),
+    ).resolves.toBeTruthy();
+  });
+
+  it("treats Sun 9 AM and Sun 9 PM local as the same day (they straddle UTC midnight)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // Different UTC dates — a UTC bucket would wave this duplicate through.
+    expect(new Date(SUN_9PM).getUTCDate()).not.toBe(
+      new Date(SUN_9AM).getUTCDate(),
+    );
+
+    await createPlan(t, token, world.groupId, "Sunday Morning", SUN_9AM);
+    let thrown: unknown;
+    try {
+      await createPlan(t, token, world.groupId, "Sunday Evening", SUN_9PM);
+    } catch (e) {
+      thrown = e;
+    }
+    expectDuplicateError(thrown);
+  });
+
+  it("uses the community's own timezone, not the server's", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    await t.run(async (ctx) => {
+      await ctx.db.patch(world.communityId, { timezone: "Pacific/Auckland" });
+    });
+
+    // 13:00Z Sun 2 Aug is Monday 3 Aug 01:00 in Auckland (UTC+12); 03:00Z the
+    // same UTC day is still Sunday 2 Aug there. Under ET these two are
+    // DIFFERENT days but the earlier one is Saturday — under NZ they are also
+    // different days, but shifted. What matters is that 13:00Z and 15:00Z (both
+    // Monday in NZ) still collide, while 03:00Z (Sunday in NZ) does not.
+    await createPlan(t, token, world.groupId, "Morning", SAT_11PM);
+    await expect(
+      createPlan(t, token, world.groupId, "Service", SUN_9AM),
+    ).resolves.toBeTruthy();
+
+    let thrown: unknown;
+    try {
+      await createPlan(t, token, world.groupId, "Second", SUN_11AM);
+    } catch (e) {
+      thrown = e;
+    }
+    const data = expectDuplicateError(thrown);
+    // Auckland renders 15:00Z Sun 2 Aug as Monday 3 Aug.
+    expect(data.dayLabel).toBe("Mon, Aug 3");
+  });
+
+  it("ignores demo-seeded plans so a demo Sunday never blocks a real one", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("eventPlans", {
+        groupId: world.groupId,
+        communityId: world.communityId,
+        title: "Demo Sunday",
+        eventDate: SUN_9AM,
+        times: [{ label: "9 AM", startsAt: SUN_9AM }],
+        status: "draft",
+        createdAt: Date.now(),
+        createdById: world.groupLeaderId,
+        updatedAt: Date.now(),
+        isDemoSeed: true,
+      });
+    });
+
+    await expect(
+      createPlan(t, token, world.groupId, "Real Sunday", SUN_11AM),
+    ).resolves.toBeTruthy();
+  });
+
+  it("scopes the collision to the group — another group may plan the same day", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const otherGroupId = await t.run(async (ctx) => {
+      const groupType = await ctx.db
+        .query("groupTypes")
+        .filter((q) => q.eq(q.field("communityId"), world.communityId))
+        .first();
+      const groupId = await ctx.db.insert("groups", {
+        communityId: world.communityId,
+        groupTypeId: groupType!._id,
+        name: "Manhattan Campus",
+        isArchived: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId,
+        userId: world.groupLeaderId,
+        role: "leader",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+      return groupId;
+    });
+
+    await createPlan(t, token, world.groupId, "Brooklyn", SUN_9AM);
+    await expect(
+      createPlan(t, token, otherGroupId, "Manhattan", SUN_9AM),
+    ).resolves.toBeTruthy();
+  });
+});
+
+describe("duplicateEvent duplicate-date guard", () => {
+  it("rejects a second duplicate onto the same target week", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const eventDate = Date.now() + 7 * DAY;
+    const { planId } = await createPlan(
+      t,
+      token,
+      world.groupId,
+      "Sunday Service",
+      eventDate,
+    );
+
+    await t.mutation(api.functions.scheduling.events.duplicateEvent, {
+      token,
+      planId,
+    });
+
+    let thrown: unknown;
+    try {
+      await t.mutation(api.functions.scheduling.events.duplicateEvent, {
+        token,
+        planId,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expectDuplicateError(thrown);
+
+    // Exactly one copy exists.
+    const plans = await t.run(async (ctx) =>
+      ctx.db
+        .query("eventPlans")
+        .withIndex("by_group", (q) => q.eq("groupId", world.groupId))
+        .collect(),
+    );
+    expect(plans).toHaveLength(2);
+  });
+
+  it("still duplicates onto an occupied day when allowSameDay is set", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    const eventDate = Date.now() + 7 * DAY;
+    const { planId } = await createPlan(
+      t,
+      token,
+      world.groupId,
+      "Sunday Service",
+      eventDate,
+    );
+    await t.mutation(api.functions.scheduling.events.duplicateEvent, {
+      token,
+      planId,
+    });
+    await expect(
+      t.mutation(api.functions.scheduling.events.duplicateEvent, {
+        token,
+        planId,
+        allowSameDay: true,
+      }),
+    ).resolves.toBeTruthy();
+  });
+});
+
+describe("updateEvent duplicate-date guard", () => {
+  it("rejects moving a plan onto a day the group already plans", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    await createPlan(t, token, world.groupId, "Sunday Service", SUN_9AM);
+    const { planId: mover } = await createPlan(
+      t,
+      token,
+      world.groupId,
+      "Saturday Night",
+      SAT_11PM,
+    );
+
+    let thrown: unknown;
+    try {
+      await t.mutation(api.functions.scheduling.events.updateEvent, {
+        token,
+        planId: mover,
+        eventDate: SUN_11AM,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expectDuplicateError(thrown);
+
+    const unchanged = await t.run(async (ctx) => ctx.db.get(mover));
+    expect(unchanged!.eventDate).toBe(SAT_11PM);
+  });
+
+  it("allows the move with allowSameDay, and never collides with itself", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    await createPlan(t, token, world.groupId, "Sunday Service", SUN_9AM);
+    const { planId: mover } = await createPlan(
+      t,
+      token,
+      world.groupId,
+      "Saturday Night",
+      SAT_11PM,
+    );
+
+    await t.mutation(api.functions.scheduling.events.updateEvent, {
+      token,
+      planId: mover,
+      eventDate: SUN_11AM,
+      allowSameDay: true,
+    });
+    expect((await t.run(async (ctx) => ctx.db.get(mover)))!.eventDate).toBe(
+      SUN_11AM,
+    );
+
+    // Re-saving the same date (or a same-day nudge) must not trip the guard on
+    // the plan's own row.
+    await t.mutation(api.functions.scheduling.events.updateEvent, {
+      token,
+      planId: mover,
+      title: "11 AM Service",
+    });
+    expect((await t.run(async (ctx) => ctx.db.get(mover)))!.title).toBe(
+      "11 AM Service",
+    );
+  });
+});
+
+describe("rosterMatrix same-date flag", () => {
+  it("counts plans sharing a local day so the grid can flag ambiguous columns", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // ~14 days out at 12:00Z (08:00 ET) so the +2h sibling below stays on the
+    // same local day whatever timezone the test runner is in. `rosterMatrix`
+    // only returns upcoming columns, so the dates must be in the future.
+    const future = Math.floor(Date.now() / DAY) * DAY + 14 * DAY + 12 * 3600000;
+    const at = (offsetHours: number) => future + offsetHours * 3600000;
+
+    const { planId: a } = await createPlan(t, token, world.groupId, "A", at(0));
+    const { planId: b } = await createPlan(
+      t,
+      token,
+      world.groupId,
+      "B",
+      at(2),
+      true,
+    );
+    const { planId: c } = await createPlan(
+      t,
+      token,
+      world.groupId,
+      "C",
+      at(24 * 7),
+    );
+
+    const matrix = await t.query(api.functions.scheduling.roster.rosterMatrix, {
+      token,
+      groupId: world.groupId,
+    });
+    const byId = new Map(
+      matrix.events.map((e) => [e._id as string, e.sameDatePlanCount]),
+    );
+    // A and B share a local day (they are two hours apart); C is alone.
+    expect(byId.get(a as string)).toBe(2);
+    expect(byId.get(b as string)).toBe(2);
+    expect(byId.get(c as string)).toBe(1);
+  });
+});

--- a/apps/convex/__tests__/scheduling/duplicatePlanDate.test.ts
+++ b/apps/convex/__tests__/scheduling/duplicatePlanDate.test.ts
@@ -409,6 +409,111 @@ describe("updateEvent duplicate-date guard", () => {
       "11 AM Service",
     );
   });
+
+  it("lets a plan move WITHIN its own local day even when another plan shares that day", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+
+    // The multi-service Sunday this whole feature exists to allow.
+    await createPlan(t, token, world.groupId, "9 AM Service", SUN_9AM);
+    const { planId: eleven } = await createPlan(
+      t,
+      token,
+      world.groupId,
+      "11 AM Service",
+      SUN_11AM,
+      true,
+    );
+
+    // The web date picker rebuilds a picked date at LOCAL MIDNIGHT, dropping
+    // the time of day — so re-picking "the same date" sends a different
+    // millisecond. Excluding the plan from itself does not save this: the 9 AM
+    // plan is a real, different plan on the same day.
+    const localMidnightSun2 = Date.UTC(2026, 7, 2, 4, 0); // 00:00 ET
+    await t.mutation(api.functions.scheduling.events.updateEvent, {
+      token,
+      planId: eleven,
+      eventDate: localMidnightSun2,
+    });
+    expect((await t.run(async (ctx) => ctx.db.get(eleven)))!.eventDate).toBe(
+      localMidnightSun2,
+    );
+
+    // Leaving the day is still guarded.
+    await createPlan(t, token, world.groupId, "Next Week", SUN_9AM + 7 * DAY);
+    let thrown: unknown;
+    try {
+      await t.mutation(api.functions.scheduling.events.updateEvent, {
+        token,
+        planId: eleven,
+        eventDate: SUN_9AM + 7 * DAY + 2 * 3600000,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expectDuplicateError(thrown);
+  });
+});
+
+describe("corrupt eventDate rows", () => {
+  /**
+   * `eventDate` is a Convex `v.number()`, i.e. a float64 — `NaN` and
+   * `Infinity` both pass validation, and `Intl.DateTimeFormat.format` throws
+   * `RangeError: Invalid time value` on them. The guard maps the formatter
+   * over every sibling plan and `rosterMatrix` over every plan in the group,
+   * so one bad row (a bad client, an import, a migration) would otherwise turn
+   * every create into an untyped 500 and make the grid unloadable.
+   */
+  async function insertCorruptPlan(
+    t: ReturnType<typeof convexTest>,
+    world: Awaited<ReturnType<typeof setupSchedulingWorld>>["world"],
+    eventDate: number,
+  ) {
+    return t.run(async (ctx) =>
+      ctx.db.insert("eventPlans", {
+        groupId: world.groupId,
+        communityId: world.communityId,
+        title: "Corrupt",
+        eventDate,
+        times: [],
+        status: "draft" as const,
+        createdAt: Date.now(),
+        createdById: world.groupLeaderId,
+        updatedAt: Date.now(),
+      }),
+    );
+  }
+
+  it("does not stop the group creating a plan", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    await insertCorruptPlan(t, world, NaN);
+
+    const { planId } = await createPlan(
+      t,
+      token,
+      world.groupId,
+      "Sunday Service",
+      SUN_9AM,
+    );
+    expect(planId).toBeTruthy();
+  });
+
+  it("does not stop the roster grid loading, and is never flagged double-booked", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const token = (await generateTokens(world.groupLeaderId)).accessToken;
+    // Two corrupt rows: they must not be bucketed together either.
+    await insertCorruptPlan(t, world, NaN);
+    await insertCorruptPlan(t, world, Infinity);
+
+    const matrix = await t.query(api.functions.scheduling.roster.rosterMatrix, {
+      token,
+      groupId: world.groupId,
+    });
+    for (const event of matrix.events) {
+      expect(event.sameDatePlanCount).toBe(1);
+    }
+  });
 });
 
 describe("rosterMatrix same-date flag", () => {

--- a/apps/convex/__tests__/scheduling/eventItems.test.ts
+++ b/apps/convex/__tests__/scheduling/eventItems.test.ts
@@ -34,13 +34,18 @@ async function setupSchedulingWorld() {
 
 const DAY = 86400000;
 
-/** Create a draft event plan and return its id. */
+/**
+ * Create a draft event plan and return its id. `dayOffset` exists so a test
+ * needing two plans puts them on different days — a group may only hold one
+ * plan per calendar day unless the leader explicitly opts in.
+ */
 async function createPlan(
   t: ReturnType<typeof convexTest>,
   token: string,
   groupId: Id<"groups">,
+  dayOffset = 7,
 ): Promise<Id<"eventPlans">> {
-  const eventDate = Date.now() + 7 * DAY;
+  const eventDate = Date.now() + dayOffset * DAY;
   const { planId } = await t.mutation(
     api.functions.scheduling.events.createEvent,
     {
@@ -222,7 +227,7 @@ describe("reorderItems", () => {
     const { t, world } = await setupSchedulingWorld();
     const token = (await generateTokens(world.groupLeaderId)).accessToken;
     const planA = await createPlan(t, token, world.groupId);
-    const planB = await createPlan(t, token, world.groupId);
+    const planB = await createPlan(t, token, world.groupId, 14);
 
     const { itemId: onA } = await t.mutation(
       api.functions.scheduling.eventItems.createItem,

--- a/apps/convex/__tests__/scheduling/localDay.test.ts
+++ b/apps/convex/__tests__/scheduling/localDay.test.ts
@@ -1,0 +1,91 @@
+/**
+ * `lib/localDay.ts` — the local-calendar-day primitives behind the
+ * duplicate-plan-date guard and the roster grid's same-date flag.
+ *
+ * These are pure, so they get a pure test. The two properties that matter are
+ * both defensive: a corrupt `eventDate` must not throw (it is mapped over every
+ * plan of a group, so one bad row would brick creation AND the grid), and the
+ * formatters must be reused rather than rebuilt per call (they are constructed
+ * once per plan per mutation otherwise).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_TIMEZONE,
+  INVALID_DAY_KEY,
+  isValidDayKey,
+  localDayKey,
+  localDayLabel,
+  resolveTimeZone,
+} from "../../lib/localDay";
+
+const ET = "America/New_York";
+
+describe("resolveTimeZone", () => {
+  it("keeps a real zone and falls back for anything else", () => {
+    expect(resolveTimeZone(ET)).toBe(ET);
+    expect(resolveTimeZone(undefined)).toBe(DEFAULT_TIMEZONE);
+    expect(resolveTimeZone("Mars/Olympus_Mons")).toBe(DEFAULT_TIMEZONE);
+  });
+});
+
+describe("localDayKey", () => {
+  it("keys the community-local day, not the UTC one", () => {
+    // 03:00Z Sun 2 Aug is Sat 1 Aug in ET.
+    expect(localDayKey(Date.UTC(2026, 7, 2, 3, 0), ET)).toBe("2026-08-01");
+    // 01:00Z Mon 3 Aug is still Sun 2 Aug in ET.
+    expect(localDayKey(Date.UTC(2026, 7, 3, 1, 0), ET)).toBe("2026-08-02");
+  });
+
+  it("returns the never-matching sentinel for a date that is not an instant", () => {
+    // `eventDate` is a Convex `v.number()` — a float64 — so all of these pass
+    // validation and reach the formatter, which throws RangeError on each.
+    for (const bad of [NaN, Infinity, -Infinity, 8.64e15 + 1, -8.64e15 - 1]) {
+      expect(localDayKey(bad, ET)).toBe(INVALID_DAY_KEY);
+      expect(isValidDayKey(localDayKey(bad, ET))).toBe(false);
+    }
+    expect(isValidDayKey(localDayKey(Date.UTC(2026, 7, 2, 13, 0), ET))).toBe(
+      true,
+    );
+  });
+
+  it("never returns a real day key for a corrupt value", () => {
+    // The sentinel must be impossible to produce from a valid instant, so a
+    // corrupt row can never be reported as sharing a day with a real one.
+    expect(INVALID_DAY_KEY).not.toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("reuses one formatter per zone instead of building one per call", () => {
+    // ~100x: constructing an Intl.DateTimeFormat dominates formatting with it,
+    // and the guard formats every sibling plan on every create/update.
+    const spy = Intl.DateTimeFormat;
+    let constructed = 0;
+    // @ts-expect-error — deliberately swapping the global for the assertion.
+    Intl.DateTimeFormat = function (...args: unknown[]) {
+      constructed++;
+      // @ts-expect-error — forwarding to the real implementation.
+      return new spy(...args);
+    };
+    try {
+      // A zone the memo has certainly not seen yet.
+      const zone = "Australia/Adelaide";
+      for (let i = 0; i < 50; i++) {
+        localDayKey(Date.UTC(2026, 7, 2, 13, 0) + i * 3600000, zone);
+      }
+      expect(constructed).toBe(1);
+    } finally {
+      Intl.DateTimeFormat = spy;
+    }
+  });
+});
+
+describe("localDayLabel", () => {
+  it("renders the community-local day for a collision message", () => {
+    expect(localDayLabel(Date.UTC(2026, 7, 2, 13, 0), ET)).toBe("Sun, Aug 2");
+  });
+
+  it("degrades to prose rather than throwing on a corrupt date", () => {
+    expect(localDayLabel(NaN, ET)).toBe("an unknown date");
+    expect(localDayLabel(Infinity, ET)).toBe("an unknown date");
+  });
+});

--- a/apps/convex/__tests__/scheduling/roster.test.ts
+++ b/apps/convex/__tests__/scheduling/roster.test.ts
@@ -37,10 +37,19 @@ async function createPlan(
   groupId: Id<"groups">,
   title: string,
   eventDate: number,
+  /** Opt in to a second plan on an already-planned day (multi-service Sunday). */
+  allowSameDay = false,
 ) {
   const { planId } = await t.mutation(
     api.functions.scheduling.events.createEvent,
-    { token, groupId, title, eventDate, times: [{ label: "9 AM", startsAt: eventDate }] },
+    {
+      token,
+      groupId,
+      title,
+      eventDate,
+      times: [{ label: "9 AM", startsAt: eventDate }],
+      allowSameDay,
+    },
   );
   return planId as Id<"eventPlans">;
 }
@@ -54,7 +63,7 @@ describe("rosterMatrix", () => {
 
     const sameDay = Date.now() + 7 * DAY;
     const planA = await createPlan(t, leader, world.groupId, "Service A", sameDay);
-    const planB = await createPlan(t, leader, world.groupId, "Service B", sameDay);
+    const planB = await createPlan(t, leader, world.groupId, "Service B", sameDay, true);
 
     // Need 2 Drums on A, 1 on B.
     await t.mutation(api.functions.scheduling.events.setNeededRoles, {

--- a/apps/convex/functions/scheduling/events.ts
+++ b/apps/convex/functions/scheduling/events.ts
@@ -74,6 +74,12 @@ const timeValidator = v.object({
  * Error code thrown when a plan would land on a local calendar day the group
  * already has a plan on. The client keys off this to offer a choice ("open the
  * one you have" vs "add another") instead of dead-ending on a raw error.
+ *
+ * MIRRORED by `DUPLICATE_PLAN_DATE` in
+ * `apps/mobile/features/scheduling/utils/duplicatePlanDate.ts`. Changing this
+ * VALUE silently turns every date collision back into an unhandled error on
+ * every client — the mobile test `duplicatePlanDate.test.ts` reads this file
+ * and fails if the two drift.
  */
 export const DUPLICATE_PLAN_DATE = "DUPLICATE_PLAN_DATE";
 

--- a/apps/convex/functions/scheduling/events.ts
+++ b/apps/convex/functions/scheduling/events.ts
@@ -18,6 +18,7 @@ import type { MutationCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
+import { localDayKey, localDayLabel, resolveTimeZone } from "../../lib/localDay";
 import {
   requireGroupMember,
   requireGroupScheduler,
@@ -65,6 +66,76 @@ const timeValidator = v.object({
 });
 
 /**
+ * Error code thrown when a plan would land on a local calendar day the group
+ * already has a plan on. The client keys off this to offer a choice ("open the
+ * one you have" vs "add another") instead of dead-ending on a raw error.
+ */
+export const DUPLICATE_PLAN_DATE = "DUPLICATE_PLAN_DATE";
+
+/**
+ * Reject a plan that would land on a day this group already has one, unless the
+ * caller explicitly opted in.
+ *
+ * WHY an error and not idempotent reuse: two services on one Sunday (9 AM and
+ * 11 AM) is normal church practice, so silently returning the existing plan
+ * would make a legitimate second plan impossible to create. And silently
+ * creating one — today's behavior — is what produced three indistinguishable
+ * plans on one date, where a leader authored tasks on one plan while being
+ * rostered on another. A typed error is the only option that both blocks the
+ * accident and keeps the deliberate case reachable: the client turns it into a
+ * choice, and "add another" re-calls with `allowSameDay: true`.
+ *
+ * Demo-seeded plans are excluded — a demo Sunday must never block a real one.
+ *
+ * @throws ConvexError with `{ code: DUPLICATE_PLAN_DATE, ... }` data.
+ */
+export async function assertPlanDateFree(
+  ctx: MutationCtx,
+  args: {
+    groupId: Id<"groups">;
+    communityId: Id<"communities">;
+    eventDate: number;
+    /** The plan being moved — never collides with itself. */
+    excludePlanId?: Id<"eventPlans">;
+    /** Caller confirmed they want a second plan on this day. */
+    allowSameDay?: boolean;
+  },
+): Promise<void> {
+  if (args.allowSameDay) return;
+
+  const community = await ctx.db.get(args.communityId);
+  const timeZone = resolveTimeZone(community?.timezone);
+  const targetDay = localDayKey(args.eventDate, timeZone);
+
+  const siblings = await ctx.db
+    .query("eventPlans")
+    .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+    .collect();
+  const clashes = siblings
+    .filter(
+      (p) =>
+        p._id !== args.excludePlanId &&
+        !p.isDemoSeed &&
+        localDayKey(p.eventDate, timeZone) === targetDay,
+    )
+    .sort((a, b) => a.createdAt - b.createdAt);
+  if (clashes.length === 0) return;
+
+  const existing = clashes[0];
+  const dayLabel = localDayLabel(args.eventDate, timeZone);
+  throw new ConvexError({
+    code: DUPLICATE_PLAN_DATE,
+    message: `"${existing.title}" is already scheduled on ${dayLabel}.`,
+    dayLabel,
+    existingPlanId: existing._id,
+    existingPlanTitle: existing.title,
+    existingEventDate: existing.eventDate,
+    /** How many other plans already sit on this day (usually 1). */
+    existingCount: clashes.length,
+  });
+}
+
+/**
  * The title a plan gets when its creator didn't name it.
  *
  * Both no-title entry points ("Add date" on the roster grid, and the
@@ -86,6 +157,10 @@ export function defaultPlanTitle(groupName: string | undefined): string {
  * Insert a `draft` event plan for a campus group. The shared implementation
  * behind the `createEvent` mutation, reused by `quickStartRostering`. Callers
  * MUST have already authorized the scheduler — this helper does no auth.
+ *
+ * Guards the group's local calendar day (see `assertPlanDateFree`): both entry
+ * points default to a DETERMINISTIC "next Sunday 9 AM", so without this a
+ * second tap silently produced a byte-identical second plan.
  */
 export async function createEventDraftImpl(
   ctx: MutationCtx,
@@ -98,12 +173,21 @@ export async function createEventDraftImpl(
     createdById: Id<"users">;
     notes?: string;
     meetingIds?: Id<"meetings">[];
+    /** Caller confirmed a deliberate second plan on an occupied day. */
+    allowSameDay?: boolean;
   },
 ): Promise<Id<"eventPlans">> {
   const title = args.title.trim();
   if (!title) {
     throw new ConvexError("Event title cannot be empty");
   }
+
+  await assertPlanDateFree(ctx, {
+    groupId: args.groupId,
+    communityId: args.communityId,
+    eventDate: args.eventDate,
+    allowSameDay: args.allowSameDay,
+  });
 
   const nowMs = Date.now();
   return ctx.db.insert("eventPlans", {
@@ -131,6 +215,10 @@ export async function createEventDraftImpl(
  * throws, matching `updateEvent`. Silently renaming it to "<Group> event" would
  * drop the leader's input with no client error path to notice it.
  *
+ * `allowSameDay` is the leader's explicit "yes, a second service that day" —
+ * without it a plan on an already-planned local day throws
+ * `DUPLICATE_PLAN_DATE`.
+ *
  * Auth: group leader or community admin.
  */
 export const createEvent = mutation({
@@ -142,6 +230,7 @@ export const createEvent = mutation({
     times: v.array(timeValidator),
     notes: v.optional(v.string()),
     meetingIds: v.optional(v.array(v.id("meetings"))),
+    allowSameDay: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -157,6 +246,7 @@ export const createEvent = mutation({
       createdById: userId,
       notes: args.notes,
       meetingIds: args.meetingIds,
+      allowSameDay: args.allowSameDay,
     });
 
     return { planId };
@@ -172,6 +262,10 @@ const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
  * source. Assignees (`roleAssignments`), `meetingIds`, and `pcoPlanId` are
  * deliberately NOT copied — duplication seeds a fresh roster to fill.
  *
+ * The copy's derived date is guarded the same way `createEvent`'s is: duplicating
+ * twice, or duplicating a plan whose next-week slot is already planned, throws
+ * `DUPLICATE_PLAN_DATE` unless the caller passes `allowSameDay`.
+ *
  * Auth: group leader or community admin for the event's group (same as
  * `createEvent`).
  */
@@ -179,6 +273,7 @@ export const duplicateEvent = mutation({
   args: {
     token: v.string(),
     planId: v.id("eventPlans"),
+    allowSameDay: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
@@ -204,6 +299,13 @@ export const duplicateEvent = mutation({
       const weeksBehind = Math.ceil((todayStart - eventDate) / ONE_WEEK_MS);
       eventDate += weeksBehind * ONE_WEEK_MS;
     }
+
+    await assertPlanDateFree(ctx, {
+      groupId: source.groupId,
+      communityId: group.communityId,
+      eventDate,
+      allowSameDay: args.allowSameDay,
+    });
 
     // Shift each time's absolute `startsAt` by the same offset the event moved,
     // so the copied times stay aligned with the new date (the label, e.g.
@@ -318,6 +420,10 @@ export const duplicateEvent = mutation({
 /**
  * Update an event's editable fields. Only provided fields change.
  *
+ * Rescheduling onto a local day the group already has a plan on throws
+ * `DUPLICATE_PLAN_DATE` unless `allowSameDay` is set — otherwise the date
+ * picker was a back door around `createEvent`'s guard.
+ *
  * Auth: group leader or community admin for the event's group.
  */
 export const updateEvent = mutation({
@@ -329,12 +435,27 @@ export const updateEvent = mutation({
     times: v.optional(v.array(timeValidator)),
     notes: v.optional(v.string()),
     meetingIds: v.optional(v.array(v.id("meetings"))),
+    allowSameDay: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuth(ctx, args.token);
     await requirePlanScheduler(ctx, args.planId, userId);
 
     const existing = await ctx.db.get(args.planId);
+
+    if (
+      existing &&
+      args.eventDate !== undefined &&
+      args.eventDate !== existing.eventDate
+    ) {
+      await assertPlanDateFree(ctx, {
+        groupId: existing.groupId,
+        communityId: existing.communityId,
+        eventDate: args.eventDate,
+        excludePlanId: args.planId,
+        allowSameDay: args.allowSameDay,
+      });
+    }
 
     const patch: Partial<Doc<"eventPlans">> = { updatedAt: Date.now() };
     if (args.title !== undefined) {

--- a/apps/convex/functions/scheduling/events.ts
+++ b/apps/convex/functions/scheduling/events.ts
@@ -18,7 +18,12 @@ import type { MutationCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
-import { localDayKey, localDayLabel, resolveTimeZone } from "../../lib/localDay";
+import {
+  isValidDayKey,
+  localDayKey,
+  localDayLabel,
+  resolveTimeZone,
+} from "../../lib/localDay";
 import {
   requireGroupMember,
   requireGroupScheduler,
@@ -73,6 +78,16 @@ const timeValidator = v.object({
 export const DUPLICATE_PLAN_DATE = "DUPLICATE_PLAN_DATE";
 
 /**
+ * How far either side of the target instant a same-local-day plan can sit.
+ *
+ * Two instants on the same local calendar day are at most ~26 h apart (a
+ * 25-hour DST-extended day, plus slack), whatever the zone — so a range scan
+ * this wide provably contains every possible collision while keeping the
+ * mutation's read set tiny. 36 h is that bound with a wide safety margin.
+ */
+const SAME_DAY_SCAN_MS = 36 * 60 * 60 * 1000;
+
+/**
  * Reject a plan that would land on a day this group already has one, unless the
  * caller explicitly opted in.
  *
@@ -97,6 +112,12 @@ export async function assertPlanDateFree(
     eventDate: number;
     /** The plan being moved — never collides with itself. */
     excludePlanId?: Id<"eventPlans">;
+    /**
+     * The date the plan being moved is on TODAY. A move that stays within the
+     * same local day isn't a move as far as this guard is concerned — see
+     * `updateEvent`, which passes it.
+     */
+    currentEventDate?: number;
     /** Caller confirmed they want a second plan on this day. */
     allowSameDay?: boolean;
   },
@@ -106,10 +127,28 @@ export async function assertPlanDateFree(
   const community = await ctx.db.get(args.communityId);
   const timeZone = resolveTimeZone(community?.timezone);
   const targetDay = localDayKey(args.eventDate, timeZone);
+  // A date we can't place on a calendar can't be shown to collide with one.
+  if (!isValidDayKey(targetDay)) return;
+
+  // Nothing to check when the plan isn't leaving the day it is already on:
+  // the web date picker rebuilds the value at local midnight, so simply
+  // re-picking the current date yields a different millisecond, and on a day
+  // that legitimately holds two services the OTHER plan would match.
+  if (
+    args.currentEventDate !== undefined &&
+    localDayKey(args.currentEventDate, timeZone) === targetDay
+  ) {
+    return;
+  }
 
   const siblings = await ctx.db
     .query("eventPlans")
-    .withIndex("by_group", (q) => q.eq("groupId", args.groupId))
+    .withIndex("by_group_date", (q) =>
+      q
+        .eq("groupId", args.groupId)
+        .gte("eventDate", args.eventDate - SAME_DAY_SCAN_MS)
+        .lte("eventDate", args.eventDate + SAME_DAY_SCAN_MS),
+    )
     .collect();
   const clashes = siblings
     .filter(
@@ -453,6 +492,12 @@ export const updateEvent = mutation({
         communityId: existing.communityId,
         eventDate: args.eventDate,
         excludePlanId: args.planId,
+        // Excluding the plan from itself is not enough: on a day that already
+        // holds two services, nudging one plan's time (or just re-picking its
+        // own date in the web picker, which snaps to local midnight) changes
+        // the millisecond without changing the day — and the SIBLING would
+        // match. A plan that never leaves its local day isn't rescheduling.
+        currentEventDate: existing.eventDate,
         allowSameDay: args.allowSameDay,
       });
     }

--- a/apps/convex/functions/scheduling/roster.ts
+++ b/apps/convex/functions/scheduling/roster.ts
@@ -21,7 +21,7 @@ import { query } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { isLeaderRole } from "../../lib/helpers";
-import { localDayKey, resolveTimeZone } from "../../lib/localDay";
+import { isValidDayKey, localDayKey, resolveTimeZone } from "../../lib/localDay";
 import {
   isGroupScheduler,
   managedTeamIdsInGroup,
@@ -135,16 +135,22 @@ export const rosterMatrix = query({
     const community = group ? await ctx.db.get(group.communityId) : null;
     const timeZone = resolveTimeZone(community?.timezone);
     const plansPerLocalDay = new Map<string, number>();
+    // A plan whose `eventDate` isn't a real instant has no local day, so it
+    // can neither be double-booked nor double-book anything else. Excluded
+    // rather than bucketed, so one corrupt row can't flag every other one.
     for (const p of allPlans) {
       if (p.isDemoSeed) continue;
       const key = localDayKey(p.eventDate, timeZone);
+      if (!isValidDayKey(key)) continue;
       plansPerLocalDay.set(key, (plansPerLocalDay.get(key) ?? 0) + 1);
     }
     /** Total plans (this one included) sharing its local day. 1 = unique. */
-    const sameDatePlanCount = (plan: Doc<"eventPlans">): number =>
-      plan.isDemoSeed
-        ? 1
-        : (plansPerLocalDay.get(localDayKey(plan.eventDate, timeZone)) ?? 1);
+    const sameDatePlanCount = (plan: Doc<"eventPlans">): number => {
+      if (plan.isDemoSeed) return 1;
+      const key = localDayKey(plan.eventDate, timeZone);
+      if (!isValidDayKey(key)) return 1;
+      return plansPerLocalDay.get(key) ?? 1;
+    };
 
     // --- Fan out the three per-plan reads. ---
     const perPlan = await Promise.all(

--- a/apps/convex/functions/scheduling/roster.ts
+++ b/apps/convex/functions/scheduling/roster.ts
@@ -21,6 +21,7 @@ import { query } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { isLeaderRole } from "../../lib/helpers";
+import { localDayKey, resolveTimeZone } from "../../lib/localDay";
 import {
   isGroupScheduler,
   managedTeamIdsInGroup,
@@ -121,6 +122,30 @@ export const rosterMatrix = query({
       ...upcoming,
     ].slice(0, cap);
 
+    // Which plans share a local calendar day with another plan of this group.
+    // `createEvent` now blocks accidental same-day plans, but duplicates
+    // created before that guard existed are still in the data — a leader has to
+    // be able to SEE that two of their columns are the same date, since the
+    // headers are otherwise indistinguishable. Computed over EVERY plan (not
+    // just the visible columns) so a duplicate hidden by the column cap still
+    // flags the one on screen. Demo-seeded plans are excluded, matching the
+    // creation guard. The day key is the community's LOCAL day: a 9 AM and an
+    // 11 AM service are one day, a Sat 11 PM and a Sun 1 AM plan are two.
+    const group = await ctx.db.get(args.groupId);
+    const community = group ? await ctx.db.get(group.communityId) : null;
+    const timeZone = resolveTimeZone(community?.timezone);
+    const plansPerLocalDay = new Map<string, number>();
+    for (const p of allPlans) {
+      if (p.isDemoSeed) continue;
+      const key = localDayKey(p.eventDate, timeZone);
+      plansPerLocalDay.set(key, (plansPerLocalDay.get(key) ?? 0) + 1);
+    }
+    /** Total plans (this one included) sharing its local day. 1 = unique. */
+    const sameDatePlanCount = (plan: Doc<"eventPlans">): number =>
+      plan.isDemoSeed
+        ? 1
+        : (plansPerLocalDay.get(localDayKey(plan.eventDate, timeZone)) ?? 1);
+
     // --- Fan out the three per-plan reads. ---
     const perPlan = await Promise.all(
       plans.map(async (plan) => {
@@ -158,6 +183,10 @@ export const rosterMatrix = query({
       // label each checkbox and total only the teams actually selected without
       // a second round-trip.
       pendingByTeam: countPendingByTeam(assignments),
+      // How many of the group's plans sit on this plan's local day (itself
+      // included). >1 means the column header is ambiguous — the grid flags it
+      // with the same ⚠ "double-booked" language it uses for people.
+      sameDatePlanCount: sameDatePlanCount(plan),
     }));
 
     // --- Resolve display names for every role and user referenced. ---

--- a/apps/convex/lib/localDay.ts
+++ b/apps/convex/lib/localDay.ts
@@ -1,0 +1,60 @@
+/**
+ * Local calendar-day helpers.
+ *
+ * Timestamps in this codebase are UTC epoch ms, but "is this the same day?" is
+ * always a LOCAL-time question for a church: a 9 AM and an 11 AM service on the
+ * same Sunday are one day, while a Saturday 11 PM and a Sunday 1 AM plan are
+ * two — and flooring by 86_400_000 (the `utcDayBucket` shortcut used by the
+ * per-person double-booking check) gets both of those wrong outside UTC. For
+ * an ET church, Sat 11 PM and Sun 1 AM are 04:00Z and 06:00Z on the SAME UTC
+ * day, so a UTC bucket would call them one day.
+ *
+ * `Intl` is deterministic inside Convex (see the note in `functions/demo.ts`),
+ * so formatting to the community's zone is safe in a query or mutation.
+ */
+
+/** Every community without an explicit zone is treated as Eastern. */
+export const DEFAULT_TIMEZONE = "America/New_York";
+
+/**
+ * Validate an IANA timezone string, falling back to {@link DEFAULT_TIMEZONE}.
+ * Mirrors `resolveTimeZone` in `functions/admin/stats.ts` — `Intl` throws a
+ * RangeError on an unknown zone, and a bad `communities.timezone` value must
+ * never break a mutation.
+ */
+export function resolveTimeZone(tz: string | undefined | null): string {
+  if (!tz) return DEFAULT_TIMEZONE;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return tz;
+  } catch {
+    return DEFAULT_TIMEZONE;
+  }
+}
+
+/**
+ * The calendar day `atMs` falls on in `timeZone`, as a sortable `YYYY-MM-DD`
+ * key. Two timestamps share a local day iff their keys are equal.
+ *
+ * @param atMs Unix ms instant.
+ * @param timeZone An already-resolved IANA zone (see {@link resolveTimeZone}).
+ */
+export function localDayKey(atMs: number, timeZone: string): string {
+  // "en-CA" formats as YYYY-MM-DD, which is both the key and sort order.
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(atMs));
+}
+
+/** "Sun, Aug 3" in `timeZone` — for user-facing collision messages. */
+export function localDayLabel(atMs: number, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  }).format(new Date(atMs));
+}

--- a/apps/convex/lib/localDay.ts
+++ b/apps/convex/lib/localDay.ts
@@ -33,28 +33,87 @@ export function resolveTimeZone(tz: string | undefined | null): string {
 }
 
 /**
+ * Constructing an `Intl.DateTimeFormat` is ~100× the cost of using one (500
+ * calls: 55 ms constructed per call vs 0.5 ms hoisted). `assertPlanDateFree`
+ * formats EVERY sibling plan of a group on every create/duplicate/date-update,
+ * and `rosterMatrix` formats every plan on every re-run of a reactive query —
+ * so the formatters are built once per zone and reused. A church has one
+ * timezone, so these maps hold one entry each.
+ */
+const dayKeyFormatters = new Map<string, Intl.DateTimeFormat>();
+const dayLabelFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function dayKeyFormatter(timeZone: string): Intl.DateTimeFormat {
+  let fmt = dayKeyFormatters.get(timeZone);
+  if (!fmt) {
+    // "en-CA" formats as YYYY-MM-DD, which is both the key and sort order.
+    fmt = new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    dayKeyFormatters.set(timeZone, fmt);
+  }
+  return fmt;
+}
+
+function dayLabelFormatter(timeZone: string): Intl.DateTimeFormat {
+  let fmt = dayLabelFormatters.get(timeZone);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
+    dayLabelFormatters.set(timeZone, fmt);
+  }
+  return fmt;
+}
+
+/**
+ * The key returned for a timestamp that isn't a real instant.
+ *
+ * `eventDate` is a Convex `v.number()`, i.e. a float64 — `NaN`, `±Infinity`
+ * and out-of-range values all pass validation, and `Intl.DateTimeFormat.format`
+ * throws `RangeError: Invalid time value` on every one of them. One such row
+ * (a bad client, an import, a migration) would otherwise take down plan
+ * creation AND the roster grid for its whole group, since both map this over
+ * every plan. Callers MUST treat this key as "unknown day": never a match, in
+ * either direction. {@link isValidDayKey} is the check.
+ */
+export const INVALID_DAY_KEY = "invalid-date";
+
+/** False for the {@link INVALID_DAY_KEY} sentinel — never compare those. */
+export function isValidDayKey(key: string): boolean {
+  return key !== INVALID_DAY_KEY;
+}
+
+/**
  * The calendar day `atMs` falls on in `timeZone`, as a sortable `YYYY-MM-DD`
- * key. Two timestamps share a local day iff their keys are equal.
+ * key. Two timestamps share a local day iff their keys are equal AND the key
+ * is valid — see {@link INVALID_DAY_KEY}.
  *
  * @param atMs Unix ms instant.
  * @param timeZone An already-resolved IANA zone (see {@link resolveTimeZone}).
  */
 export function localDayKey(atMs: number, timeZone: string): string {
-  // "en-CA" formats as YYYY-MM-DD, which is both the key and sort order.
-  return new Intl.DateTimeFormat("en-CA", {
-    timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(new Date(atMs));
+  if (!Number.isFinite(atMs)) return INVALID_DAY_KEY;
+  try {
+    return dayKeyFormatter(timeZone).format(new Date(atMs));
+  } catch {
+    // |atMs| > 8.64e15 is finite but outside the Date range.
+    return INVALID_DAY_KEY;
+  }
 }
 
 /** "Sun, Aug 3" in `timeZone` — for user-facing collision messages. */
 export function localDayLabel(atMs: number, timeZone: string): string {
-  return new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  }).format(new Date(atMs));
+  if (!Number.isFinite(atMs)) return "an unknown date";
+  try {
+    return dayLabelFormatter(timeZone).format(new Date(atMs));
+  } catch {
+    return "an unknown date";
+  }
 }

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -2939,6 +2939,12 @@ export default defineSchema({
     isDemoSeed: v.optional(v.boolean()),
   })
     .index("by_group", ["groupId"])
+    // The same-day guard (`assertPlanDateFree`) only cares about plans within
+    // a day of the target date. Without this index it had to `.collect()` the
+    // group's ENTIRE plan history, which put every plan of the group in the
+    // mutation's read set — so two leaders editing unrelated dates would
+    // OCC-conflict.
+    .index("by_group_date", ["groupId", "eventDate"])
     .index("by_community_date", ["communityId", "eventDate"])
     // Forward-propagation lookups: all plans linked to a given template.
     .index("by_task_template", ["taskTemplateId"])

--- a/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
+++ b/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
@@ -56,9 +56,13 @@ import {
 import type { Id } from "@services/api/convex";
 import { useAuth } from "@providers/AuthProvider";
 import { confirmAsync, notify } from "@/utils/platformAlert";
+import { errorMessage } from "@utils/error-handling";
 import { NeededRolesModal } from "./NeededRolesModal";
 import { DuplicateDateFlag } from "./DuplicateDateFlag";
-import { parseDuplicatePlanDate } from "../utils/duplicatePlanDate";
+import {
+  parseDuplicatePlanDate,
+  savePlanDate,
+} from "../utils/duplicatePlanDate";
 
 type Colors = ReturnType<typeof useTheme>["colors"];
 
@@ -84,10 +88,16 @@ type EventDoc = {
   roles: EventRole[];
 };
 
-/** Best-effort human message from a thrown value (Convex error or Error). */
+/**
+ * Best-effort human message from a thrown value.
+ *
+ * Delegates to the shared extractor rather than reading `.message` directly: a
+ * real Convex client puts the payload on `.data` and leaves `.message` as a
+ * hybrid stacktrace with the serialized JSON embedded in it — which is what a
+ * leader was shown when a mutation failed.
+ */
 function errMessage(e: unknown): string {
-  const err = e as { data?: { message?: string }; message?: string };
-  return err?.data?.message ?? err?.message ?? "Please try again.";
+  return errorMessage(e, "Please try again.");
 }
 
 function formatTimeLabel(date: Date): string {
@@ -226,44 +236,12 @@ export function DateColumnHeaderEditor({
 
   const handleChangeDate = useCallback(
     async (date: Date | null) => {
-      if (!date) return;
-      const ms = date.getTime();
-      // Guard against intermediate/invalid values while typing into the native
-      // date input. Editing the year digit-by-digit briefly yields a complete
-      // but absurd date (e.g. year 0026); without this guard that gets saved as
-      // `eventDate`, shoving the plan into the far past so it drops out of the
-      // upcoming-only grid and looks like the plan was deleted. Only persist a
-      // valid, plausibly-dated value; ignore the keystrokes in between.
-      if (Number.isNaN(ms)) return;
-      const year = date.getFullYear();
-      if (year < 2000 || year > 3000) return;
-      try {
-        await updateEvent({ planId: event._id, eventDate: ms });
-      } catch (e) {
-        // Rescheduling onto an already-planned day is blocked for the same
-        // reason creating one there is — but moving a plan to sit alongside an
-        // existing service is a real thing to want, so offer it.
-        const duplicate = parseDuplicatePlanDate(e);
-        if (!duplicate) {
-          notify("Couldn't update date", errMessage(e));
-          return;
-        }
-        const ok = await confirmAsync({
-          title: `Already a plan on ${duplicate.dayLabel}`,
-          message: `"${duplicate.existingPlanTitle}" is already on that date. Move this plan there anyway, so the day has two?`,
-          confirmText: "Move it there",
-        });
-        if (!ok) return;
-        try {
-          await updateEvent({
-            planId: event._id,
-            eventDate: ms,
-            allowSameDay: true,
-          });
-        } catch (e2) {
-          notify("Couldn't update date", errMessage(e2));
-        }
-      }
+      await savePlanDate({
+        date,
+        save: (eventDate, allowSameDay) =>
+          updateEvent({ planId: event._id, eventDate, allowSameDay }),
+        onError: (m) => notify("Couldn't update date", m),
+      });
     },
     [updateEvent, event._id],
   );

--- a/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
+++ b/apps/mobile/features/scheduling/components/DateColumnHeaderEditor.tsx
@@ -57,6 +57,8 @@ import type { Id } from "@services/api/convex";
 import { useAuth } from "@providers/AuthProvider";
 import { confirmAsync, notify } from "@/utils/platformAlert";
 import { NeededRolesModal } from "./NeededRolesModal";
+import { DuplicateDateFlag } from "./DuplicateDateFlag";
+import { parseDuplicatePlanDate } from "../utils/duplicatePlanDate";
 
 type Colors = ReturnType<typeof useTheme>["colors"];
 
@@ -67,6 +69,12 @@ export type HeaderEvent = {
   eventDate: number;
   times: Array<{ label: string; startsAt: number }>;
   status: "draft" | "published";
+  /**
+   * How many of the group's plans share this one's local day, itself included.
+   * >1 flags the column — otherwise two same-date headers are identical, which
+   * is how a leader edits one plan while rostered on the other.
+   */
+  sameDatePlanCount: number;
 };
 
 type EventRole = { roleId: Id<"teamRoles">; teamId: Id<"teams">; needed: number };
@@ -232,7 +240,29 @@ export function DateColumnHeaderEditor({
       try {
         await updateEvent({ planId: event._id, eventDate: ms });
       } catch (e) {
-        notify("Couldn't update date", errMessage(e));
+        // Rescheduling onto an already-planned day is blocked for the same
+        // reason creating one there is — but moving a plan to sit alongside an
+        // existing service is a real thing to want, so offer it.
+        const duplicate = parseDuplicatePlanDate(e);
+        if (!duplicate) {
+          notify("Couldn't update date", errMessage(e));
+          return;
+        }
+        const ok = await confirmAsync({
+          title: `Already a plan on ${duplicate.dayLabel}`,
+          message: `"${duplicate.existingPlanTitle}" is already on that date. Move this plan there anyway, so the day has two?`,
+          confirmText: "Move it there",
+        });
+        if (!ok) return;
+        try {
+          await updateEvent({
+            planId: event._id,
+            eventDate: ms,
+            allowSameDay: true,
+          });
+        } catch (e2) {
+          notify("Couldn't update date", errMessage(e2));
+        }
       }
     },
     [updateEvent, event._id],
@@ -285,13 +315,32 @@ export function DateColumnHeaderEditor({
     router.push(`/rostering/${groupId}/tasks/${event._id}` as never);
   }, [router, groupId, event._id]);
 
+  // A duplicate lands one week after the source, so duplicating twice — or
+  // duplicating a plan whose next week is already planned — collides. The
+  // backend refuses it; ask rather than dead-ending, since a second service on
+  // that day is legitimate.
   const handleDuplicate = useCallback(async () => {
     setMenuOpen(false);
     try {
       await duplicateEvent({ planId: event._id });
       // The reactive grid adds the copy's column on its own.
     } catch (e) {
-      notify("Couldn't duplicate", errMessage(e));
+      const duplicate = parseDuplicatePlanDate(e);
+      if (!duplicate) {
+        notify("Couldn't duplicate", errMessage(e));
+        return;
+      }
+      const ok = await confirmAsync({
+        title: `Already a plan on ${duplicate.dayLabel}`,
+        message: `"${duplicate.existingPlanTitle}" is already on that date. Add this copy as a second plan for the same day?`,
+        confirmText: "Duplicate anyway",
+      });
+      if (!ok) return;
+      try {
+        await duplicateEvent({ planId: event._id, allowSameDay: true });
+      } catch (e2) {
+        notify("Couldn't duplicate", errMessage(e2));
+      }
     }
   }, [duplicateEvent, event._id]);
 
@@ -410,6 +459,13 @@ export function DateColumnHeaderEditor({
         >
           {dateLabel(event.eventDate)}
         </Text>
+        {/* Another plan of this group is on this date — same ⚠ language the
+            grid uses for a person staffed twice in a day. */}
+        <DuplicateDateFlag
+          sameDatePlanCount={event.sameDatePlanCount}
+          colors={colors}
+          withLabel={!narrow}
+        />
       </TouchableOpacity>
 
       {/* Coverage / availability tally (rendered by the caller, view-aware). */}

--- a/apps/mobile/features/scheduling/components/DuplicateDateFlag.tsx
+++ b/apps/mobile/features/scheduling/components/DuplicateDateFlag.tsx
@@ -48,7 +48,12 @@ export function DuplicateDateFlag({
   colors: Colors;
   withLabel?: boolean;
 }) {
-  if (sameDatePlanCount <= 1) return null;
+  // Fail CLOSED, not open. `sameDatePlanCount` comes from `rosterMatrix`, and
+  // the production deploy ships the mobile OTA and the Convex functions in
+  // parallel — a client that pulls the bundle first sees `undefined` on every
+  // event. `undefined <= 1` is false, so a `<= 1` test rendered the warning on
+  // every column with `undefined - 1` in it: "NaN other plans on this date."
+  if (!(sameDatePlanCount > 1)) return null;
   const label = duplicateDateLabel(sameDatePlanCount);
   return (
     <View

--- a/apps/mobile/features/scheduling/components/DuplicateDateFlag.tsx
+++ b/apps/mobile/features/scheduling/components/DuplicateDateFlag.tsx
@@ -1,0 +1,73 @@
+/**
+ * DuplicateDateFlag
+ *
+ * The ⚠ on a roster date column whose date is shared with another plan of the
+ * same group. Duplicate plans on one date used to be created silently — a
+ * leader authored tasks on one plan while rostered on another, because the two
+ * column headers were indistinguishable. Creation is guarded now, but the
+ * duplicates already in the data still need to be visible.
+ *
+ * Deliberately the SAME vocabulary the grid already uses for a person staffed
+ * twice in a day: `warning` icon in `colors.destructive`, the word
+ * "Double-booked", and the shared legend entry. No new chrome.
+ *
+ * Rendered by both date-column headers — the mobile tappable one in
+ * RosterGridScreen and the desktop inline editor (DateColumnHeaderEditor).
+ */
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import type { useTheme } from "@hooks/useTheme";
+
+type Colors = ReturnType<typeof useTheme>["colors"];
+
+/** The screen-reader / hover text for a column sharing its date. */
+export function duplicateDateLabel(sameDatePlanCount: number): string {
+  const others = sameDatePlanCount - 1;
+  return `Double-booked date — ${others} other plan${others === 1 ? "" : "s"} on this date. Check you are on the right one.`;
+}
+
+/**
+ * Web-only `title` tooltip. RN-Web forwards an unknown `title` DOM prop onto
+ * the host node; the RN types don't know it, hence the bag + spread (the same
+ * idiom as RosterGridScreen's `webTitle`). On native this is `{}` — the
+ * `accessibilityLabel` carries the text.
+ */
+function webTitle(title: string): Record<string, unknown> {
+  if (typeof document === "undefined") return {};
+  return { title };
+}
+
+export function DuplicateDateFlag({
+  sameDatePlanCount,
+  colors,
+  /** Show the "Same date" wording next to the icon (wide desktop columns). */
+  withLabel = false,
+}: {
+  sameDatePlanCount: number;
+  colors: Colors;
+  withLabel?: boolean;
+}) {
+  if (sameDatePlanCount <= 1) return null;
+  const label = duplicateDateLabel(sameDatePlanCount);
+  return (
+    <View
+      style={styles.wrap}
+      accessibilityRole="image"
+      accessibilityLabel={label}
+      {...webTitle(label)}
+    >
+      <Ionicons name="warning" size={11} color={colors.destructive} />
+      {withLabel && (
+        <Text style={[styles.text, { color: colors.destructive }]} numberOfLines={1}>
+          Same date
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { flexDirection: "row", alignItems: "center", gap: 2 },
+  text: { fontSize: 9, fontWeight: "700" },
+});

--- a/apps/mobile/features/scheduling/components/EventEditorPanel.tsx
+++ b/apps/mobile/features/scheduling/components/EventEditorPanel.tsx
@@ -47,6 +47,13 @@ import {
 import type { Id } from "@services/api/convex";
 import { useAuth } from "@providers/AuthProvider";
 import { confirmAsync, notify } from "@/utils/platformAlert";
+import { parseDuplicatePlanDate } from "../utils/duplicatePlanDate";
+
+/** Best-effort human message from a thrown value (mirrors DateColumnHeaderEditor). */
+function errMessage(e: unknown): string {
+  const err = e as { data?: { message?: string }; message?: string };
+  return err?.data?.message ?? err?.message ?? "Please try again.";
+}
 import { NeededRolesModal } from "./NeededRolesModal";
 import { TimesEditor } from "./TimesEditor";
 
@@ -220,7 +227,29 @@ export function EventEditorPanel({
       try {
         await updateEvent({ planId, eventDate: date.getTime() });
       } catch (e: any) {
-        notify("Couldn't update date", e?.message ?? "Please try again.");
+        // A group may hold only one plan per local day unless the leader says
+        // otherwise — moving a plan alongside an existing service is a real
+        // thing to want, so ask instead of just refusing.
+        const duplicate = parseDuplicatePlanDate(e);
+        if (!duplicate) {
+          notify("Couldn't update date", e?.message ?? "Please try again.");
+          return;
+        }
+        const ok = await confirmAsync({
+          title: `Already a plan on ${duplicate.dayLabel}`,
+          message: `"${duplicate.existingPlanTitle}" is already on that date. Move this plan there anyway, so the day has two?`,
+          confirmText: "Move it there",
+        });
+        if (!ok) return;
+        try {
+          await updateEvent({
+            planId,
+            eventDate: date.getTime(),
+            allowSameDay: true,
+          });
+        } catch (e2) {
+          notify("Couldn't update date", errMessage(e2));
+        }
       }
     },
     [updateEvent, planId],
@@ -278,15 +307,33 @@ export function EventEditorPanel({
   const handleDuplicate = useCallback(async () => {
     if (!event) return;
     setMenuOpen(false);
-    try {
-      const result = await duplicateEvent({ planId });
+    const openCopy = (copyId: string) => {
       // The reactive grid will show the new column; jump the panel to the copy
       // so the leader can set its date right away.
-      router.push(
-        `/rostering/${event.groupId}/event/${result.planId}` as never,
-      );
+      router.push(`/rostering/${event.groupId}/event/${copyId}` as never);
+    };
+    try {
+      const result = await duplicateEvent({ planId });
+      openCopy(result.planId);
     } catch (e: any) {
-      notify("Couldn't duplicate", e?.message ?? "Please try again.");
+      // The copy lands a week out, so duplicating twice collides.
+      const duplicate = parseDuplicatePlanDate(e);
+      if (!duplicate) {
+        notify("Couldn't duplicate", e?.message ?? "Please try again.");
+        return;
+      }
+      const ok = await confirmAsync({
+        title: `Already a plan on ${duplicate.dayLabel}`,
+        message: `"${duplicate.existingPlanTitle}" is already on that date. Add this copy as a second plan for the same day?`,
+        confirmText: "Duplicate anyway",
+      });
+      if (!ok) return;
+      try {
+        const result = await duplicateEvent({ planId, allowSameDay: true });
+        openCopy(result.planId);
+      } catch (e2) {
+        notify("Couldn't duplicate", errMessage(e2));
+      }
     }
   }, [event, duplicateEvent, planId, router]);
 

--- a/apps/mobile/features/scheduling/components/EventEditorPanel.tsx
+++ b/apps/mobile/features/scheduling/components/EventEditorPanel.tsx
@@ -47,12 +47,22 @@ import {
 import type { Id } from "@services/api/convex";
 import { useAuth } from "@providers/AuthProvider";
 import { confirmAsync, notify } from "@/utils/platformAlert";
-import { parseDuplicatePlanDate } from "../utils/duplicatePlanDate";
+import { errorMessage } from "@utils/error-handling";
+import {
+  parseDuplicatePlanDate,
+  savePlanDate,
+} from "../utils/duplicatePlanDate";
 
-/** Best-effort human message from a thrown value (mirrors DateColumnHeaderEditor). */
+/**
+ * Best-effort human message from a thrown value.
+ *
+ * Delegates to the shared extractor rather than reading `.message` directly: a
+ * real Convex client puts the payload on `.data` and leaves `.message` as a
+ * hybrid stacktrace with the serialized JSON embedded in it — which is what a
+ * leader was shown when a mutation failed.
+ */
 function errMessage(e: unknown): string {
-  const err = e as { data?: { message?: string }; message?: string };
-  return err?.data?.message ?? err?.message ?? "Please try again.";
+  return errorMessage(e, "Please try again.");
 }
 import { NeededRolesModal } from "./NeededRolesModal";
 import { TimesEditor } from "./TimesEditor";
@@ -223,34 +233,12 @@ export function EventEditorPanel({
 
   const handleChangeDate = useCallback(
     async (date: Date | null) => {
-      if (!date) return;
-      try {
-        await updateEvent({ planId, eventDate: date.getTime() });
-      } catch (e: any) {
-        // A group may hold only one plan per local day unless the leader says
-        // otherwise — moving a plan alongside an existing service is a real
-        // thing to want, so ask instead of just refusing.
-        const duplicate = parseDuplicatePlanDate(e);
-        if (!duplicate) {
-          notify("Couldn't update date", e?.message ?? "Please try again.");
-          return;
-        }
-        const ok = await confirmAsync({
-          title: `Already a plan on ${duplicate.dayLabel}`,
-          message: `"${duplicate.existingPlanTitle}" is already on that date. Move this plan there anyway, so the day has two?`,
-          confirmText: "Move it there",
-        });
-        if (!ok) return;
-        try {
-          await updateEvent({
-            planId,
-            eventDate: date.getTime(),
-            allowSameDay: true,
-          });
-        } catch (e2) {
-          notify("Couldn't update date", errMessage(e2));
-        }
-      }
+      await savePlanDate({
+        date,
+        save: (eventDate, allowSameDay) =>
+          updateEvent({ planId, eventDate, allowSameDay }),
+        onError: (m) => notify("Couldn't update date", m),
+      });
     },
     [updateEvent, planId],
   );
@@ -315,11 +303,11 @@ export function EventEditorPanel({
     try {
       const result = await duplicateEvent({ planId });
       openCopy(result.planId);
-    } catch (e: any) {
+    } catch (e) {
       // The copy lands a week out, so duplicating twice collides.
       const duplicate = parseDuplicatePlanDate(e);
       if (!duplicate) {
-        notify("Couldn't duplicate", e?.message ?? "Please try again.");
+        notify("Couldn't duplicate", errMessage(e));
         return;
       }
       const ok = await confirmAsync({

--- a/apps/mobile/features/scheduling/components/EventEditorScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventEditorScreen.tsx
@@ -39,6 +39,7 @@ import {
 import type { Id } from "@services/api/convex";
 import { confirmAsync, notify } from "@/utils/platformAlert";
 import { DEFAULT_ROLE_COLOR } from "../utils/format";
+import { savePlanDate } from "../utils/duplicatePlanDate";
 import { NeededRolesModal } from "./NeededRolesModal";
 import { AssignSheet } from "./AssignSheet";
 import { TimesEditor } from "./TimesEditor";
@@ -204,14 +205,17 @@ export function EventEditorScreen() {
   flushTitleRef.current = flushTitle;
   useEffect(() => () => void flushTitleRef.current(), []);
 
+  // This screen is where BOTH "＋ Add date" and "Duplicate" push the leader to
+  // set the new plan's date, so it has to resolve a collision rather than
+  // dead-end on one. See `savePlanDate`.
   const handleChangeDate = useCallback(
     async (date: Date | null) => {
-      if (!date) return;
-      try {
-        await updateEvent({ planId, eventDate: date.getTime() });
-      } catch (e: any) {
-        notify("Couldn't update date", e?.message ?? "Please try again.");
-      }
+      await savePlanDate({
+        date,
+        save: (eventDate, allowSameDay) =>
+          updateEvent({ planId, eventDate, allowSameDay }),
+        onError: (m) => notify("Couldn't update date", m),
+      });
     },
     [updateEvent, planId],
   );

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -76,11 +76,19 @@ import {
   memberInTeamScope,
   memberNeedsAvailability,
 } from "../utils/rosterFilters";
+import {
+  useAddPlanDate,
+  nextSundayAtNine,
+} from "../hooks/useAddPlanDate";
 import { useStartDirectMessage } from "@features/chat/hooks/useStartDirectMessage";
 import { AssignSheet } from "./AssignSheet";
 import { GridPresenceBar } from "./GridPresenceBar";
 import { EventEditorPanel } from "./EventEditorPanel";
 import { DateColumnHeaderEditor } from "./DateColumnHeaderEditor";
+import {
+  DuplicateDateFlag,
+  duplicateDateLabel,
+} from "./DuplicateDateFlag";
 import { TeamChannelToggle } from "./TeamChannelToggle";
 
 // ---------------------------------------------------------------------------
@@ -122,6 +130,13 @@ type RosterEvent = {
   pendingCount: number;
   /** The same count per serving team, keyed by team id — the publish picker. */
   pendingByTeam: Record<string, number>;
+  /**
+   * How many of the group's plans sit on this plan's local day, itself
+   * included. `1` is the normal case; anything higher means the date column is
+   * ambiguous and gets the ⚠ "double-booked" flag. Duplicates predating the
+   * creation guard still exist in production, so the grid has to show them.
+   */
+  sameDatePlanCount: number;
 };
 
 type RosterTeam = {
@@ -277,15 +292,6 @@ function webTitle(title: string): Record<string, unknown> {
   return { title };
 }
 
-/** Next Sunday at 9:00 AM local time — the neutral default for a new plan. */
-function nextSundayAtNine(): Date {
-  const d = new Date();
-  const daysUntilSunday = (7 - d.getDay()) % 7 || 7;
-  d.setDate(d.getDate() + daysUntilSunday);
-  d.setHours(9, 0, 0, 0);
-  return d;
-}
-
 /** Debounce a value by `delay` ms — same pattern as AssignSheet. */
 function useDebouncedValue<T>(value: T, delay: number): T {
   const [debounced, setDebounced] = useState(value);
@@ -395,11 +401,6 @@ export function RosterGridScreen() {
 
   const assignRole = useAuthenticatedMutation(
     api.functions.scheduling.assignments.assignRole,
-  );
-  // Create a plan straight from the grid (the "＋ Add date" column / quick-start
-  // CTA). The reactive rosterMatrix query self-refreshes to show the new column.
-  const createEvent = useAuthenticatedMutation(
-    api.functions.scheduling.events.createEvent,
   );
   const quickStartRostering = useAuthenticatedMutation(
     api.functions.scheduling.quickStart.quickStartRostering,
@@ -1290,28 +1291,28 @@ export function RosterGridScreen() {
     [sharingLink, createAvailabilityLink, groupId],
   );
 
-  // Create a new draft plan at the neutral default date (next Sunday 9 AM, same
-  // as the editor's default). The reactive rosterMatrix self-refreshes → a new
-  // date column appears; the leader sets the real date in the plan editor.
-  // The title is left to the backend (`defaultPlanTitle`, derived from the
-  // group) — this used to send the literal "Untitled event plan", which shipped
-  // through to serving mode's plan headers and read like a bug.
+  const openPlanRoute = useCallback(
+    (planId: string) => {
+      router.push(`/rostering/${groupId}/event/${planId}` as never);
+    },
+    [router, groupId],
+  );
+
+  // Creating a draft plan at the neutral default date, and resolving the case
+  // where the group already has one that day. See useAddPlanDate.
+  const { addPlanDate } = useAddPlanDate({ groupId, onOpenPlan: openPlanRoute });
+
   const handleAddDate = useCallback(async () => {
     if (creatingEvent) return;
     setCreatingEvent(true);
     try {
-      const date = nextSundayAtNine();
-      await createEvent({
-        groupId,
-        eventDate: date.getTime(),
-        times: [{ label: "9:00 AM", startsAt: date.getTime() }],
-      });
+      await addPlanDate("ask");
     } catch (e) {
       surfaceError("Couldn't add date", e);
     } finally {
       setCreatingEvent(false);
     }
-  }, [creatingEvent, createEvent, groupId, surfaceError]);
+  }, [creatingEvent, addPlanDate, surfaceError]);
 
   // One-tap bootstrap for a brand-new group: starter team + roles + a draft
   // plan, then into the editor to own the date. Idempotent on the backend.
@@ -1327,14 +1328,17 @@ export function RosterGridScreen() {
         startsAt: nextSundayAtNine().getTime(),
       });
       if (result.planId) {
-        router.push(`/rostering/${groupId}/event/${result.planId}` as never);
+        openPlanRoute(result.planId);
         return;
       }
       // `alreadySetUp` with no new plan → the group already had teams or only
       // past plans (hidden by the default upcoming filter), so quick-start
       // created nothing. Fall back to creating/opening a plan so the CTA is
       // never a dead tap that just clears its spinner on the empty screen.
-      await handleAddDate();
+      // Calls the shared creator directly rather than `handleAddDate`, which
+      // would fight this handler over the `creatingEvent` flag and re-surface
+      // the same failure twice.
+      await addPlanDate("open");
     } catch (e) {
       surfaceError("Couldn't set up rostering", e);
     } finally {
@@ -1344,9 +1348,9 @@ export function RosterGridScreen() {
     settingUp,
     quickStartRostering,
     groupId,
-    router,
+    openPlanRoute,
     surfaceError,
-    handleAddDate,
+    addPlanDate,
   ]);
 
   // Inline "＋ Add role" under a team section → existing `createRole` mutation
@@ -1761,13 +1765,19 @@ export function RosterGridScreen() {
               );
             }
 
+            // Another plan of this group sits on the same date — the header on
+            // its own can't tell them apart, which is exactly how a leader ends
+            // up editing one plan while rostered on the other.
+            const duplicateDate = ev.sameDatePlanCount > 1;
             return (
               <TouchableOpacity
                 key={ev._id}
                 activeOpacity={0.6}
                 onPress={() => openPlanPanel(ev._id)}
                 accessibilityRole="button"
-                accessibilityLabel={`${ev.title}, ${weekday(ev.eventDate)} ${monthDay(ev.eventDate)} — open plan details`}
+                accessibilityLabel={`${ev.title}, ${weekday(ev.eventDate)} ${monthDay(ev.eventDate)} — open plan details${
+                  duplicateDate ? `. ${duplicateDateLabel(ev.sameDatePlanCount)}` : ""
+                }`}
                 style={[
                   styles.headerCell,
                   { width: CELL_W, height: HEADER_H, borderLeftColor: colors.border },
@@ -1789,9 +1799,15 @@ export function RosterGridScreen() {
                 <Text style={[styles.headerCellWk, { color: colors.textSecondary }]}>
                   {weekday(ev.eventDate)}
                 </Text>
-                <Text style={[styles.headerCellDate, { color: colors.text }]}>
-                  {monthDay(ev.eventDate)}
-                </Text>
+                <View style={styles.headerCellDateRow}>
+                  <Text style={[styles.headerCellDate, { color: colors.text }]}>
+                    {monthDay(ev.eventDate)}
+                  </Text>
+                  <DuplicateDateFlag
+                    sameDatePlanCount={ev.sameDatePlanCount}
+                    colors={colors}
+                  />
+                </View>
                 <View style={styles.headerCellTally}>{tally}</View>
               </TouchableOpacity>
             );
@@ -4721,6 +4737,7 @@ const styles = StyleSheet.create({
   headerCellTitle: { fontSize: 9, flexShrink: 1 },
   headerCellWk: { fontSize: 10 },
   headerCellDate: { fontSize: 13, fontWeight: "700" },
+  headerCellDateRow: { flexDirection: "row", alignItems: "center", gap: 3 },
   headerCellTally: { flexDirection: "row", alignItems: "center", gap: 2, marginTop: 1 },
   headerCellTallyText: { fontSize: 11, fontWeight: "700" },
   addDateCell: {

--- a/apps/mobile/features/scheduling/components/__tests__/DuplicateDateFlag.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/DuplicateDateFlag.test.tsx
@@ -40,6 +40,21 @@ describe("DuplicateDateFlag", () => {
         <DuplicateDateFlag sameDatePlanCount={0} colors={COLORS} />,
       ).toJSON(),
     ).toBeNull();
+
+    // The one that actually happens: the production deploy runs the Convex
+    // deploy and the mobile OTA in parallel, so a client can pull a bundle
+    // that reads `sameDatePlanCount` before the field exists. `undefined <= 1`
+    // is false, so failing open flagged EVERY column with "NaN other plans".
+    for (const missing of [undefined, null, NaN]) {
+      expect(
+        render(
+          <DuplicateDateFlag
+            sameDatePlanCount={missing as unknown as number}
+            colors={COLORS}
+          />,
+        ).toJSON(),
+      ).toBeNull();
+    }
   });
 
   it("flags a shared date with an accessible explanation", () => {

--- a/apps/mobile/features/scheduling/components/__tests__/DuplicateDateFlag.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/DuplicateDateFlag.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * The ⚠ on a roster date column that shares its date with another plan.
+ *
+ * Legacy duplicates already exist in production, so prevention alone isn't
+ * enough — two same-date headers are otherwise indistinguishable, which is how
+ * a leader authored tasks on one Aug 2 plan while rostered on another.
+ */
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+import {
+  DuplicateDateFlag,
+  duplicateDateLabel,
+} from "../DuplicateDateFlag";
+
+const COLORS = { destructive: "#DC2626" } as never;
+
+describe("duplicateDateLabel", () => {
+  it("counts the OTHER plans, not including this one", () => {
+    expect(duplicateDateLabel(2)).toContain("1 other plan on this date");
+    expect(duplicateDateLabel(3)).toContain("2 other plans on this date");
+  });
+
+  it("reuses the grid's existing double-booked vocabulary", () => {
+    expect(duplicateDateLabel(2)).toContain("Double-booked");
+  });
+});
+
+describe("DuplicateDateFlag", () => {
+  it("renders nothing for a date with a single plan", () => {
+    const { toJSON } = render(
+      <DuplicateDateFlag sameDatePlanCount={1} colors={COLORS} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders nothing when the count is missing or nonsensical", () => {
+    expect(
+      render(
+        <DuplicateDateFlag sameDatePlanCount={0} colors={COLORS} />,
+      ).toJSON(),
+    ).toBeNull();
+  });
+
+  it("flags a shared date with an accessible explanation", () => {
+    const { getByLabelText } = render(
+      <DuplicateDateFlag sameDatePlanCount={2} colors={COLORS} />,
+    );
+    expect(getByLabelText(duplicateDateLabel(2))).toBeTruthy();
+  });
+
+  it("adds the 'Same date' wording only when there is room for it", () => {
+    const bare = render(
+      <DuplicateDateFlag sameDatePlanCount={2} colors={COLORS} />,
+    );
+    expect(bare.queryByText("Same date")).toBeNull();
+
+    const labelled = render(
+      <DuplicateDateFlag sameDatePlanCount={2} colors={COLORS} withLabel />,
+    );
+    expect(labelled.getByText("Same date")).toBeTruthy();
+  });
+});

--- a/apps/mobile/features/scheduling/hooks/__tests__/useAddPlanDate.test.tsx
+++ b/apps/mobile/features/scheduling/hooks/__tests__/useAddPlanDate.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * "＋ Add date" and the quick-start fall-through, at the seam where a duplicate
+ * date is resolved.
+ *
+ * The regression this guards: `nextSundayAtNine()` is deterministic, so two
+ * taps used to write two byte-identical plans. Now the second create is
+ * refused, and what happens next depends on which entry point asked.
+ */
+import React from "react";
+import { Text } from "react-native";
+import { render, waitFor } from "@testing-library/react-native";
+import { renderHook } from "@testing-library/react-native";
+
+const mockCreateEvent = jest.fn();
+jest.mock("@services/api/convex", () => ({
+  api: { functions: { scheduling: { events: { createEvent: "createEvent" } } } },
+  useAuthenticatedMutation: () => mockCreateEvent,
+}));
+
+const mockPrompt = jest.fn();
+jest.mock("../../utils/duplicatePlanDate", () => {
+  const actual = jest.requireActual("../../utils/duplicatePlanDate");
+  return {
+    ...actual,
+    promptDuplicatePlanDate: (...a: unknown[]) => mockPrompt(...a),
+  };
+});
+
+import { useAddPlanDate, nextSundayAtNine } from "../useAddPlanDate";
+
+const DUPLICATE = {
+  data: {
+    code: "DUPLICATE_PLAN_DATE",
+    message: '"Sunday Service" is already scheduled on Sun, Aug 2.',
+    dayLabel: "Sun, Aug 2",
+    existingPlanId: "existing-plan",
+    existingPlanTitle: "Sunday Service",
+    existingEventDate: 1785675600000,
+    existingCount: 1,
+  },
+};
+
+function setup() {
+  const onOpenPlan = jest.fn();
+  const { result } = renderHook(() =>
+    useAddPlanDate({ groupId: "group-1" as never, onOpenPlan }),
+  );
+  return { result, onOpenPlan };
+}
+
+beforeEach(() => {
+  mockCreateEvent.mockReset();
+  mockPrompt.mockReset();
+});
+
+describe("nextSundayAtNine", () => {
+  it("returns a future Sunday at 9:00 local time", () => {
+    const d = nextSundayAtNine();
+    expect(d.getDay()).toBe(0);
+    expect(d.getHours()).toBe(9);
+    expect(d.getMinutes()).toBe(0);
+    expect(d.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("is deterministic — which is exactly why the backend guard is needed", () => {
+    expect(nextSundayAtNine().getTime()).toBe(nextSundayAtNine().getTime());
+  });
+});
+
+describe("useAddPlanDate", () => {
+  it("creates a plan at the default date, letting the backend name it", async () => {
+    mockCreateEvent.mockResolvedValue({ planId: "new-plan" });
+    const { result, onOpenPlan } = setup();
+
+    await expect(result.current.addPlanDate("ask")).resolves.toBe("created");
+
+    expect(mockCreateEvent).toHaveBeenCalledTimes(1);
+    const args = mockCreateEvent.mock.calls[0][0];
+    expect(args.groupId).toBe("group-1");
+    expect(args.times).toEqual([
+      { label: "9:00 AM", startsAt: args.eventDate },
+    ]);
+    // No client-invented title, and no same-day opt-in unless asked for.
+    expect(args.title).toBeUndefined();
+    expect(args.allowSameDay).toBeUndefined();
+    expect(onOpenPlan).not.toHaveBeenCalled();
+    expect(mockPrompt).not.toHaveBeenCalled();
+  });
+
+  it("asks the leader when the date is taken, and opens the plan they have", async () => {
+    mockCreateEvent.mockRejectedValueOnce(DUPLICATE);
+    mockPrompt.mockResolvedValue("open-existing");
+    const { result, onOpenPlan } = setup();
+
+    await expect(result.current.addPlanDate("ask")).resolves.toBe(
+      "opened-existing",
+    );
+
+    expect(mockPrompt).toHaveBeenCalledTimes(1);
+    expect(onOpenPlan).toHaveBeenCalledWith("existing-plan");
+    // Crucially, no second plan was written.
+    expect(mockCreateEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("still allows a deliberate second service on the same Sunday", async () => {
+    mockCreateEvent
+      .mockRejectedValueOnce(DUPLICATE)
+      .mockResolvedValueOnce({ planId: "second-plan" });
+    mockPrompt.mockResolvedValue("add-another");
+    const { result, onOpenPlan } = setup();
+
+    await expect(result.current.addPlanDate("ask")).resolves.toBe("created");
+
+    expect(mockCreateEvent).toHaveBeenCalledTimes(2);
+    expect(mockCreateEvent.mock.calls[1][0].allowSameDay).toBe(true);
+    expect(onOpenPlan).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing when the leader backs out", async () => {
+    mockCreateEvent.mockRejectedValueOnce(DUPLICATE);
+    mockPrompt.mockResolvedValue("cancel");
+    const { result, onOpenPlan } = setup();
+
+    await expect(result.current.addPlanDate("ask")).resolves.toBe("cancelled");
+    expect(mockCreateEvent).toHaveBeenCalledTimes(1);
+    expect(onOpenPlan).not.toHaveBeenCalled();
+  });
+
+  it('goes straight to the existing plan in "open" mode without prompting', async () => {
+    // The quick-start fall-through: the leader asked to be set up, not for a
+    // second service, so there is nothing to ask about.
+    mockCreateEvent.mockRejectedValueOnce(DUPLICATE);
+    const { result, onOpenPlan } = setup();
+
+    await expect(result.current.addPlanDate("open")).resolves.toBe(
+      "opened-existing",
+    );
+    expect(mockPrompt).not.toHaveBeenCalled();
+    expect(onOpenPlan).toHaveBeenCalledWith("existing-plan");
+    expect(mockCreateEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows anything that is not a duplicate-date collision", async () => {
+    mockCreateEvent.mockRejectedValueOnce(new Error("offline"));
+    const { result } = setup();
+
+    await expect(result.current.addPlanDate("ask")).rejects.toThrow("offline");
+    expect(mockPrompt).not.toHaveBeenCalled();
+  });
+
+  it("is stable enough to be called from a rendered screen", async () => {
+    mockCreateEvent.mockResolvedValue({ planId: "new-plan" });
+    const Harness = () => {
+      const { addPlanDate } = useAddPlanDate({
+        groupId: "group-1" as never,
+        onOpenPlan: jest.fn(),
+      });
+      React.useEffect(() => {
+        void addPlanDate("ask");
+      }, [addPlanDate]);
+      return <Text>ready</Text>;
+    };
+    const { getByText } = render(<Harness />);
+    expect(getByText("ready")).toBeTruthy();
+    // The effect depends on `addPlanDate`; an unstable identity would loop.
+    await waitFor(() => expect(mockCreateEvent).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/mobile/features/scheduling/hooks/useAddPlanDate.ts
+++ b/apps/mobile/features/scheduling/hooks/useAddPlanDate.ts
@@ -1,0 +1,100 @@
+/**
+ * useAddPlanDate
+ *
+ * Creating a draft plan at the roster's neutral default date, and resolving the
+ * one thing that can go wrong with it: the group already has a plan that day.
+ *
+ * `nextSundayAtNine()` is DETERMINISTIC, so before the backend guard existed a
+ * second tap of "＋ Add date" wrote a byte-identical second plan — the roster
+ * grid then showed two indistinguishable columns, and a leader could author
+ * tasks on one while being rostered on the other. The backend now rejects the
+ * second plan with `DUPLICATE_PLAN_DATE` instead of silently writing it, and
+ * this hook decides what that rejection means to the leader.
+ *
+ * Extracted from RosterGridScreen so both entry points (the ＋ button and the
+ * quick-start fall-through) share one implementation and it can be tested
+ * without mounting the 5k-line grid.
+ */
+import { useCallback } from "react";
+import { useAuthenticatedMutation, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import {
+  parseDuplicatePlanDate,
+  promptDuplicatePlanDate,
+} from "../utils/duplicatePlanDate";
+
+/** Next Sunday at 9:00 AM local time — the neutral default for a new plan. */
+export function nextSundayAtNine(): Date {
+  const d = new Date();
+  const daysUntilSunday = (7 - d.getDay()) % 7 || 7;
+  d.setDate(d.getDate() + daysUntilSunday);
+  d.setHours(9, 0, 0, 0);
+  return d;
+}
+
+/**
+ * What to do when the default date is already planned.
+ *
+ *  - `"ask"` — put the choice to the leader. The ＋ Add date button: a second
+ *    service on one Sunday (9 AM + 11 AM) is legitimate, so they decide.
+ *  - `"open"` — go straight to the plan they already have. The quick-start
+ *    fall-through: they asked to be set up, not for a second service.
+ */
+export type OnDuplicateDate = "ask" | "open";
+
+export type AddPlanDateOutcome = "created" | "opened-existing" | "cancelled";
+
+export function useAddPlanDate(args: {
+  groupId: Id<"groups">;
+  /** Navigate to a plan — used when the leader opens the one they have. */
+  onOpenPlan: (planId: string) => void;
+}) {
+  const { groupId, onOpenPlan } = args;
+  const createEvent = useAuthenticatedMutation(
+    api.functions.scheduling.events.createEvent,
+  );
+
+  /**
+   * Create the plan. The title is left to the backend (`defaultPlanTitle`,
+   * derived from the group) — the client used to send a literal "Untitled event
+   * plan", which shipped through to serving mode's headers and read like a bug.
+   *
+   * Rethrows anything that isn't the duplicate-date collision, so callers keep
+   * their existing error surfacing.
+   */
+  const addPlanDate = useCallback(
+    async (onDuplicate: OnDuplicateDate): Promise<AddPlanDateOutcome> => {
+      const date = nextSundayAtNine();
+      const eventArgs = {
+        groupId,
+        eventDate: date.getTime(),
+        times: [{ label: "9:00 AM", startsAt: date.getTime() }],
+      };
+      try {
+        await createEvent(eventArgs);
+        return "created";
+      } catch (e) {
+        const duplicate = parseDuplicatePlanDate(e);
+        if (!duplicate) throw e;
+
+        if (onDuplicate === "open") {
+          onOpenPlan(duplicate.existingPlanId);
+          return "opened-existing";
+        }
+        const choice = await promptDuplicatePlanDate(duplicate);
+        if (choice === "open-existing") {
+          onOpenPlan(duplicate.existingPlanId);
+          return "opened-existing";
+        }
+        if (choice === "add-another") {
+          await createEvent({ ...eventArgs, allowSameDay: true });
+          return "created";
+        }
+        return "cancelled";
+      }
+    },
+    [createEvent, groupId, onOpenPlan],
+  );
+
+  return { addPlanDate };
+}

--- a/apps/mobile/features/scheduling/utils/__tests__/duplicatePlanDate.test.ts
+++ b/apps/mobile/features/scheduling/utils/__tests__/duplicatePlanDate.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Client half of the duplicate-plan-date guard.
+ *
+ * The backend throws a typed `DUPLICATE_PLAN_DATE` ConvexError rather than
+ * silently creating a second plan on a date the group already has one on. These
+ * helpers have to (a) recognise that error and nothing else, and (b) turn it
+ * into a question the leader can answer — an accidental double-tap and a real
+ * 9 AM/11 AM Sunday look identical from here, so we must ask.
+ */
+import { chooseAsync } from "@/utils/platformAlert";
+import {
+  parseDuplicatePlanDate,
+  duplicatePlanMessage,
+  promptDuplicatePlanDate,
+} from "../duplicatePlanDate";
+
+jest.mock("@/utils/platformAlert", () => ({
+  chooseAsync: jest.fn(),
+}));
+
+const mockChoose = chooseAsync as jest.MockedFunction<typeof chooseAsync>;
+
+const PAYLOAD = {
+  code: "DUPLICATE_PLAN_DATE",
+  message: '"Sunday Service" is already scheduled on Sun, Aug 2.',
+  dayLabel: "Sun, Aug 2",
+  existingPlanId: "plan-1",
+  existingPlanTitle: "Sunday Service",
+  existingEventDate: 1785675600000,
+  existingCount: 1,
+};
+
+beforeEach(() => {
+  mockChoose.mockReset();
+});
+
+describe("parseDuplicatePlanDate", () => {
+  it("reads the payload off a ConvexError-shaped throw", () => {
+    expect(parseDuplicatePlanDate({ data: PAYLOAD })).toEqual({
+      existingPlanId: "plan-1",
+      existingPlanTitle: "Sunday Service",
+      existingEventDate: 1785675600000,
+      dayLabel: "Sun, Aug 2",
+      existingCount: 1,
+    });
+  });
+
+  it("accepts a payload that arrived as a JSON string", () => {
+    const parsed = parseDuplicatePlanDate({ data: JSON.stringify(PAYLOAD) });
+    expect(parsed?.existingPlanId).toBe("plan-1");
+    expect(parsed?.dayLabel).toBe("Sun, Aug 2");
+  });
+
+  it("returns null for other errors so callers fall through to normal handling", () => {
+    expect(parseDuplicatePlanDate(new Error("network"))).toBeNull();
+    expect(parseDuplicatePlanDate(undefined)).toBeNull();
+    expect(parseDuplicatePlanDate("nope")).toBeNull();
+    expect(
+      parseDuplicatePlanDate({ data: { code: "NOT_FOUND", message: "gone" } }),
+    ).toBeNull();
+    expect(parseDuplicatePlanDate({ data: "{not json" })).toBeNull();
+  });
+
+  it("returns null when the payload is missing what the prompt needs", () => {
+    const { existingPlanId: _drop, ...incomplete } = PAYLOAD;
+    expect(parseDuplicatePlanDate({ data: incomplete })).toBeNull();
+  });
+
+  it("defaults existingCount when the backend omits it", () => {
+    const { existingCount: _drop, ...noCount } = PAYLOAD;
+    expect(parseDuplicatePlanDate({ data: noCount })?.existingCount).toBe(1);
+  });
+});
+
+describe("duplicatePlanMessage", () => {
+  it("names the plan already there and offers the multi-service reading", () => {
+    const info = parseDuplicatePlanDate({ data: PAYLOAD })!;
+    const message = duplicatePlanMessage(info);
+    expect(message).toContain("Sunday Service");
+    expect(message).toContain("Sun, Aug 2");
+    // The leader must be able to tell this is a choice, not a wall.
+    expect(message).toContain("11 AM service");
+  });
+
+  it("says how many plans are already on the date when there are several", () => {
+    const info = parseDuplicatePlanDate({
+      data: { ...PAYLOAD, existingCount: 3 },
+    })!;
+    expect(duplicatePlanMessage(info)).toContain("3 plans are on that date");
+  });
+});
+
+describe("promptDuplicatePlanDate", () => {
+  const info = parseDuplicatePlanDate({ data: PAYLOAD })!;
+
+  it("offers opening the existing plan as the primary action", async () => {
+    mockChoose.mockResolvedValue("primary");
+    await expect(promptDuplicatePlanDate(info)).resolves.toBe("open-existing");
+    expect(mockChoose).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Already a plan on Sun, Aug 2",
+        primaryText: "Open the existing plan",
+        secondaryText: "Add another anyway",
+      }),
+    );
+  });
+
+  it("keeps a deliberate second service reachable", async () => {
+    mockChoose.mockResolvedValue("secondary");
+    await expect(promptDuplicatePlanDate(info)).resolves.toBe("add-another");
+  });
+
+  it("does nothing when dismissed", async () => {
+    mockChoose.mockResolvedValue("cancel");
+    await expect(promptDuplicatePlanDate(info)).resolves.toBe("cancel");
+  });
+});

--- a/apps/mobile/features/scheduling/utils/__tests__/duplicatePlanDate.test.ts
+++ b/apps/mobile/features/scheduling/utils/__tests__/duplicatePlanDate.test.ts
@@ -7,18 +7,25 @@
  * into a question the leader can answer — an accidental double-tap and a real
  * 9 AM/11 AM Sunday look identical from here, so we must ask.
  */
-import { chooseAsync } from "@/utils/platformAlert";
+import fs from "fs";
+import path from "path";
+
+import { chooseAsync, confirmAsync } from "@/utils/platformAlert";
 import {
+  DUPLICATE_PLAN_DATE,
   parseDuplicatePlanDate,
   duplicatePlanMessage,
   promptDuplicatePlanDate,
+  savePlanDate,
 } from "../duplicatePlanDate";
 
 jest.mock("@/utils/platformAlert", () => ({
   chooseAsync: jest.fn(),
+  confirmAsync: jest.fn(),
 }));
 
 const mockChoose = chooseAsync as jest.MockedFunction<typeof chooseAsync>;
+const mockConfirm = confirmAsync as jest.MockedFunction<typeof confirmAsync>;
 
 const PAYLOAD = {
   code: "DUPLICATE_PLAN_DATE",
@@ -32,6 +39,7 @@ const PAYLOAD = {
 
 beforeEach(() => {
   mockChoose.mockReset();
+  mockConfirm.mockReset();
 });
 
 describe("parseDuplicatePlanDate", () => {
@@ -113,5 +121,129 @@ describe("promptDuplicatePlanDate", () => {
   it("does nothing when dismissed", async () => {
     mockChoose.mockResolvedValue("cancel");
     await expect(promptDuplicatePlanDate(info)).resolves.toBe("cancel");
+  });
+});
+
+describe("savePlanDate", () => {
+  const onError = jest.fn();
+  beforeEach(() => onError.mockReset());
+
+  const aug = () => new Date(2026, 7, 2, 9, 0, 0, 0);
+
+  it("saves a valid date straight through", async () => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    await expect(savePlanDate({ date: aug(), save, onError })).resolves.toBe(
+      "saved",
+    );
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith(aug().getTime());
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  it("ignores the values a web <input type=\"date\"> fires mid-keystroke", async () => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    // Typing "2026" into the year emits 0002, 0020, 0202 on the way — each a
+    // complete, valid Date. Persisting one strands the plan in the far past
+    // (it drops out of the upcoming-only grid and reads as deleted), and if it
+    // happens to collide it pops a blocking confirm while the leader types.
+    for (const partial of [
+      new Date(2, 7, 2),
+      new Date(1999, 11, 31),
+      new Date(3001, 0, 1),
+      new Date(NaN),
+    ]) {
+      await expect(
+        savePlanDate({ date: partial, save, onError }),
+      ).resolves.toBe("ignored");
+    }
+    // A dismissed native picker hands back null.
+    await expect(savePlanDate({ date: null, save, onError })).resolves.toBe(
+      "ignored",
+    );
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("asks, then retries with allowSameDay when the day is already planned", async () => {
+    const save = jest
+      .fn()
+      .mockRejectedValueOnce({ data: PAYLOAD })
+      .mockResolvedValueOnce(undefined);
+    mockConfirm.mockResolvedValue(true);
+
+    await expect(savePlanDate({ date: aug(), save, onError })).resolves.toBe(
+      "saved",
+    );
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Already a plan on Sun, Aug 2",
+        confirmText: "Move it there",
+      }),
+    );
+    expect(save).toHaveBeenNthCalledWith(2, aug().getTime(), true);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("leaves the date alone when the leader declines", async () => {
+    const save = jest.fn().mockRejectedValue({ data: PAYLOAD });
+    mockConfirm.mockResolvedValue(false);
+
+    await expect(savePlanDate({ date: aug(), save, onError })).resolves.toBe(
+      "cancelled",
+    );
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("never surfaces the raw ConvexError message, which is a stacktrace", async () => {
+    // A real client leaves the serialized payload embedded in `.message` and
+    // puts the object on `.data` — surfacing `.message` showed the leader
+    // "[CONVEX M(functions/scheduling/events:updateEvent)] … {\"code\":…}".
+    const convexError = Object.assign(
+      new Error(
+        '[CONVEX M(functions/scheduling/events:updateEvent)] Uncaught ConvexError: {"code":"NOT_ALLOWED","message":"You are not a scheduler."}',
+      ),
+      { data: { code: "NOT_ALLOWED", message: "You are not a scheduler." } },
+    );
+    const save = jest.fn().mockRejectedValue(convexError);
+
+    await expect(savePlanDate({ date: aug(), save, onError })).resolves.toBe(
+      "failed",
+    );
+    expect(onError).toHaveBeenCalledWith("You are not a scheduler.");
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed retry instead of swallowing it", async () => {
+    const save = jest
+      .fn()
+      .mockRejectedValueOnce({ data: PAYLOAD })
+      .mockRejectedValueOnce(new Error("Network request failed"));
+    mockConfirm.mockResolvedValue(true);
+
+    await expect(savePlanDate({ date: aug(), save, onError })).resolves.toBe(
+      "failed",
+    );
+    expect(onError).toHaveBeenCalledWith("Network request failed");
+  });
+});
+
+describe("DUPLICATE_PLAN_DATE", () => {
+  it("matches the literal the backend actually throws", () => {
+    // The constant is mirrored, not imported: `scheduling/events.ts` pulls in
+    // `_generated/server`, and mobile never imports Convex runtime code. A
+    // rename on either side would otherwise turn every date collision back
+    // into an unhandled error with nothing failing, so pin it here.
+    const backend = fs.readFileSync(
+      path.join(
+        __dirname,
+        "../../../../../convex/functions/scheduling/events.ts",
+      ),
+      "utf8",
+    );
+    const match = backend.match(
+      /export const DUPLICATE_PLAN_DATE = "([^"]+)"/,
+    );
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe(DUPLICATE_PLAN_DATE);
   });
 });

--- a/apps/mobile/features/scheduling/utils/duplicatePlanDate.ts
+++ b/apps/mobile/features/scheduling/utils/duplicatePlanDate.ts
@@ -1,0 +1,104 @@
+/**
+ * Client half of the duplicate-plan-date guard.
+ *
+ * The backend (`scheduling/events.ts`) refuses to put a second plan on a local
+ * calendar day a group already has one on, throwing a typed
+ * `DUPLICATE_PLAN_DATE` ConvexError rather than silently creating the
+ * duplicate. It is an error and not idempotent reuse because two services on
+ * one Sunday is normal — so the leader has to be ASKED, not overruled.
+ *
+ * These helpers turn that error into the question and back into an intent.
+ * Kept out of the components so the parsing (which reaches into an untyped
+ * error payload) and the wording are unit-testable without mounting the grid.
+ */
+import { chooseAsync } from "@/utils/platformAlert";
+
+/** The payload `assertPlanDateFree` attaches to the thrown ConvexError. */
+export type DuplicatePlanDate = {
+  /** The plan already on that day (the earliest-created one). */
+  existingPlanId: string;
+  existingPlanTitle: string;
+  existingEventDate: number;
+  /** "Sun, Aug 3", already rendered in the community's timezone. */
+  dayLabel: string;
+  /** How many other plans sit on that day. Usually 1. */
+  existingCount: number;
+};
+
+/** What the leader decided when told the date is taken. */
+export type DuplicatePlanChoice = "open-existing" | "add-another" | "cancel";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Recognise the typed duplicate-date error and pull out what the prompt needs.
+ * Returns `null` for anything else, so callers fall through to their normal
+ * error handling.
+ *
+ * `data` arrives as an object from a real Convex client; some transports hand
+ * back the JSON string it was wired as, so both are accepted.
+ */
+export function parseDuplicatePlanDate(e: unknown): DuplicatePlanDate | null {
+  const err = asRecord(e);
+  if (!err) return null;
+
+  let payload = err.data;
+  if (typeof payload === "string") {
+    try {
+      payload = JSON.parse(payload);
+    } catch {
+      return null;
+    }
+  }
+  const data = asRecord(payload);
+  if (!data || data.code !== "DUPLICATE_PLAN_DATE") return null;
+  if (
+    typeof data.existingPlanId !== "string" ||
+    typeof data.existingPlanTitle !== "string" ||
+    typeof data.existingEventDate !== "number" ||
+    typeof data.dayLabel !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    existingPlanId: data.existingPlanId,
+    existingPlanTitle: data.existingPlanTitle,
+    existingEventDate: data.existingEventDate,
+    dayLabel: data.dayLabel,
+    existingCount:
+      typeof data.existingCount === "number" ? data.existingCount : 1,
+  };
+}
+
+/** The body copy shown when a date is already planned. */
+export function duplicatePlanMessage(info: DuplicatePlanDate): string {
+  const others =
+    info.existingCount > 1
+      ? ` (${info.existingCount} plans are on that date.)`
+      : "";
+  return `"${info.existingPlanTitle}" is already on ${info.dayLabel}.${others} Open it, or add a second plan for the same day — for example a 9 AM and an 11 AM service?`;
+}
+
+/**
+ * Ask the leader what they meant. "Open it" is the primary action: an
+ * accidental second tap is far more common than a genuine second service, and
+ * opening the plan they already have is the non-destructive answer.
+ */
+export async function promptDuplicatePlanDate(
+  info: DuplicatePlanDate,
+): Promise<DuplicatePlanChoice> {
+  const choice = await chooseAsync({
+    title: `Already a plan on ${info.dayLabel}`,
+    message: duplicatePlanMessage(info),
+    primaryText: "Open the existing plan",
+    secondaryText: "Add another anyway",
+  });
+  if (choice === "primary") return "open-existing";
+  if (choice === "secondary") return "add-another";
+  return "cancel";
+}

--- a/apps/mobile/features/scheduling/utils/duplicatePlanDate.ts
+++ b/apps/mobile/features/scheduling/utils/duplicatePlanDate.ts
@@ -11,7 +11,22 @@
  * Kept out of the components so the parsing (which reaches into an untyped
  * error payload) and the wording are unit-testable without mounting the grid.
  */
-import { chooseAsync } from "@/utils/platformAlert";
+import { chooseAsync, confirmAsync } from "@/utils/platformAlert";
+import { errorMessage } from "@utils/error-handling";
+
+/**
+ * The `code` on the ConvexError this module recognises.
+ *
+ * MIRRORS `DUPLICATE_PLAN_DATE` in `apps/convex/functions/scheduling/events.ts`
+ * — the two must stay identical or every date collision silently becomes an
+ * unhandled error again. The literal cannot be imported: that module pulls in
+ * `_generated/server`, and this codebase deliberately never imports Convex
+ * runtime code into the mobile bundle (it mirrors constants instead — see
+ * `chatSendErrors.ts`, `INBOX_EVENT_HIDE_AFTER_MS`). The pin is a test:
+ * `__tests__/duplicatePlanDate.test.ts` reads the backend file and fails if
+ * the two drift.
+ */
+export const DUPLICATE_PLAN_DATE = "DUPLICATE_PLAN_DATE";
 
 /** The payload `assertPlanDateFree` attaches to the thrown ConvexError. */
 export type DuplicatePlanDate = {
@@ -55,7 +70,7 @@ export function parseDuplicatePlanDate(e: unknown): DuplicatePlanDate | null {
     }
   }
   const data = asRecord(payload);
-  if (!data || data.code !== "DUPLICATE_PLAN_DATE") return null;
+  if (!data || data.code !== DUPLICATE_PLAN_DATE) return null;
   if (
     typeof data.existingPlanId !== "string" ||
     typeof data.existingPlanTitle !== "string" ||
@@ -101,4 +116,67 @@ export async function promptDuplicatePlanDate(
   if (choice === "primary") return "open-existing";
   if (choice === "secondary") return "add-another";
   return "cancel";
+}
+
+/** What {@link savePlanDate} did with the value the picker produced. */
+export type SavePlanDateOutcome = "saved" | "ignored" | "cancelled" | "failed";
+
+/**
+ * Persist a plan's new date, resolving the one thing that can go wrong: the
+ * group already has a plan on the day the leader picked.
+ *
+ * Shared by every date editor (the roster grid's column header, the desktop
+ * panel, and the full-screen editor) because they must not drift: the
+ * full-screen editor is where BOTH "＋ Add date" and "Duplicate" push the
+ * leader to set the new plan's date, and while it lacked this handling a
+ * second service on an occupied Sunday was unreachable from it — the leader
+ * got a raw ConvexError body instead (`.message` is a hybrid stacktrace with
+ * the serialized payload embedded; only `.data` carries the object).
+ *
+ * @param date The picker's value. `null` — a dismissed native picker — is a
+ *   no-op, as are the intermediate values a web `<input type="date">` fires
+ *   per keystroke while the year is typed digit by digit ("0026" is a
+ *   complete, valid date). Without that filter a keystroke could both strand
+ *   the plan in the far past and pop a blocking confirm mid-typing.
+ * @param save `updateEvent` bound to the plan.
+ * @param onError Surface a failure — the caller owns the alert's title.
+ */
+export async function savePlanDate(args: {
+  date: Date | null;
+  save: (eventDate: number, allowSameDay?: boolean) => Promise<unknown>;
+  onError: (message: string) => void;
+}): Promise<SavePlanDateOutcome> {
+  const { date, save, onError } = args;
+  if (!date) return "ignored";
+  const ms = date.getTime();
+  if (Number.isNaN(ms)) return "ignored";
+  const year = date.getFullYear();
+  if (year < 2000 || year > 3000) return "ignored";
+
+  try {
+    await save(ms);
+    return "saved";
+  } catch (e) {
+    // A group holds one plan per local day unless the leader says otherwise —
+    // but moving a plan alongside an existing service is a real thing to want,
+    // so ask instead of refusing.
+    const duplicate = parseDuplicatePlanDate(e);
+    if (!duplicate) {
+      onError(errorMessage(e, "Please try again."));
+      return "failed";
+    }
+    const ok = await confirmAsync({
+      title: `Already a plan on ${duplicate.dayLabel}`,
+      message: `"${duplicate.existingPlanTitle}" is already on that date. Move this plan there anyway, so the day has two?`,
+      confirmText: "Move it there",
+    });
+    if (!ok) return "cancelled";
+    try {
+      await save(ms, true);
+      return "saved";
+    } catch (e2) {
+      onError(errorMessage(e2, "Please try again."));
+      return "failed";
+    }
+  }
 }

--- a/apps/mobile/utils/__tests__/platformAlert.test.ts
+++ b/apps/mobile/utils/__tests__/platformAlert.test.ts
@@ -21,12 +21,12 @@ function lastAlertButtons(): Button[] {
 describe("confirmAsync", () => {
   afterEach(() => {
     jest.restoreAllMocks();
-    // @ts-expect-error — test-only platform override.
+    // Test-only platform override.
     Platform.OS = "ios";
   });
 
   it("spells the confirm action out on web, where the button is always 'OK'", async () => {
-    // @ts-expect-error — test-only platform override.
+    // Test-only platform override.
     Platform.OS = "web";
     const confirm = jest.fn().mockReturnValue(true);
     // @ts-expect-error — jsdom window stub.
@@ -48,7 +48,7 @@ describe("confirmAsync", () => {
   });
 
   it("leaves a plain OK/Cancel confirm unadorned", async () => {
-    // @ts-expect-error — test-only platform override.
+    // Test-only platform override.
     Platform.OS = "web";
     const confirm = jest.fn().mockReturnValue(false);
     // @ts-expect-error — jsdom window stub.
@@ -64,7 +64,7 @@ describe("confirmAsync", () => {
 describe("chooseAsync", () => {
   afterEach(() => {
     jest.restoreAllMocks();
-    // @ts-expect-error — test-only platform override.
+    // Test-only platform override.
     Platform.OS = "ios";
   });
 
@@ -76,7 +76,7 @@ describe("chooseAsync", () => {
   };
 
   it("keeps the title and message on the web fallback's SECOND dialog", async () => {
-    // @ts-expect-error — test-only platform override.
+    // Test-only platform override.
     Platform.OS = "web";
     // Decline the first (primary) question, accept the second.
     const confirm = jest
@@ -100,7 +100,7 @@ describe("chooseAsync", () => {
   });
 
   it("glosses a custom cancel label on the second web dialog", async () => {
-    // @ts-expect-error — test-only platform override.
+    // Test-only platform override.
     Platform.OS = "web";
     const confirm = jest.fn().mockReturnValue(false);
     // @ts-expect-error — jsdom window stub.
@@ -113,7 +113,7 @@ describe("chooseAsync", () => {
   });
 
   it("names both web actions on the first dialog too", async () => {
-    // @ts-expect-error — test-only platform override.
+    // Test-only platform override.
     Platform.OS = "web";
     const confirm = jest.fn().mockReturnValue(true);
     // @ts-expect-error — jsdom window stub.
@@ -126,7 +126,7 @@ describe("chooseAsync", () => {
   });
 
   it("puts the primary action at the TOP of the iOS stack", async () => {
-    // @ts-expect-error — test-only platform override.
+    // Test-only platform override.
     Platform.OS = "ios";
     jest.spyOn(Alert, "alert").mockImplementation(() => {});
 
@@ -145,7 +145,7 @@ describe("chooseAsync", () => {
   });
 
   it("puts the primary action in Android's positive (rightmost) slot", async () => {
-    // @ts-expect-error — test-only platform override.
+    // Test-only platform override.
     Platform.OS = "android";
     jest.spyOn(Alert, "alert").mockImplementation(() => {});
 
@@ -160,7 +160,7 @@ describe("chooseAsync", () => {
   });
 
   it("resolves with the button the user actually pressed", async () => {
-    // @ts-expect-error — test-only platform override.
+    // Test-only platform override.
     Platform.OS = "ios";
     jest.spyOn(Alert, "alert").mockImplementation(() => {});
 

--- a/apps/mobile/utils/__tests__/platformAlert.test.ts
+++ b/apps/mobile/utils/__tests__/platformAlert.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Cross-platform confirm helpers.
+ *
+ * Both branches have failed silently before: `Alert.alert` is a no-op on web
+ * (so a confirm built on it never runs its action), and `window.confirm`'s
+ * buttons are hardcoded "OK"/"Cancel" (so a caller's wording vanishes unless it
+ * is put in the body). These tests pin the wording AND the native button order,
+ * which is the part no test can otherwise see.
+ */
+import { Alert, Platform } from "react-native";
+
+import { chooseAsync, confirmAsync } from "../platformAlert";
+
+type Button = { text?: string; style?: string; isPreferred?: boolean };
+
+function lastAlertButtons(): Button[] {
+  const spy = Alert.alert as unknown as jest.Mock;
+  return spy.mock.calls[spy.mock.calls.length - 1][2] as Button[];
+}
+
+describe("confirmAsync", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    // @ts-expect-error — test-only platform override.
+    Platform.OS = "ios";
+  });
+
+  it("spells the confirm action out on web, where the button is always 'OK'", async () => {
+    // @ts-expect-error — test-only platform override.
+    Platform.OS = "web";
+    const confirm = jest.fn().mockReturnValue(true);
+    // @ts-expect-error — jsdom window stub.
+    global.window = { confirm };
+
+    await expect(
+      confirmAsync({
+        title: "Already a plan on Sun, Aug 2",
+        message: '"Sunday Service" is already on that date.',
+        confirmText: "Move it there",
+      }),
+    ).resolves.toBe(true);
+
+    const body = confirm.mock.calls[0][0] as string;
+    expect(body).toContain("Already a plan on Sun, Aug 2");
+    expect(body).toContain('"Sunday Service" is already on that date.');
+    // Without this the user approves an unnamed action.
+    expect(body).toContain("OK = Move it there");
+  });
+
+  it("leaves a plain OK/Cancel confirm unadorned", async () => {
+    // @ts-expect-error — test-only platform override.
+    Platform.OS = "web";
+    const confirm = jest.fn().mockReturnValue(false);
+    // @ts-expect-error — jsdom window stub.
+    global.window = { confirm };
+
+    await confirmAsync({ title: "Delete event plan?", message: "Are you sure?" });
+    expect(confirm.mock.calls[0][0]).toBe(
+      "Delete event plan?\n\nAre you sure?",
+    );
+  });
+});
+
+describe("chooseAsync", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    // @ts-expect-error — test-only platform override.
+    Platform.OS = "ios";
+  });
+
+  const opts = {
+    title: "Already a plan on Sun, Aug 2",
+    message: '"Sunday Service" is already on that date.',
+    primaryText: "Open the existing plan",
+    secondaryText: "Add another anyway",
+  };
+
+  it("keeps the title and message on the web fallback's SECOND dialog", async () => {
+    // @ts-expect-error — test-only platform override.
+    Platform.OS = "web";
+    // Decline the first (primary) question, accept the second.
+    const confirm = jest
+      .fn()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    // @ts-expect-error — jsdom window stub.
+    global.window = { confirm };
+
+    await expect(chooseAsync(opts)).resolves.toBe("secondary");
+
+    const second = confirm.mock.calls[1][0] as string;
+    // It used to be a bare "Add another anyway?" — a user whose first Cancel
+    // meant "stop entirely" got an unlabelled prompt, and a reflexive OK made
+    // the duplicate this whole flow exists to prevent.
+    expect(second).toContain("Already a plan on Sun, Aug 2");
+    expect(second).toContain('"Sunday Service" is already on that date.');
+    expect(second).toContain("OK = Add another anyway");
+    // The default "Cancel" needs no gloss — the browser's own button says it.
+    expect(second).not.toContain("Cancel = Cancel");
+  });
+
+  it("glosses a custom cancel label on the second web dialog", async () => {
+    // @ts-expect-error — test-only platform override.
+    Platform.OS = "web";
+    const confirm = jest.fn().mockReturnValue(false);
+    // @ts-expect-error — jsdom window stub.
+    global.window = { confirm };
+
+    await expect(
+      chooseAsync({ ...opts, cancelText: "Leave it alone" }),
+    ).resolves.toBe("cancel");
+    expect(confirm.mock.calls[1][0]).toContain("Cancel = Leave it alone");
+  });
+
+  it("names both web actions on the first dialog too", async () => {
+    // @ts-expect-error — test-only platform override.
+    Platform.OS = "web";
+    const confirm = jest.fn().mockReturnValue(true);
+    // @ts-expect-error — jsdom window stub.
+    global.window = { confirm };
+
+    await expect(chooseAsync(opts)).resolves.toBe("primary");
+    const first = confirm.mock.calls[0][0] as string;
+    expect(first).toContain("OK = Open the existing plan");
+    expect(first).toContain("Cancel = see the other options");
+  });
+
+  it("puts the primary action at the TOP of the iOS stack", async () => {
+    // @ts-expect-error — test-only platform override.
+    Platform.OS = "ios";
+    jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+    void chooseAsync(opts);
+    const buttons = lastAlertButtons();
+    // iOS renders in the order given but forces `cancel` to the bottom, so the
+    // first non-cancel entry is what the leader reads first. With the primary
+    // last, "Add another anyway" sat on top — the accidental action.
+    expect(buttons.map((b) => b.text)).toEqual([
+      "Cancel",
+      "Open the existing plan",
+      "Add another anyway",
+    ]);
+    expect(buttons[0].style).toBe("cancel");
+    expect(buttons[1].isPreferred).toBe(true);
+  });
+
+  it("puts the primary action in Android's positive (rightmost) slot", async () => {
+    // @ts-expect-error — test-only platform override.
+    Platform.OS = "android";
+    jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+    void chooseAsync(opts);
+    // RN's Alert.js pops from the end: [0]→neutral, [1]→negative,
+    // [2]→positive. The affirmative slot is last, the opposite of iOS.
+    expect(lastAlertButtons().map((b) => b.text)).toEqual([
+      "Cancel",
+      "Add another anyway",
+      "Open the existing plan",
+    ]);
+  });
+
+  it("resolves with the button the user actually pressed", async () => {
+    // @ts-expect-error — test-only platform override.
+    Platform.OS = "ios";
+    jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+    const pending = chooseAsync(opts);
+    const buttons = lastAlertButtons() as Array<{ onPress: () => void }>;
+    buttons[2].onPress(); // "Add another anyway" on iOS
+    await expect(pending).resolves.toBe("secondary");
+  });
+});

--- a/apps/mobile/utils/platformAlert.ts
+++ b/apps/mobile/utils/platformAlert.ts
@@ -10,6 +10,28 @@
 import { Alert, Platform } from "react-native";
 
 /**
+ * Body text for a `window.confirm`, with each action's REAL wording spelled
+ * out in it.
+ *
+ * The browser's buttons are always "OK" and "Cancel" — they cannot be
+ * relabelled — so a caller's `confirmText: "Move it there"` is otherwise
+ * silently dropped and the user is asked to approve an unnamed action. Each
+ * `[buttonLabel, meaning]` pair is appended only when the caller actually
+ * customised it, so the common OK/Cancel case stays clean.
+ */
+function webBody(
+  title: string,
+  message: string,
+  actions: Array<[button: string, meaning: string]>,
+): string {
+  const lines = actions
+    .filter(([button, meaning]) => button !== meaning)
+    .map(([button, meaning]) => `${button} = ${meaning}`);
+  const head = message ? `${title}\n\n${message}` : title;
+  return lines.length ? `${head}\n\n${lines.join("\n")}` : head;
+}
+
+/**
  * Imperative confirm. Resolves `true` if the user confirms, `false` if they
  * cancel or dismiss. Works on web (window.confirm) and native (Alert.alert).
  */
@@ -33,7 +55,14 @@ export function confirmAsync(opts: {
     if (typeof window === "undefined" || !window.confirm) {
       return Promise.resolve(false);
     }
-    return Promise.resolve(window.confirm(message ? `${title}\n\n${message}` : title));
+    return Promise.resolve(
+      window.confirm(
+        webBody(title, message, [
+          ["OK", confirmText],
+          ["Cancel", cancelText],
+        ]),
+      ),
+    );
   }
 
   return new Promise((resolve) => {
@@ -64,6 +93,21 @@ export type Choice = "primary" | "secondary" | "cancel";
  * primary action first and, only if declined, offers the secondary. Two small
  * dialogs beats inventing a modal here, and each question stays unambiguous.
  * Order the actions so the one a user most often wants is `primary`.
+ *
+ * The native button array is platform-branched because the two platforms read
+ * it in OPPOSITE directions, and both must put `primary` in the emphasised
+ * slot:
+ *
+ *  - iOS stacks the actions in the order given and forces the `cancel`-styled
+ *    one to the bottom, so the first entry after `cancel` is the TOP of the
+ *    stack. `isPreferred` additionally bolds it.
+ *  - Android maps `[0]→neutral (left), [1]→negative (middle), [2]→positive
+ *    (right)` (`Alert.js` pops from the end), and `positive` is the affirmative
+ *    slot — so the primary action has to be LAST.
+ *
+ * With one shared array, whichever platform lost had the accidental action in
+ * the emphasised position — which is exactly backwards for a prompt whose
+ * whole point is that the accidental second tap is the common case.
  */
 export function chooseAsync(opts: {
   title: string;
@@ -84,24 +128,54 @@ export function chooseAsync(opts: {
     if (typeof window === "undefined" || !window.confirm) {
       return Promise.resolve("cancel");
     }
-    const head = message ? `${title}\n\n${message}` : title;
-    if (window.confirm(`${head}\n\n${primaryText}?`)) {
+    if (
+      window.confirm(
+        webBody(title, message, [
+          ["OK", primaryText],
+          ["Cancel", "see the other options"],
+        ]),
+      )
+    ) {
       return Promise.resolve("primary");
     }
+    // The second dialog REPEATS the title and message. It used to be a bare
+    // `confirm("Add another anyway?")` with no context at all — so a user
+    // whose first Cancel meant "stop, I didn't want this" was immediately
+    // shown an unlabelled prompt, and a reflexive OK created the very
+    // duplicate this prompt exists to prevent.
     return Promise.resolve(
-      window.confirm(`${secondaryText}?`) ? "secondary" : "cancel",
+      window.confirm(
+        webBody(title, message, [
+          ["OK", secondaryText],
+          ["Cancel", cancelText],
+        ]),
+      )
+        ? "secondary"
+        : "cancel",
     );
   }
 
   return new Promise((resolve) => {
+    const cancel = {
+      text: cancelText,
+      style: "cancel" as const,
+      onPress: () => resolve("cancel"),
+    };
+    const primary = {
+      text: primaryText,
+      isPreferred: true,
+      onPress: () => resolve("primary"),
+    };
+    const secondary = {
+      text: secondaryText,
+      onPress: () => resolve("secondary"),
+    };
     Alert.alert(
       title,
       message || undefined,
-      [
-        { text: cancelText, style: "cancel", onPress: () => resolve("cancel") },
-        { text: secondaryText, onPress: () => resolve("secondary") },
-        { text: primaryText, onPress: () => resolve("primary") },
-      ],
+      Platform.OS === "ios"
+        ? [cancel, primary, secondary]
+        : [cancel, secondary, primary],
       { onDismiss: () => resolve("cancel") },
     );
   });

--- a/apps/mobile/utils/platformAlert.ts
+++ b/apps/mobile/utils/platformAlert.ts
@@ -53,6 +53,60 @@ export function confirmAsync(opts: {
   });
 }
 
+/** Which button the user picked in {@link chooseAsync}. */
+export type Choice = "primary" | "secondary" | "cancel";
+
+/**
+ * Imperative two-action prompt ("open the one you have" / "add another" /
+ * cancel). Native gets a single three-button `Alert.alert`.
+ *
+ * Web has no three-way primitive — `window.confirm` is binary — so it asks the
+ * primary action first and, only if declined, offers the secondary. Two small
+ * dialogs beats inventing a modal here, and each question stays unambiguous.
+ * Order the actions so the one a user most often wants is `primary`.
+ */
+export function chooseAsync(opts: {
+  title: string;
+  message?: string;
+  primaryText: string;
+  secondaryText: string;
+  cancelText?: string;
+}): Promise<Choice> {
+  const {
+    title,
+    message = "",
+    primaryText,
+    secondaryText,
+    cancelText = "Cancel",
+  } = opts;
+
+  if (Platform.OS === "web") {
+    if (typeof window === "undefined" || !window.confirm) {
+      return Promise.resolve("cancel");
+    }
+    const head = message ? `${title}\n\n${message}` : title;
+    if (window.confirm(`${head}\n\n${primaryText}?`)) {
+      return Promise.resolve("primary");
+    }
+    return Promise.resolve(
+      window.confirm(`${secondaryText}?`) ? "secondary" : "cancel",
+    );
+  }
+
+  return new Promise((resolve) => {
+    Alert.alert(
+      title,
+      message || undefined,
+      [
+        { text: cancelText, style: "cancel", onPress: () => resolve("cancel") },
+        { text: secondaryText, onPress: () => resolve("secondary") },
+        { text: primaryText, onPress: () => resolve("primary") },
+      ],
+      { onDismiss: () => resolve("cancel") },
+    );
+  });
+}
+
 /**
  * One-button informational / error notice. Web uses window.alert (Alert.alert
  * is a no-op there), so a failure message isn't swallowed silently.

--- a/apps/web/src/pages/guides/EventPlans.tsx
+++ b/apps/web/src/pages/guides/EventPlans.tsx
@@ -170,6 +170,17 @@ export function EventPlans() {
           <Term>Set needed roles</Term>. Everything auto-saves as you go.
         </P>
         <P>
+          A group holds <strong>one plan per date</strong>. If you try to add a
+          second plan on a date you have already planned, Together asks whether
+          you meant to open the plan you have, or to add another — so an extra
+          tap can't quietly leave you with two identical-looking dates. Two
+          plans on one day is still allowed when you say so; usually, though,
+          two services on a Sunday belong on <em>one</em> plan as two{" "}
+          <Term>service times</Term>. If a date does end up with more than one
+          plan, every column for that date is flagged with a{" "}
+          <Term>Double-booked</Term> warning on the roster grid.
+        </P>
+        <P>
           A plan starts as a <Term>Draft</Term>. Each plan card shows a
           fill-progress bar reading{" "}
           <Term>{"{filled}/{needed} filled"}</Term> with a{" "}

--- a/docs/architecture/ADR-023-native-event-scheduling.md
+++ b/docs/architecture/ADR-023-native-event-scheduling.md
@@ -290,6 +290,37 @@ roleAssignments: defineTable({
   columns with the same ⚠ "double-booked" language it already uses for a
   person staffed twice in a day.
 
+  Three constraints on the guard, each learned the hard way:
+
+  - **A plan that stays on its own local day is not rescheduling.** Excluding
+    the plan from itself by id is not enough — the web date picker rebuilds a
+    picked value at local *midnight*, dropping the time of day, so re-picking
+    the same date sends a different millisecond. On a Sunday that legitimately
+    holds a 9 AM and an 11 AM plan the *sibling* then matched and the edit
+    threw. `updateEvent` passes `currentEventDate`, and the guard returns early
+    when the local day is unchanged.
+  - **A corrupt `eventDate` must never be contagious.** It is a Convex
+    `v.number()` (float64), so `NaN`/`Infinity`/out-of-range pass validation
+    and make `Intl.DateTimeFormat.format` throw `RangeError`. Because the guard
+    maps the formatter over every sibling and `rosterMatrix` over every plan,
+    one bad row would take down creation *and* the roster grid for the whole
+    group. `localDayKey` yields an `INVALID_DAY_KEY` sentinel that matches
+    nothing in either direction, and callers skip those rows.
+  - **Bound the read.** The sibling lookup is a ±36 h range scan on
+    `eventPlans.by_group_date`, not a `.collect()` of the group's whole plan
+    history. Two instants on one local day are at most ~26 h apart (a
+    DST-extended day), so the scan is provably complete — and it keeps
+    concurrent edits to unrelated dates from OCC-conflicting. The `Intl`
+    formatters are memoized per timezone for the same reason: constructing one
+    costs ~100× using one.
+
+  On the client, every date editor goes through `savePlanDate`
+  (`features/scheduling/utils/duplicatePlanDate.ts`) rather than hand-rolling
+  the catch. The three editors (roster column header, desktop panel,
+  full-screen editor) had already drifted once — the full-screen editor is
+  where both "＋ Add date" and "Duplicate" *send* the leader to set a date, and
+  it was the one that dead-ended on the raw error.
+
 ## Availability collection (follow-up)
 
 Phase 1 shipped without any way to gather "who can serve which date". This

--- a/docs/architecture/ADR-023-native-event-scheduling.md
+++ b/docs/architecture/ADR-023-native-event-scheduling.md
@@ -257,6 +257,39 @@ roleAssignments: defineTable({
   keeps `eventPlans` naming explicit, and user-facing copy always says
   "event plan", to avoid the collision.
 
+- **One plan per group per local calendar day, unless the leader says
+  otherwise.** Nothing used to prevent duplicates: Convex has no unique
+  indexes, `createEventDraftImpl` validated only a non-empty title, and both
+  roster-grid entry points default to a *deterministic* "next Sunday 9 AM" —
+  so a second tap wrote a byte-identical second plan. In production this
+  produced three indistinguishable plans on one date, with a leader authoring
+  tasks on one while rostered on another.
+
+  `assertPlanDateFree` (`functions/scheduling/events.ts`) guards
+  `createEventDraftImpl` (so `createEvent` and `quickStartRostering`),
+  `duplicateEvent`, and `updateEvent`'s date moves. It throws a typed
+  `DUPLICATE_PLAN_DATE` `ConvexError` carrying the existing plan's
+  id/title/date, **not** an idempotent return of that plan: two services on
+  one Sunday is normal church practice, so the deliberate case has to stay
+  reachable. The client turns the error into a choice ("open the one you
+  have" / "add another"), and "add another" re-calls with
+  `allowSameDay: true`. Demo-seeded plans (`isDemoSeed`) are excluded so a
+  demo Sunday never blocks a real one.
+
+  "Same day" is the **community-local** day (`lib/localDay.ts`, keyed
+  `YYYY-MM-DD` via `Intl` in `communities.timezone`), not the
+  floor-by-86_400_000 UTC bucket the per-person double-booking check uses.
+  The UTC bucket is wrong in both directions outside UTC: for an ET church a
+  Sat 11 PM and a Sun 1 AM plan share a UTC day but are two local days, and a
+  Sun 9 AM and a Sun 9 PM plan straddle UTC midnight but are one.
+
+  Prevention alone is insufficient — duplicates created before the guard are
+  still in the data — so `rosterMatrix` returns `sameDatePlanCount` per
+  column (computed over *every* plan of the group, so a duplicate hidden by
+  the column cap still flags the one on screen) and the grid marks those
+  columns with the same ⚠ "double-booked" language it already uses for a
+  person staffed twice in a day.
+
 ## Availability collection (follow-up)
 
 Phase 1 shipped without any way to gather "who can serve which date". This


### PR DESCRIPTION
Root cause of a real report: a leader authored six tasks on one Aug 2 plan while being rostered on a *different* Aug 2 plan. Serving mode opened the one they were rostered on — correctly — and it had no tasks. Three plans existed on that date with indistinguishable headers, so nothing on screen revealed the mismatch. #705 made them distinguishable; this stops them being created by accident.

## Nothing prevented duplicates, at any level

Convex has no unique indexes, so `by_community_date` is a read index, not a constraint. `createEventDraftImpl` validated only a non-empty title. No client confirm anywhere. And `nextSundayAtNine()` is **deterministic** — tapping `＋ Add date` twice produced two byte-identical plans.

## Semantics: a typed error, not idempotent reuse

**Two services on one Sunday is normal.** A 9am and an 11am are legitimately two plans on one date, so the guard cannot simply forbid same-day plans. Idempotent reuse would have made a deliberate second service *impossible* — the leader would have no way to say "no, I really do want another."

So: a typed `ConvexError` carrying `{ code: "DUPLICATE_PLAN_DATE", dayLabel, existingPlanId, existingPlanTitle, existingEventDate, existingCount }` — enough for the client to offer "open the one you have" without a second round-trip — plus an explicit `allowSameDay: true` opt-in on all three mutations. `isDemoSeed` plans are excluded so a demo Sunday can't block a real one.

The two entry points want different things from the same collision, which is why they behave differently: `＋ Add date` **asks** (a second service is plausible), while the quick-start fall-through **opens the existing plan** without asking — that leader asked to be *set up*, not for a second service.

## The day bucket is local, not UTC

`eventDate` is a UTC timestamp but "same day" is a local-time question, and the existing `utcDayBucket` (floor by 86.4M) is wrong in **both** directions outside UTC. New `apps/convex/lib/localDay.ts` keys on the community's timezone instead:

| Case | UTC day | ET day | Correct |
|---|---|---|---|
| Sat 11 PM ET vs Sun 9 AM ET | same | different | **allowed** — UTC bucket would have blocked it |
| Sun 9 AM ET vs Sun 9 PM ET | different | same | **blocked** — UTC bucket would have allowed it |

Both boundaries are tested against real `Intl` output, plus a test that repoints the community at `Pacific/Auckland` and asserts the collision set *and* the rendered `dayLabel` move with it.

**Known inconsistency left alone:** `assignments.ts` / `roster.ts` still use `utcDayBucket` for per-person double-booking. That's a real bug of the same family, but fixing it changes unrelated behaviour and belongs in its own PR.

## Coverage

The guard applies to `createEventDraftImpl` (so `createEvent` and `quickStartRostering`), `duplicateEvent`, and `updateEvent` when `eventDate` changes. It also covers `EventEditorPanel`'s date picker and duplicate action — both were back doors around it, and both previously rendered the raw error payload as their message.

Existing duplicates already exist in production, so prevention alone is insufficient: same-date columns in the roster grid are now flagged, reusing the existing double-booked visual vocabulary rather than new chrome. No merge tool — out of scope.

## Verification

- `apps/convex` — 164 files / 2887 tests passed; `npx convex typecheck` clean
- `apps/mobile` — 226 suites / 2318 tests passed
- ESLint identical to the pre-change baseline (0 errors); web lint clean
- `check-navigator-screens` selftest + check passed
- No dependency changes; native-safety gates not applicable
- Three existing convex tests adjusted: `assignments.test.ts` and `roster.test.ts` build multi-service Sundays deliberately, so they now pass `allowSameDay: true`; `eventItems.test.ts` only needed two plans, so its second moved a week out

The intermittent unidentified convex failure from #705 **did not reproduce** across 6 full runs here.

## Not verified

No device run. Pure JS/TS, no native or dependency change — but the dialogs and the duplicate-date flag have not been seen rendered; the tests assert presence and accessibility label, not visual placement.

`chooseAsync`'s **web** path uses two sequential `window.confirm`s, since web has no three-way primitive and a custom modal would have meant new chrome. Native gets a single three-button `Alert`. Deliberate tradeoff, documented in the function, unverified in a browser.

`convex-test` serializes `ConvexError.data` to a JSON string where a real client returns the object. Both forms are accepted by the parser, but only the string form is exercised end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168KrbHskjSAFjB6sSHgkXA

---
_Generated by [Claude Code](https://claude.ai/code/session_0168KrbHskjSAFjB6sSHgkXA)_