### PR TITLE
fix(messaging): show the full message in previews & notifications

### DIFF
--- a/apps/convex/__tests__/mention-email.test.ts
+++ b/apps/convex/__tests__/mention-email.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { mentionEmail } from "../lib/notifications/emailTemplates";
+import {
+  chatRequestEmail,
+  leaderDmEmail,
+  mentionEmail,
+} from "../lib/notifications/emailTemplates";
 
 describe("mentionEmail", () => {
   it("renders sender, group, and message preview", () => {
@@ -39,6 +43,41 @@ describe("mentionEmail", () => {
     expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
     expect(html).toContain("&quot;quoted&quot; &amp; &lt;b&gt;bold&lt;/b&gt;");
     expect(html).toContain('Hi Jo &quot;J&quot;,');
+  });
+});
+
+/**
+ * The emails now quote the *whole* message, so the quote box has to keep the
+ * sender's line breaks — otherwise a multi-paragraph prayer request renders as
+ * one run-on blob. `white-space: pre-wrap` does that, which in turn means the
+ * escaped text must be interpolated with no surrounding template whitespace.
+ */
+describe("notification email quote boxes preserve line breaks", () => {
+  const multiline = "Line one.\n\nLine two.";
+
+  it.each([
+    [
+      "chatRequestEmail",
+      chatRequestEmail({
+        senderName: "Alice",
+        isGroupChat: false,
+        messagePreview: multiline,
+      }),
+    ],
+    [
+      "leaderDmEmail",
+      leaderDmEmail({
+        senderName: "Alice",
+        relationshipLabel: "group leader",
+        bodyLine: "She leads your group.",
+        messagePreview: multiline,
+      }),
+    ],
+  ])("%s sets pre-wrap and does not pad the quote", (_name, html) => {
+    expect(html).toContain("white-space: pre-wrap");
+    // The message sits flush against its quote marks — no stray newline or
+    // indentation that pre-wrap would render as blank space.
+    expect(html).toContain(`>"${multiline}"</p>`);
   });
 });
 

--- a/apps/convex/__tests__/messaging/events.test.ts
+++ b/apps/convex/__tests__/messaging/events.test.ts
@@ -1821,3 +1821,230 @@ describe("leader/co-lead DM notifications", () => {
     expect(emailFrom(fetchMock)).toBeUndefined();
   });
 });
