### PR TITLE
fix(scheduling): make runsheet dropdown selectable on desktop web

### DIFF
--- a/apps/mobile/features/scheduling/components/AnchoredMenu.tsx
+++ b/apps/mobile/features/scheduling/components/AnchoredMenu.tsx
@@ -9,10 +9,11 @@
  *
  * It renders inside a transparent `Modal` so it overlays the app and is never
  * clipped by the table card's `overflow: "hidden"`, yet a full-screen
- * transparent backdrop dismisses it on an outside press. The menu box is
- * absolutely positioned at the anchor's measured window rect (below by default,
- * flipped above when near the viewport bottom) and caps its height with an
- * internal scroll so long Team / Role lists stay usable.
+ * transparent backdrop — a sibling behind the menu, never its parent (see the
+ * render note) — dismisses it on an outside press. The menu box is absolutely
+ * positioned at the anchor's measured window rect (below by default, flipped
+ * above when near the viewport bottom) and caps its height with an internal
+ * scroll so long Team / Role lists stay usable.
  *
  * The caller measures its anchor with `ref.measureInWindow` (see `measureAnchor`)
  * and passes the resulting `AnchorRect`. Selection semantics mirror the old
@@ -29,7 +30,6 @@ import {
   ScrollView,
   Platform,
   useWindowDimensions,
-  type GestureResponderEvent,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@hooks/useTheme";
@@ -123,9 +123,26 @@ export function AnchoredMenu({
 
   return (
     <RNModal transparent visible animationType="fade" onRequestClose={onClose}>
-      <Pressable style={styles.backdrop} onPress={onClose}>
+      {/*
+       * Backdrop and menu are SIBLINGS, not nested — the menu must not live
+       * inside the backdrop Pressable. An earlier version nested them and
+       * relied on `e.stopPropagation()` to keep an option press from bubbling
+       * to the backdrop's `onClose`. On react-native-web that RN
+       * `stopPropagation` does not reliably map to DOM event propagation, so
+       * every option click bubbled up and closed the menu instead of
+       * selecting — the dropdown looked dead on desktop web. Mirroring the
+       * sibling-backdrop layout of `CustomModal` (an absolute-fill backdrop
+       * behind an absolutely-positioned menu) makes option presses land
+       * directly on the rows and outside presses hit the backdrop, with no
+       * propagation trickery on any platform.
+       */}
+      <View style={styles.root}>
         <Pressable
-          onPress={(e: GestureResponderEvent) => e.stopPropagation()}
+          testID="anchored-menu-backdrop"
+          style={styles.backdrop}
+          onPress={onClose}
+        />
+        <View
           style={[
             styles.menu,
             positionStyle,
@@ -216,14 +233,17 @@ export function AnchoredMenu({
               })
             )}
           </ScrollView>
-        </Pressable>
-      </Pressable>
+        </View>
+      </View>
     </RNModal>
   );
 }
 
 const styles = StyleSheet.create({
-  backdrop: { flex: 1 },
+  root: { flex: 1 },
+  // Absolute-fill sibling behind the menu (not a parent of it) so an outside
+  // press dismisses without swallowing option presses. See render note.
+  backdrop: { ...StyleSheet.absoluteFillObject },
   menu: {
     position: "absolute",
     borderWidth: StyleSheet.hairlineWidth,

--- a/apps/mobile/features/scheduling/components/__tests__/AnchoredMenu.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/AnchoredMenu.test.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { AnchoredMenu, type AnchoredMenuOption } from "../AnchoredMenu";
+
+jest.mock("@hooks/useTheme", () => ({
+  useTheme: () => ({
+    colors: {
+      text: "#000",
+      textSecondary: "#555",
+      textTertiary: "#999",
+      surface: "#fff",
+      surfaceSecondary: "#eee",
+      border: "#ccc",
+      buttonPrimary: "#2563EB",
+    },
+  }),
+}));
+
+const ANCHOR = { x: 40, y: 120, width: 160, height: 32 };
+const OPTIONS: AnchoredMenuOption[] = [
+  { id: "pre", name: "Pre-service" },
+  { id: "service", name: "Service" },
+  { id: "post", name: "Post-service" },
+];
+
+/**
+ * Regression guard for the desktop-web bug (issue #728): the backdrop and menu
+ * must be SIBLINGS so an option press selects instead of being swallowed by the
+ * backdrop's dismiss handler. When the menu was nested inside the backdrop
+ * Pressable, react-native-web's `stopPropagation` failed to stop DOM bubbling,
+ * so every option click closed the menu instead of selecting.
+ */
+describe("AnchoredMenu", () => {
+  it("selects an option (and does not dismiss) when a row is pressed", () => {
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+    const { getByText } = render(
+      <AnchoredMenu
+        anchor={ANCHOR}
+        options={OPTIONS}
+        selectedId="pre"
+        onSelect={onSelect}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.press(getByText("Service"));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith("service");
+    // The press must NOT bubble to the backdrop's dismiss handler.
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("dismisses when the backdrop is pressed", () => {
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <AnchoredMenu
+        anchor={ANCHOR}
+        options={OPTIONS}
+        selectedId="pre"
+        onSelect={onSelect}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.press(getByTestId("anchored-menu-backdrop"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("reports null for the empty option", () => {
+    const onSelect = jest.fn();
+    const { getByText } = render(
+      <AnchoredMenu
+        anchor={ANCHOR}
+        options={OPTIONS}
+        selectedId="service"
+        emptyOption={{ label: "No segment" }}
+        onSelect={onSelect}
+        onClose={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(getByText("No segment"));
+
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("toggles rows without dismissing in multi-select mode", () => {
+    const onToggle = jest.fn();
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+    const { getByText } = render(
+      <AnchoredMenu
+        anchor={ANCHOR}
+        options={OPTIONS}
+        selectedIds={["pre"]}
+        onSelect={onSelect}
+        onToggle={onToggle}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.press(getByText("Service"));
+
+    expect(onToggle).toHaveBeenCalledWith("service");
+    expect(onSelect).not.toHaveBeenCalled();
+    // Multi-select stays open — only an outside press closes it.
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/features/scheduling/components/__tests__/AnchoredMenu.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/AnchoredMenu.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render } from "@testing-library/react-native";
+import { fireEvent, render, within } from "@testing-library/react-native";
 import { AnchoredMenu, type AnchoredMenuOption } from "../AnchoredMenu";
 
 jest.mock("@hooks/useTheme", () => ({
@@ -24,13 +24,41 @@ const OPTIONS: AnchoredMenuOption[] = [
 ];
 
 /**
- * Regression guard for the desktop-web bug (issue #728): the backdrop and menu
- * must be SIBLINGS so an option press selects instead of being swallowed by the
- * backdrop's dismiss handler. When the menu was nested inside the backdrop
- * Pressable, react-native-web's `stopPropagation` failed to stop DOM bubbling,
- * so every option click closed the menu instead of selecting.
+ * The desktop-web bug (issue #728) was a DOM event-bubbling defect: with the
+ * menu nested INSIDE the backdrop Pressable, react-native-web's
+ * `stopPropagation` failed to stop a real option click from bubbling up to the
+ * backdrop's `onClose`, so every click dismissed the menu instead of selecting.
+ * The fix makes the backdrop and menu SIBLINGS.
+ *
+ * This preset renders through `react-test-renderer` (no DOM, no DOM bubbling)
+ * and `fireEvent.press` invokes only the nearest `onPress`, so the behavioral
+ * "select / dismiss" tests below CANNOT reproduce the bug — they document the
+ * contract but would stay green on the un-fixed nested tree too. The actual
+ * regression guard is the STRUCTURAL test ("keeps the backdrop … a sibling"):
+ * it asserts the option rows are not descendants of the backdrop, which is the
+ * one condition that fails the moment the buggy nesting comes back.
  */
 describe("AnchoredMenu", () => {
+  it("keeps the backdrop a sibling of the options, not their ancestor (regression guard for #728)", () => {
+    const { getByTestId } = render(
+      <AnchoredMenu
+        anchor={ANCHOR}
+        options={OPTIONS}
+        selectedId="pre"
+        onSelect={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+
+    // If the menu were nested inside the backdrop (the #728 bug), the option
+    // rows would be descendants of the backdrop Pressable and this scoped
+    // query would find them. As siblings, the backdrop subtree is empty.
+    const backdrop = getByTestId("anchored-menu-backdrop");
+    expect(within(backdrop).queryByText("Service")).toBeNull();
+    expect(within(backdrop).queryByText("Pre-service")).toBeNull();
+    expect(within(backdrop).queryByText("Post-service")).toBeNull();
+  });
+
   it("selects an option (and does not dismiss) when a row is pressed", () => {
     const onSelect = jest.fn();
     const onClose = jest.fn();


### PR DESCRIPTION
## What was wrong

On the **desktop web** version of the app, the dropdowns in the runsheet (the "⋯" row-actions menu, the "When" segment pill, and the template picker) didn't respond — clicking an option did nothing, so users couldn't make a selection. (Issue #728, filed via the dev dashboard.)

## Why

All of those dropdowns are rendered by one small component, `AnchoredMenu`. It put the menu **inside** the tap-anywhere-to-close backdrop and relied on `e.stopPropagation()` to stop an option tap from also triggering the backdrop's "close" handler.

That works on phones, but on the web `react-native`'s `stopPropagation()` doesn't actually stop the browser's own click from bubbling up. So every time you clicked an option, the click also reached the backdrop and **closed the menu instead of selecting** — the dropdown looked dead.

## The fix

Rebuilt `AnchoredMenu` to match the layout the app's main modal (`CustomModal`) already uses successfully: the backdrop is now a **separate layer sitting behind** the menu rather than wrapping it. Option taps land directly on the menu rows, and only taps outside the menu hit the backdrop — no browser-specific propagation tricks needed. Behavior on native phones is unchanged.

## Verification

Because this is a browser-only event-bubbling issue (invisible to unit tests, which don't simulate DOM bubbling), I reproduced the exact `react-native-web` rendering in a real Chromium browser via Playwright and clicked an option in both the old and new structures:

- **Before** (menu nested in backdrop): clicking "Service" → *menu dismissed, no selection*.
- **After** (backdrop as sibling): clicking "Service" → *Service selected* ✓.

[Before/after: rendered mock in a real browser showing the dropdown dead vs. selectable](https://images.togather.nyc/dev-assistant/fe2711fb-5ab5-432c-967f-aad97169297a-anchored-menu-fix.png)

> ⚠️ The image is a **rendered mock** built from the real component's DOM/CSS and driven in a real browser — not a device/staging capture (this run has no simulator). It faithfully reproduces the root cause and the fix.

Also added `AnchoredMenu` unit tests guarding the interaction contract (select an option, dismiss on backdrop press, empty-option → `null`, multi-select toggle). `pnpm test` for `AnchoredMenu` passes; typecheck and eslint clean on the changed files.

## Done when

- [x] Clicking a runsheet dropdown option selects it on desktop web
- [x] Outside click still dismisses the menu
- [x] Native (phone) behavior unchanged
- [x] Tests cover the select/dismiss/toggle contract

Closes #728

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKKCQpfnnvHCDC4Me8pv6c)_