+
+// ============================================================================
+// Issue #661 — full message in previews & notifications
+// ============================================================================
+//
+// The message body used to be sliced to 100 chars before it reached ANY
+// notification surface, so the "would like to chat" email quoted a half-word
+// with no "…". Emails now get the whole message (1000-char safety cap); the
+// push gets a 200-char, always-ellipsized excerpt.
+
+describe("full message in previews & notifications (#661)", () => {
+  /** Longer than the old 100-char cut, shorter than the new caps. */
+  const LONG_MESSAGE =
+    "Hi there, I have been going through a really hard week at work. " +
+    "Please keep me in prayers, I will be back next week for sure.";
+
+  test("chat-request email quotes the whole message, not the first 100 chars", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, user2Id, communityId } = await seedTestData(t);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: "x" }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enableRecipientNotifications(t, user2Id, "recipient@example.com", "full-661");
+    const channelId = await seedDmRequest(t, {
+      communityId,
+      senderId: userId,
+      recipientId: user2Id,
+    });
+
+    await fireDmMessage(t, {
+      channelId,
+      senderId: userId,
+      content: LONG_MESSAGE,
+      senderName: "Test User",
+    });
+
+    expect(LONG_MESSAGE.length).toBeGreaterThan(100);
+    const email = emailFrom(fetchMock);
+    expect(email?.html).toContain("Please keep me in prayers");
+    expect(email?.html).toContain(LONG_MESSAGE);
+    // Nothing was shortened, so no ellipsis was appended to the quote.
+    expect(email?.html).not.toContain(`${LONG_MESSAGE}…`);
+  });
+
+  test("email caps a runaway message at ~1000 chars and ends in an ellipsis", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, user2Id, communityId } = await seedTestData(t);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: "x" }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enableRecipientNotifications(t, user2Id, "recipient@example.com", "cap-661");
+    const channelId = await seedDmRequest(t, {
+      communityId,
+      senderId: userId,
+      recipientId: user2Id,
+    });
+
+    await fireDmMessage(t, {
+      channelId,
+      senderId: userId,
+      content: "A".repeat(1500),
+      senderName: "Test User",
+    });
+
+    const email = emailFrom(fetchMock);
+    expect(email?.html).toContain(`${"A".repeat(999)}…`);
+    expect(email?.html).not.toContain("A".repeat(1001));
+  });
+
+  test("push body shows ~200 chars and always ends in an ellipsis when shortened", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, user2Id, communityId } = await seedTestData(t);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: "x" }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enableRecipientNotifications(t, user2Id, "recipient@example.com", "push-661");
+    const channelId = await seedDmRequest(t, {
+      communityId,
+      senderId: userId,
+      recipientId: user2Id,
+    });
+
+    await fireDmMessage(t, {
+      channelId,
+      senderId: userId,
+      content: "B".repeat(500),
+      senderName: "Test User",
+    });
+
+    const push = pushFrom(fetchMock);
+    // "would like to chat: " prefix + a 200-char ellipsized excerpt.
+    expect(push?.body).toBe(`would like to chat: ${"B".repeat(199)}…`);
+  });
+
+  test("group push carries the short excerpt while the mention email carries the full body", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, user2Id, channelId } = await seedTestData(t);
+    const now = Date.now();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: "x" }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enableRecipientNotifications(t, user2Id, "mentioned@example.com", "mention-661");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("chatReadState", {
+        channelId,
+        userId: user2Id,
+        lastReadAt: now,
+        unreadCount: 0,
+      });
+    });
+
+    const essay = "C".repeat(400);
+    const messageId = await t.run(async (ctx) => {
+      return await ctx.db.insert("chatMessages", {
+        channelId,
+        senderId: userId,
+        content: essay,
+        contentType: "text",
+        createdAt: now,
+        isDeleted: false,
+        senderName: "Test User",
+        mentionedUserIds: [user2Id],
+      });
+    });
+
+    await t.mutation(internal.functions.messaging.events.onMessageSent, {
+      messageId,
+      channelId,
+      senderId: userId,
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    // Push: 200-char ellipsized excerpt under the "Group: Channel" line.
+    const push = pushFrom(fetchMock);
+    expect(push?.body).toBe(`Test Group: General\n${"C".repeat(199)}…`);
+
+    // Email: the full 400-char body, still HTML-escaped by the template.
+    const email = emailFrom(fetchMock);
+    expect(email?.html).toContain(essay);
+  });
+
+  test("emails keep escaping the longer body", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, user2Id, communityId } = await seedTestData(t);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: "x" }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enableRecipientNotifications(t, user2Id, "recipient@example.com", "escape-661");
+    const channelId = await seedDmRequest(t, {
+      communityId,
+      senderId: userId,
+      recipientId: user2Id,
+    });
+
+    await fireDmMessage(t, {
+      channelId,
+      senderId: userId,
+      content: `${"D".repeat(120)}<script>alert(1)</script>`,
+      senderName: "Test User",
+    });
+
+    const email = emailFrom(fetchMock);
+    expect(email?.html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(email?.html).not.toContain("<script>alert(1)</script>");
+  });
+
+  test("an emoji at the push cut boundary is not split", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { userId, user2Id, communityId } = await seedTestData(t);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: "x" }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await enableRecipientNotifications(t, user2Id, "recipient@example.com", "emoji-661");
+    const channelId = await seedDmRequest(t, {
+      communityId,
+      senderId: userId,
+      recipientId: user2Id,
+    });
+
+    // 🙏 is a surrogate pair. Land it exactly across the 199-char cut so a
+    // naive slice would keep only its high surrogate and render "�".
+    await fireDmMessage(t, {
+      channelId,
+      senderId: userId,
+      content: `${"E".repeat(198)}🙏${"F".repeat(50)}`,
+      senderName: "Test User",
+    });
+
+    const push = pushFrom(fetchMock);
+    expect(push?.body).toBe(`would like to chat: ${"E".repeat(198)}…`);
+    // No lone surrogate anywhere in the body.
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(String(push?.body))).toBe(
+      false,
+    );
+  });
+});

--- a/apps/convex/__tests__/messaging/messages.test.ts
+++ b/apps/convex/__tests__/messaging/messages.test.ts
@@ -286,7 +286,9 @@ describe("Send Message", () => {
     const t = convexTest(schema, modules);
     const { channelId, accessToken } = await seedTestData(t);
 
-    const longMessage = "A".repeat(150);
+    // Inbox rows render 2 lines of this preview (#661), so the stored cap is
+    // 200 — a 150-char message now survives whole.
+    const longMessage = "A".repeat(300);
 
     await t.mutation(api.functions.messaging.messages.sendMessage, {
       token: accessToken,
@@ -302,7 +304,58 @@ describe("Send Message", () => {
       return await ctx.db.get(channelId);
     });
 
-    expect(channel?.lastMessagePreview?.length).toBeLessThanOrEqual(100);
+    expect(channel?.lastMessagePreview).toBe("A".repeat(200));
+  });
+
+  test("stores a 2-line-worth preview without splitting an emoji (#661)", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { channelId, accessToken } = await seedTestData(t);
+
+    // 🙏 straddles the 200-char cut: a naive slice keeps half of it.
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: accessToken,
+      channelId,
+      content: `${"A".repeat(199)}🙏${"B".repeat(50)}`,
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const channel = await t.run(async (ctx) => {
+      return await ctx.db.get(channelId);
+    });
+
+    expect(channel?.lastMessagePreview).toBe("A".repeat(199));
+    expect(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(
+        String(channel?.lastMessagePreview),
+      ),
+    ).toBe(false);
+  });
+
+  test("keeps canned previews for non-text messages (#661)", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { channelId, accessToken } = await seedTestData(t);
+
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: accessToken,
+      channelId,
+      content: "",
+      attachments: [
+        { type: "image", url: "https://example.com/a.jpg", name: "a.jpg" },
+      ],
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const channel = await t.run(async (ctx) => {
+      return await ctx.db.get(channelId);
+    });
+
+    expect(channel?.lastMessagePreview).toBe("Sent a photo");
   });
 
   test("should extract mentions from message", async () => {

--- a/apps/convex/__tests__/text-preview.test.ts
+++ b/apps/convex/__tests__/text-preview.test.ts
@@ -70,4 +70,35 @@ describe("truncateWithEllipsis", () => {
     expect(out).toBe(`${"A".repeat(198)}…`);
     expect(hasLoneSurrogate(out)).toBe(false);
   });
+
+  it("backs up to the word boundary instead of chopping a word", () => {
+    // The budget lands inside "prayers", which is exactly the mid-word cut
+    // issue #661 reported — just at a later offset than the old 100-char one.
+    expect(truncateWithEllipsis("Please keep me in prayers tonight", 22)).toBe(
+      "Please keep me in…",
+    );
+  });
+
+  it("does not back up when the cut already lands between words", () => {
+    expect(truncateWithEllipsis("Please keep me in prayers", 19)).toBe(
+      "Please keep me in…",
+    );
+  });
+
+  it("hard-cuts a single token too long to back up out of", () => {
+    // No space within the search window, so shortening to a word boundary
+    // would throw away almost the whole preview.
+    const url = `https://example.com/${"a".repeat(300)}`;
+    const out = truncateWithEllipsis(url, 200);
+    expect(out).toBe(`${url.slice(0, 199)}…`);
+    expect(out.length).toBe(200);
+  });
+
+  it("keeps the word-boundary cut inside the budget", () => {
+    const words = "lorem ipsum dolor sit amet ".repeat(20);
+    const out = truncateWithEllipsis(words, 200);
+    expect(out.length).toBeLessThanOrEqual(200);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out.slice(0, -1).endsWith(" ")).toBe(false);
+  });
 });

--- a/apps/convex/__tests__/text-preview.test.ts
+++ b/apps/convex/__tests__/text-preview.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Character-safe truncation (issue #661).
+ *
+ * Every surface that still shortens a message body (push, stored inbox preview,
+ * the email safety cap) goes through these helpers, so a cut must never leave a
+ * broken glyph.
+ */
+
+import { describe, it, expect } from "vitest";
+import { truncateChars, truncateWithEllipsis } from "../lib/textPreview";
+
+/** True when the string ends with (or contains) an unpaired surrogate. */
+function hasLoneSurrogate(s: string): boolean {
+  return (
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(s) ||
+    /(?:^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(s)
+  );
+}
+
+describe("truncateChars", () => {
+  it("returns short text untouched", () => {
+    expect(truncateChars("hello", 200)).toBe("hello");
+  });
+
+  it("cuts at the limit when nothing straddles the boundary", () => {
+    expect(truncateChars("A".repeat(300), 200)).toBe("A".repeat(200));
+  });
+
+  it("never splits a surrogate pair at the cut point", () => {
+    // 🙏 occupies units 199 and 200, so a naive slice(0, 200) keeps half of it.
+    const text = `${"A".repeat(199)}🙏 tail`;
+    const out = truncateChars(text, 200);
+    expect(out).toBe("A".repeat(199));
+    expect(hasLoneSurrogate(out)).toBe(false);
+  });
+
+  it("keeps a whole emoji that fits", () => {
+    const text = `${"A".repeat(198)}🙏 tail`;
+    expect(truncateChars(text, 200)).toBe(`${"A".repeat(198)}🙏`);
+  });
+
+  it("drops a dangling zero-width joiner rather than orphaning it", () => {
+    // 👨‍👩‍👧 = 👨 ZWJ 👩 ZWJ 👧 (8 UTF-16 units). Cutting after the second ZWJ
+    // would leave the joiner with nothing to join.
+    const family = "👨‍👩‍👧";
+    const out = truncateChars(family, 5);
+    expect(out).toBe("👨‍👩");
+    expect(out.endsWith("‍")).toBe(false);
+  });
+
+  it("returns empty for a non-positive limit", () => {
+    expect(truncateChars("anything", 0)).toBe("");
+  });
+});
+
+describe("truncateWithEllipsis", () => {
+  it("adds no ellipsis when the text fits", () => {
+    expect(truncateWithEllipsis("hello", 200)).toBe("hello");
+    expect(truncateWithEllipsis("A".repeat(200), 200)).toBe("A".repeat(200));
+  });
+
+  it("ellipsizes within the budget", () => {
+    const out = truncateWithEllipsis("A".repeat(300), 200);
+    expect(out).toBe(`${"A".repeat(199)}…`);
+    expect(out.length).toBe(200);
+  });
+
+  it("ellipsizes without splitting an emoji at the boundary", () => {
+    const out = truncateWithEllipsis(`${"A".repeat(198)}🙏${"B".repeat(50)}`, 200);
+    expect(out).toBe(`${"A".repeat(198)}…`);
+    expect(hasLoneSurrogate(out)).toBe(false);
+  });
+});

--- a/apps/convex/functions/messaging/events.ts
+++ b/apps/convex/functions/messaging/events.ts
@@ -24,12 +24,24 @@ import {
   getLeaderDmRelationship,
   type LeaderDmRelationship,
 } from "../../lib/leaderDm";
+import { truncateWithEllipsis } from "../../lib/textPreview";
 
 // ============================================================================
 // Constants
 // ============================================================================
 
-const MAX_PREVIEW_LENGTH = 100;
+/**
+ * Emails have no space limit, so the quote box shows the whole message — this
+ * is only a runaway-length guard for a pasted essay, and it ellipsizes when hit.
+ */
+const MAX_EMAIL_PREVIEW_LENGTH = 1000;
+
+/**
+ * Push bodies are clipped again by iOS/Android on the lock screen, but we stop
+ * being the thing that cuts the message short: a generous cap that always ends
+ * in "…" so a shortened push reads as an intentional preview.
+ */
+const MAX_PUSH_PREVIEW_LENGTH = 200;
 
 /**
  * First-message notification copy per leadership relationship. The push keeps
@@ -149,9 +161,15 @@ export const onMessageSent = internalMutation({
       }
     }
 
-    // Generate preview for notifications (but don't update channel - sendMessage already does it
-    // with smart previews like "Sent a photo" or "Sent X files")
-    const preview = message.content.slice(0, MAX_PREVIEW_LENGTH);
+    // Generate previews for notifications (but don't update channel - sendMessage
+    // already does it with smart previews like "Sent a photo" or "Sent X files").
+    // Two sizes: `preview` is the email-grade body (effectively the whole
+    // message), `pushPreview` is the shortened, always-ellipsized push body.
+    const preview = truncateWithEllipsis(
+      message.content,
+      MAX_EMAIL_PREVIEW_LENGTH,
+    );
+    const pushPreview = truncateWithEllipsis(preview, MAX_PUSH_PREVIEW_LENGTH);
 
     // Get all channel members (except sender if there is one). Muted members
     // stay in this list so their unread bookkeeping keeps running — mute
@@ -332,6 +350,7 @@ export const onMessageSent = internalMutation({
             messageId: args.messageId,
             senderName,
             messagePreview: preview,
+            messagePushPreview: pushPreview,
             senderAvatarUrl,
             groupId: bucket.groupId,
             groupName: bucket.groupName,
@@ -473,6 +492,7 @@ export const onMessageSent = internalMutation({
           messageId: args.messageId,
           senderName,
           messagePreview: preview,
+          messagePushPreview: pushPreview,
           senderAvatarUrl,
           groupId: group?._id,
           groupName: group?.name || channel?.name || 'Group Chat',
@@ -498,7 +518,10 @@ export const sendMessageNotifications = internalAction({
     channelId: v.id("chatChannels"),
     messageId: v.id("chatMessages"),
     senderName: v.string(),
+    /** Email-grade body: effectively the whole message (1000-char safety cap). */
     messagePreview: v.string(),
+    /** Push-grade body: shortened + always ellipsized. Falls back to the above. */
+    messagePushPreview: v.optional(v.string()),
     senderAvatarUrl: v.optional(v.string()),
     groupId: v.optional(v.id("groups")),
     groupName: v.string(),
@@ -544,6 +567,7 @@ export const sendMessageNotifications = internalAction({
           senderName: args.senderName,
           senderAvatarUrl: args.senderAvatarUrl,
           messagePreview: args.messagePreview,
+          messagePushPreview: args.messagePushPreview,
           groupId: args.groupId,
           groupName: args.groupName,
           channelId: args.channelId,
@@ -567,6 +591,7 @@ export const sendMessageNotifications = internalAction({
           senderName: args.senderName,
           senderAvatarUrl: args.senderAvatarUrl,
           messagePreview: args.messagePreview,
+          messagePushPreview: args.messagePushPreview,
           groupId: args.groupId,
           groupName: args.groupName,
           channelId: args.channelId,
@@ -589,10 +614,10 @@ export const sendMessageNotifications = internalAction({
 
 /**
  * Truncate a string to `max` chars, suffixing "…" if truncation occurred.
+ * Character-safe, so a cut at an emoji boundary never leaves a broken glyph.
  */
 function truncateForBody(text: string, max: number): string {
-  if (text.length <= max) return text;
-  return text.slice(0, Math.max(0, max - 1)) + "…";
+  return truncateWithEllipsis(text, max);
 }
 
 /**
@@ -651,10 +676,13 @@ export const sendAdHocMessageNotifications = internalAction({
       `[sendAdHocMessageNotifications] channelId=${args.channelId}, pending=${args.pendingRecipients.length}, accepted=${args.acceptedRecipients.length}`,
     );
 
-    // Truncate the body's message excerpt. Match the previous fanout's
-    // ~120-char ceiling so iOS/Android push surfaces don't ellipsize twice.
-    const MAX_BODY_PREVIEW = 120;
-    const previewBody = truncateForBody(args.messagePreview, MAX_BODY_PREVIEW);
+    // Truncate the *push* body's message excerpt. The email below deliberately
+    // uses the untruncated `args.messagePreview` — emails have room for the
+    // whole message; only the push needs a ceiling (and the OS clips it again).
+    const previewBody = truncateForBody(
+      args.messagePreview,
+      MAX_PUSH_PREVIEW_LENGTH,
+    );
 
     // Resolve channel + non-sender accepted member names so group_dms can
     // render "<sender> in <channelName | first-two-others>" titles when

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -29,6 +29,7 @@ import { canAccessEventChannel } from "./eventChat";
 import { isCommunityAdminForChannel } from "./helpers";
 import { resolveChannelCommunityId } from "../../lib/messaging/communityScope";
 import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
+import { truncateChars } from "../../lib/textPreview";
 
 /**
  * Decorate a list of message rows with `senderNotificationsDisabled` so chat
@@ -141,7 +142,11 @@ async function canAccessMeetingChat(
 // Constants
 // ============================================================================
 
-const MAX_PREVIEW_LENGTH = 100;
+/**
+ * Stored `lastMessagePreview` budget. Inbox rows render 2 lines of this, so it
+ * needs enough text to fill them — the row itself clamps what's visible.
+ */
+const MAX_PREVIEW_LENGTH = 200;
 const DEFAULT_PAGE_SIZE = 50;
 
 // Message type for preview generation (minimal interface for preview logic)
@@ -178,7 +183,7 @@ export function generateMessagePreview(message: MessageForPreview): string {
 
     if (imageCount > 0 && content.trim()) {
       // Has both images and text - show text
-      return content.slice(0, MAX_PREVIEW_LENGTH);
+      return truncateChars(content, MAX_PREVIEW_LENGTH);
     } else if (imageCount > 0) {
       // Only images
       return imageCount === 1 ? "Sent a photo" : `Sent ${imageCount} photos`;
@@ -192,25 +197,25 @@ export function generateMessagePreview(message: MessageForPreview): string {
       // Documents and other files
       return fileCount === 1 ? "Sent a file" : `Sent ${fileCount} files`;
     } else {
-      return content.slice(0, MAX_PREVIEW_LENGTH);
+      return truncateChars(content, MAX_PREVIEW_LENGTH);
     }
   } else if (DOMAIN_CONFIG.eventLinkRegexSingle().test(content)) {
     // Event link shared
     return content.trim() === content.match(DOMAIN_CONFIG.eventLinkRegexSingle())?.[0]
       ? "Shared an event"
-      : content.slice(0, MAX_PREVIEW_LENGTH);
+      : truncateChars(content, MAX_PREVIEW_LENGTH);
   } else if (DOMAIN_CONFIG.toolLinkRegexSingle().test(content)) {
     // Tool link shared (Run Sheet, Resource)
     return content.trim() === content.match(DOMAIN_CONFIG.toolLinkRegexSingle())?.[0]
       ? "Shared a tool"
-      : content.slice(0, MAX_PREVIEW_LENGTH);
+      : truncateChars(content, MAX_PREVIEW_LENGTH);
   } else if (DOMAIN_CONFIG.groupLinkRegexSingle().test(content)) {
     // Group link shared
     return content.trim() === content.match(DOMAIN_CONFIG.groupLinkRegexSingle())?.[0]
       ? "Shared a group"
-      : content.slice(0, MAX_PREVIEW_LENGTH);
+      : truncateChars(content, MAX_PREVIEW_LENGTH);
   } else {
-    return content.slice(0, MAX_PREVIEW_LENGTH);
+    return truncateChars(content, MAX_PREVIEW_LENGTH);
   }
 }
 
@@ -1801,7 +1806,7 @@ export const sendSystemMessage = internalMutation({
     // Update channel metadata
     await ctx.db.patch(args.channelId, {
       lastMessageAt: now,
-      lastMessagePreview: args.content.substring(0, MAX_PREVIEW_LENGTH),
+      lastMessagePreview: truncateChars(args.content, MAX_PREVIEW_LENGTH),
       updatedAt: now,
     });
 

--- a/apps/convex/lib/notifications/definitions.ts
+++ b/apps/convex/lib/notifications/definitions.ts
@@ -41,7 +41,13 @@ interface MessageData {
   senderName: string;
   senderAvatarUrl?: string;
   groupName: string;
+  /** Email-grade body: effectively the whole message (1000-char safety cap). */
   messagePreview: string;
+  /**
+   * Push-grade body: shortened + always ellipsized. Optional so older/other
+   * callers keep working — the push falls back to `messagePreview`.
+   */
+  messagePushPreview?: string;
   groupId: string;
   channelId: string;
   channelName?: string;
@@ -332,7 +338,10 @@ function getChannelLabel(data: MessageData): string {
 }
 
 function formatChatPushBody(data: MessageData): string {
-  return `${data.groupName}: ${getChannelLabel(data)}\n${data.messagePreview}`;
+  // The push gets the shortened, ellipsized excerpt; the mention email below
+  // gets the full `messagePreview`.
+  const body = data.messagePushPreview ?? data.messagePreview;
+  return `${data.groupName}: ${getChannelLabel(data)}\n${body}`;
 }
 
 /**

--- a/apps/convex/lib/notifications/definitions.ts
+++ b/apps/convex/lib/notifications/definitions.ts
@@ -1,5 +1,6 @@
 import type { NotificationDefinition } from './types';
 import { escapeHtml } from './emailTemplates';
+import { truncateWithEllipsis } from '../textPreview';
 
 // ============================================================================
 // Data Types
@@ -416,9 +417,7 @@ export const mention: NotificationDefinition<MessageData> = {
         <h1 class="heading">${escapeHtml(ctx.data.senderName)} mentioned you</h1>
         <p class="text">${greeting}</p>
         <p class="text">${escapeHtml(ctx.data.senderName)} mentioned you in ${escapeHtml(ctx.data.groupName)}:</p>
-        <p class="text" style="background-color: #f5f5f5; padding: 16px; border-radius: 8px; font-style: italic;">
-          "${escapeHtml(ctx.data.messagePreview)}"
-        </p>
+        <p class="text" style="background-color: #f5f5f5; padding: 16px; border-radius: 8px; font-style: italic; white-space: pre-wrap;">"${escapeHtml(ctx.data.messagePreview)}"</p>
       `),
       };
     },
@@ -606,7 +605,7 @@ export const contentReport: NotificationDefinition<ContentReportData> = {
   formatters: {
     push: (ctx) => ({
       title: 'Content Reported',
-      body: `${ctx.data.reporterName} reported: "${ctx.data.messagePreview.slice(0, 50)}..."`,
+      body: `${ctx.data.reporterName} reported: "${truncateWithEllipsis(ctx.data.messagePreview, 50)}"`,
       data: {
         type: 'content_report',
         communityId: ctx.data.communityId,

--- a/apps/convex/lib/notifications/emailTemplates.ts
+++ b/apps/convex/lib/notifications/emailTemplates.ts
@@ -69,6 +69,20 @@ export const baseStyles = {
     border-top: 1px solid #e6ebf1;
     margin: 20px 0;
   `,
+  /**
+   * The quoted message body inside a `messageBox`. `white-space: pre-wrap`
+   * is load-bearing now that emails carry the *whole* message: without it a
+   * multi-paragraph message collapses into one run-on blob. Interpolate the
+   * escaped text with NO surrounding whitespace — `pre-wrap` would render the
+   * template literal's own newlines and indentation too.
+   */
+  quote: `
+    color: #1a1a1a;
+    font-size: 15px;
+    line-height: 24px;
+    margin: 0;
+    white-space: pre-wrap;
+  `,
   footer: `
     text-align: center;
     color: #8898aa;
@@ -195,9 +209,7 @@ export function chatRequestEmail(data: {
     <p style="${baseStyles.text}">${greeting}</p>
     <h1 style="${baseStyles.heading}">${escapeHtml(data.senderName)} ${channelLine}</h1>
     <div style="${baseStyles.messageBox}">
-      <p style="color: #1a1a1a; font-size: 15px; line-height: 24px; margin: 0;">
-        "${escapeHtml(data.messagePreview)}"
-      </p>
+      <p style="${baseStyles.quote}">"${escapeHtml(data.messagePreview)}"</p>
     </div>
     <p style="${baseStyles.text}">
       Open Togather to accept the chat, reply, or block. Until you accept,
@@ -238,9 +250,7 @@ export function leaderDmEmail(data: {
     <h1 style="${baseStyles.heading}">${heading}</h1>
     <p style="${baseStyles.text}">${escapeHtml(data.bodyLine)}</p>
     <div style="${baseStyles.messageBox}">
-      <p style="color: #1a1a1a; font-size: 15px; line-height: 24px; margin: 0;">
-        "${escapeHtml(data.messagePreview)}"
-      </p>
+      <p style="${baseStyles.quote}">"${escapeHtml(data.messagePreview)}"</p>
     </div>
     <p style="${baseStyles.text}">
       It's already in your inbox — no request to accept. Open Togather to reply.

--- a/apps/convex/lib/textPreview.ts
+++ b/apps/convex/lib/textPreview.ts
@@ -1,0 +1,53 @@
+/**
+ * Character-safe truncation for message previews.
+ *
+ * JS strings are UTF-16, so a naive `slice(0, n)` can cut an emoji in half and
+ * leave a lone surrogate that renders as "�" in an email, a push body, or an
+ * inbox row. Every place we still shorten a message body goes through here.
+ *
+ * We deliberately avoid `Intl.Segmenter` (grapheme clusters): the Convex
+ * runtime's Intl support is not something we want to depend on for the hot
+ * notification path, and the issue's requirement is only that a cut never
+ * leaves a broken character. Dropping a lone surrogate and a dangling
+ * zero-width joiner covers that — cutting a 👨‍👩‍👧 family emoji short yields
+ * 👨‍👩 (two people), which renders fine, not mojibake.
+ */
+
+/** UTF-16 high surrogate: the first half of an astral character (most emoji). */
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+/**
+ * Truncate to at most `max` UTF-16 units without splitting a character.
+ * Adds no ellipsis — use {@link truncateWithEllipsis} when the cut should be
+ * visible to the reader.
+ */
+export function truncateChars(text: string, max: number): string {
+  if (max <= 0) return "";
+  if (text.length <= max) return text;
+
+  let end = max;
+  // A high surrogate at the cut point has lost its low surrogate.
+  if (isHighSurrogate(text.charCodeAt(end - 1))) end -= 1;
+
+  let out = text.slice(0, end);
+  // A trailing ZWJ is the glue of an emoji sequence whose tail we just dropped.
+  while (out.length > 0 && out.charCodeAt(out.length - 1) === 0x200d) {
+    out = out.slice(0, -1);
+    // The joiner may itself have been preceded by a now-orphaned surrogate half.
+    if (out.length > 0 && isHighSurrogate(out.charCodeAt(out.length - 1))) {
+      out = out.slice(0, -1);
+    }
+  }
+  return out;
+}
+
+/**
+ * Truncate to at most `max` UTF-16 units (ellipsis included in the budget),
+ * suffixing "…" only when the text was actually shortened.
+ */
+export function truncateWithEllipsis(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return truncateChars(text, Math.max(0, max - 1)) + "…";
+}

--- a/apps/convex/lib/textPreview.ts
+++ b/apps/convex/lib/textPreview.ts
@@ -44,10 +44,36 @@ export function truncateChars(text: string, max: number): string {
 }
 
 /**
+ * How much of the budget we're willing to give up to land on a word boundary.
+ * A cut inside the last 25% of the text backs up to the preceding space; a
+ * single token longer than that (a URL, a wall of CJK with no spaces) gets the
+ * character-safe hard cut instead of being shortened to almost nothing.
+ */
+const WORD_BOUNDARY_SEARCH_RATIO = 0.25;
+
+/**
  * Truncate to at most `max` UTF-16 units (ellipsis included in the budget),
  * suffixing "…" only when the text was actually shortened.
+ *
+ * Prefers a word boundary: issue #661's complaint was messages ending
+ * mid-word, and a cut at char 1000 is just as chopped as a cut at char 100.
+ * Falls back to the hard character-safe cut when there's no space to back up
+ * to within {@link WORD_BOUNDARY_SEARCH_RATIO} of the budget.
  */
 export function truncateWithEllipsis(text: string, max: number): string {
   if (text.length <= max) return text;
-  return truncateChars(text, Math.max(0, max - 1)) + "…";
+
+  const hardCut = truncateChars(text, Math.max(0, max - 1));
+  // Only a cut that lands *inside* a word needs backing up — if the next
+  // character is whitespace we already ended cleanly.
+  if (/\s/.test(text.charAt(hardCut.length))) {
+    return hardCut.trimEnd() + "…";
+  }
+
+  const floor = Math.floor(hardCut.length * (1 - WORD_BOUNDARY_SEARCH_RATIO));
+  const lastSpace = hardCut.search(/\s+\S*$/);
+  if (lastSpace > 0 && lastSpace >= floor) {
+    return hardCut.slice(0, lastSpace) + "…";
+  }
+  return hardCut + "…";
 }

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -2247,7 +2247,7 @@ function EventInboxRowItem({ row, isActive, whatsappShellEnabled }: EventInboxRo
             { color: isPast ? colors.textTertiary : colors.textSecondary },
             hasUnread && !isPast && { fontWeight: "600", color: colors.text },
           ]}
-          numberOfLines={1}
+          numberOfLines={2}
         >
           {messagePreview}
         </Text>
@@ -2477,7 +2477,7 @@ function DirectMessageRow({ row, primaryColor, colors, whatsappShellEnabled }: D
           )}
         </View>
         <Text
-          numberOfLines={1}
+          numberOfLines={2}
           style={[styles.dmRowPreview, { color: colors.textSecondary }]}
         >
           {previewWithSender}

--- a/apps/mobile/features/chat/components/GroupedInboxItem.tsx
+++ b/apps/mobile/features/chat/components/GroupedInboxItem.tsx
@@ -751,7 +751,7 @@ function GroupedInboxItemInner({
           <View style={styles.bottomRow}>
             <Text
               style={[styles.lastMessage, { color: colors.textSecondary }, hasUnread && { fontWeight: "600", color: colors.text }]}
-              numberOfLines={1}
+              numberOfLines={2}
             >
               {getMessagePreview(primaryChannel)}
             </Text>
@@ -1089,7 +1089,7 @@ function GroupedInboxItemInner({
           <View style={styles.bottomRow}>
             <Text
               style={[styles.lastMessage, { color: colors.textSecondary }, mainHasUnread && { fontWeight: "600", color: colors.text }]}
-              numberOfLines={1}
+              numberOfLines={2}
             >
               {getMessagePreview(mainChannel)}
             </Text>
@@ -1149,7 +1149,7 @@ function GroupedInboxItemInner({
               <Text style={[styles.subChannelName, { color: colors.text }, hasUnread && styles.subChannelNameUnread]}>{channel.name}</Text>
               <Text
                 style={[styles.subChannelPreview, { color: colors.textSecondary }, hasUnread && { fontWeight: "500", color: colors.text }]}
-                numberOfLines={1}
+                numberOfLines={2}
               >
                 {getMessagePreview(channel)}
               </Text>


### PR DESCRIPTION
## Summary

- Notification **emails** (chat-request, leader-DM, @mention) now quote the whole message — safety cap ~1000 chars, "…" only when the cap is hit (was: hard `slice(0,100)` with no ellipsis, cutting mid-word).
- **Push** bodies carry up to 200 chars and always end "…" when shortened (new optional `messagePushPreview` in the notification definitions; email keeps the full value).
- **Inbox / group-list rows** show up to 2 lines of the message preview (5 `numberOfLines` clamps changed; name/title clamps untouched); stored `lastMessagePreview` raised 100 → 200 so rows have content to fill.
- New `apps/convex/lib/textPreview.ts` — UTF-16-safe truncation (no split surrogate pairs / dangling ZWJ), used at every remaining cut point. No new dependencies.

## Acceptance criteria

From issue #661's "Done when" checklist ("Done when" is its criteria section):

- [x] Email quote box shows the whole message up to ~1000 chars, never a mid-word cut, "…" only at the cap — incl. a test using the reported "Please keep me in prayers" sentence.
- [x] Push shows noticeably more (200 chars via `truncateForBody`) and ends "…" when shortened.
- [x] Inbox/group rows show up to 2 lines ending "…"; row height is padding-driven so rows grow by one line, list layout unchanged.
- [x] Non-text messages keep "Sent a photo" / "Shared an event" / etc. in all three surfaces (canned-label branches untouched, test added).
- [x] Emoji at a cut boundary never renders broken — helper tested at push and stored-preview boundaries (🙏 across the cut; regex asserts no lone surrogate).
- [x] Group message, 1:1 DM request, and @mention email paths all read fully.

## Evidence

### Tests
```
apps/convex: npx vitest run __tests__/messaging __tests__/mention-email.test.ts
             __tests__/email-render.test.ts __tests__/moderation.test.ts
             __tests__/text-preview.test.ts
             -> 27 files, 661 tests passed (17 new/updated for this change)
typecheck:   apps/convex tsc clean; apps/mobile zero new errors in touched files
```

### Other consumers audited
SMS channel is unimplemented (`lib/notifications/send.ts:238`); event blasts and moderation notifications slice on their own separate paths (untouched); CLI channel list re-slices to 50 locally. `messagePushPreview` is optional so unupdated callers fall back to old behavior.

### Verification status
> ⚠️ Backend + prop-only mobile change; the 2-line row rendering is reasoned
> from styles, not screenshotted (no Expo session was run). Worth a quick
> visual check on staging/web before relying on it.

### Deploy note
Touches `apps/convex/**` **function logic only** — no schema, crons, or migrations. Merging deploys to staging immediately (no preview step); tests are green.

Known one-line follow-up (not in this PR): `apps/convex/schema.ts:1722` carries a stale `// First 100 chars` comment on `lastMessagePreview` — schema.ts is CODEOWNERS-protected, left for a human edit.

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)
