### PR TITLE
feat(finance-ui): the member giving flow, rebuilt on the WA shell

### DIFF
--- a/apps/mobile/app/groups/[group_id]/__tests__/give-success.test.tsx
+++ b/apps/mobile/app/groups/[group_id]/__tests__/give-success.test.tsx
@@ -88,13 +88,36 @@ describe("GiveSuccessScreen", () => {
     expect(mockReplace).not.toHaveBeenCalled();
   });
 
-  it("replaces into the fund when there is no stack (a cold web boot on success_url)", () => {
+  it("replaces into the fund when there is no stack at all", () => {
     canGoBack = false;
     render(<GiveSuccessScreen />);
     act(() => {
       jest.advanceTimersByTime(4000);
     });
     expect(mockReplace).toHaveBeenCalledWith("/groups/group_1/fund");
+  });
+
+  // The root layout pins `(tabs)` as initialRouteName, so a cold deep link
+  // DOES have a frame underneath — popping would drop the donor on the tab bar.
+  // `session_id` is on Stripe's success_url and nothing else.
+  it("replaces after Stripe's redirect even though the tab bar is poppable", () => {
+    setParams({ amount: "5000", session_id: "cs_test_123" });
+    canGoBack = true;
+    render(<GiveSuccessScreen />);
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+    expect(mockReplace).toHaveBeenCalledWith("/groups/group_1/fund");
+    expect(mockBack).not.toHaveBeenCalled();
+  });
+
+  it("pops, not replaces, when the native flow routed here (no session_id)", () => {
+    render(<GiveSuccessScreen />);
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+    expect(mockBack).toHaveBeenCalledTimes(1);
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 
   it("does not navigate before the auto-return delay is up", () => {

--- a/apps/mobile/app/groups/[group_id]/__tests__/give-success.test.tsx
+++ b/apps/mobile/app/groups/[group_id]/__tests__/give-success.test.tsx
@@ -9,6 +9,7 @@
  */
 import React from "react";
 import { render, screen, act } from "@testing-library/react-native";
+import { AccessibilityInfo } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useStoredAuthToken } from "@services/api/convex";
 import GiveSuccessScreen from "../give-success";
@@ -42,6 +43,12 @@ describe("GiveSuccessScreen", () => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     canGoBack = true;
+    jest
+      .spyOn(AccessibilityInfo, "isReduceMotionEnabled")
+      .mockResolvedValue(false);
+    jest
+      .spyOn(AccessibilityInfo, "addEventListener")
+      .mockReturnValue({ remove: jest.fn() } as never);
     setParams({ amount: "5000", fund: "Young Adults", community: "First Church" });
     (useStoredAuthToken as jest.Mock).mockReturnValue("token_abc");
     (useRouter as jest.Mock).mockReturnValue({
@@ -107,6 +114,38 @@ describe("GiveSuccessScreen", () => {
     });
     expect(mockBack).not.toHaveBeenCalled();
     expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  // The GIF is a 54-frame burst; firing it at someone who asked for less
+  // motion, as the reward for paying, is exactly the case the setting exists
+  // for. The waiting dots already honour it.
+  describe("Reduce Motion", () => {
+    it("plays the celebration when motion is fine", async () => {
+      render(<GiveSuccessScreen />);
+      await act(async () => {});
+      expect(screen.getByTestId("give-success-gif")).toBeTruthy();
+      expect(screen.queryByTestId("give-success-static-mark")).toBeNull();
+    });
+
+    it("swaps it for a still mark when the setting is on", async () => {
+      (AccessibilityInfo.isReduceMotionEnabled as jest.Mock).mockResolvedValue(true);
+      render(<GiveSuccessScreen />);
+      await act(async () => {});
+      expect(screen.getByTestId("give-success-static-mark")).toBeTruthy();
+      expect(screen.queryByTestId("give-success-gif")).toBeNull();
+    });
+
+    // Nothing animates while the answer is still in flight, and nothing
+    // animates if it never arrives (RN-Web rejects rather than resolving).
+    it("stays still while detection is pending, and if it never resolves", async () => {
+      (AccessibilityInfo.isReduceMotionEnabled as jest.Mock).mockRejectedValue(
+        new Error("unsupported"),
+      );
+      render(<GiveSuccessScreen />);
+      expect(screen.getByTestId("give-success-static-mark")).toBeTruthy();
+      await act(async () => {});
+      expect(screen.getByTestId("give-success-static-mark")).toBeTruthy();
+    });
   });
 
   // Stripe's in-app browser has its own storage and no session, so /fund there

--- a/apps/mobile/app/groups/[group_id]/__tests__/give-success.test.tsx
+++ b/apps/mobile/app/groups/[group_id]/__tests__/give-success.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * give-success — the thank-you Stripe returns donors to.
+ *
+ * The parsing is covered in `giveSuccessParams.test.ts`; what's asserted here
+ * is the part that can strand someone: whether the screen navigates, and where
+ * to. It is reached in two very different contexts — the real app, and Stripe's
+ * in-app browser, which has no session — and only one of them has a fund screen
+ * worth returning to.
+ */
+import React from "react";
+import { render, screen, act } from "@testing-library/react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useStoredAuthToken } from "@services/api/convex";
+import GiveSuccessScreen from "../give-success";
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+jest.mock("@services/api/convex", () => ({
+  useStoredAuthToken: jest.fn(),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+}));
+
+const mockBack = jest.fn();
+const mockReplace = jest.fn();
+let canGoBack = true;
+
+function setParams(params: Record<string, string>) {
+  (useLocalSearchParams as jest.Mock).mockReturnValue({
+    group_id: "group_1",
+    ...params,
+  });
+}
+
+describe("GiveSuccessScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    canGoBack = true;
+    setParams({ amount: "5000", fund: "Young Adults", community: "First Church" });
+    (useStoredAuthToken as jest.Mock).mockReturnValue("token_abc");
+    (useRouter as jest.Mock).mockReturnValue({
+      back: mockBack,
+      replace: mockReplace,
+      canGoBack: () => canGoBack,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("thanks the donor in the community's name and shows the amount in dollars", () => {
+    render(<GiveSuccessScreen />);
+    expect(screen.getByText("First Church says thank you")).toBeTruthy();
+    expect(screen.getByTestId("give-success-amount").props.children).toBe("$50.00");
+    expect(screen.getByText("to Young Adults")).toBeTruthy();
+  });
+
+  it("shows no amount rather than '$NaN' when the param is garbage", () => {
+    setParams({ amount: "not-a-number" });
+    render(<GiveSuccessScreen />);
+    expect(screen.queryByTestId("give-success-amount")).toBeNull();
+    expect(screen.getByText("Thank you 🎉")).toBeTruthy();
+  });
+
+  // fund → give → (replaced) give-success: the fund is still one frame down.
+  // Replacing instead would stack a second copy, and Back from it would reveal
+  // an identical fund screen and look like a no-op.
+  it("pops back to the fund already in the stack", () => {
+    render(<GiveSuccessScreen />);
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+    expect(mockBack).toHaveBeenCalledTimes(1);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("replaces into the fund when there is no stack (a cold web boot on success_url)", () => {
+    canGoBack = false;
+    render(<GiveSuccessScreen />);
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+    expect(mockReplace).toHaveBeenCalledWith("/groups/group_1/fund");
+  });
+
+  it("does not navigate before the auto-return delay is up", () => {
+    render(<GiveSuccessScreen />);
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(mockBack).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("drops the pending auto-return when it unmounts", () => {
+    const { unmount } = render(<GiveSuccessScreen />);
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    expect(mockBack).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  // Stripe's in-app browser has its own storage and no session, so /fund there
+  // is a skeleton that never fills. The thank-you is terminal in that context.
+  describe("inside Stripe's auth-less in-app browser", () => {
+    beforeEach(() => {
+      (useStoredAuthToken as jest.Mock).mockReturnValue(null);
+    });
+
+    it("never auto-returns", () => {
+      render(<GiveSuccessScreen />);
+      act(() => {
+        jest.advanceTimersByTime(30000);
+      });
+      expect(mockBack).not.toHaveBeenCalled();
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it("tells the donor to close the window instead of offering Done", () => {
+      render(<GiveSuccessScreen />);
+      expect(screen.getByTestId("give-success-close-hint")).toBeTruthy();
+      expect(screen.queryByLabelText("Done")).toBeNull();
+    });
+
+    it("still shows the thank-you and the amount", () => {
+      render(<GiveSuccessScreen />);
+      expect(screen.getByText("First Church says thank you")).toBeTruthy();
+      expect(screen.getByTestId("give-success-amount").props.children).toBe("$50.00");
+    });
+  });
+});

--- a/apps/mobile/app/groups/[group_id]/give-success.tsx
+++ b/apps/mobile/app/groups/[group_id]/give-success.tsx
@@ -25,12 +25,13 @@
  * ADR-013), and a tinted View is the same picture with no native view in it.
  */
 import React, { useEffect } from "react";
-import { View, Text, StyleSheet, Image, Pressable } from "react-native";
+import { View, Text, StyleSheet, Image, Pressable, AccessibilityInfo } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useStoredAuthToken } from "@services/api/convex";
+import { Ionicons } from "@expo/vector-icons";
 import { parseGiveSuccessParams } from "@features/finance/member/giveSuccessParams";
-import { GIVING_GOLD_WASH } from "@features/finance/member/giveTheme";
+import { GIVING_GOLD, GIVING_GOLD_WASH } from "@features/finance/member/giveTheme";
 
 const starStrikeGif = require("../../../assets/star-strike.gif");
 
@@ -47,6 +48,7 @@ export default function GiveSuccessScreen() {
     community?: string;
   }>();
 
+  const reduceMotion = useReduceMotion();
   const { amountLabel, thankYouLine, fundLine } = parseGiveSuccessParams(params);
   const groupId = params.group_id;
   const token = useStoredAuthToken();
@@ -80,7 +82,16 @@ export default function GiveSuccessScreen() {
       <View style={styles.wash} pointerEvents="none" />
 
       <View style={styles.content}>
-        <Image source={starStrikeGif} style={styles.gif} />
+        {/* The GIF is a 54-frame burst. Someone who asked for less motion
+            should not get it fired at them for completing a payment, so the
+            celebration falls back to the same glyph at rest. */}
+        {reduceMotion ? (
+          <View style={styles.gifFallback} testID="give-success-static-mark">
+            <Ionicons name="star" size={64} color={GIVING_GOLD} />
+          </View>
+        ) : (
+          <Image source={starStrikeGif} style={styles.gif} testID="give-success-gif" />
+        )}
         <Text style={styles.thankYou}>{thankYouLine}</Text>
         {!!amountLabel && (
           <Text style={styles.amount} testID="give-success-amount">
@@ -108,6 +119,38 @@ export default function GiveSuccessScreen() {
   );
 }
 
+/**
+ * Whether the viewer asked for less motion.
+ *
+ * Starts `true` so nothing animates while detection is pending, and stays
+ * `true` if `isReduceMotionEnabled()` rejects (RN-Web does) — there is no
+ * answer coming, and at-rest is the safe resting state. Same shape as
+ * `PulseDots` in GiveScreenView; kept local rather than shared because this
+ * screen must not import anything that could pull in a provider.
+ */
+function useReduceMotion(): boolean {
+  const [reduceMotion, setReduceMotion] = React.useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    AccessibilityInfo.isReduceMotionEnabled()
+      .then((enabled) => {
+        if (!cancelled) setReduceMotion(enabled);
+      })
+      .catch(() => {});
+    const subscription = AccessibilityInfo.addEventListener(
+      "reduceMotionChanged",
+      setReduceMotion,
+    );
+    return () => {
+      cancelled = true;
+      subscription?.remove?.();
+    };
+  }, []);
+
+  return reduceMotion;
+}
+
 const styles = StyleSheet.create({
   // Fixed light palette rather than the themed one on purpose: this renders
   // before providers have settled, and a celebration card that flips to a dark
@@ -132,6 +175,13 @@ const styles = StyleSheet.create({
   },
   content: { alignItems: "center", flex: 1, justifyContent: "center" },
   gif: { width: 140, height: 140, marginBottom: 16 },
+  gifFallback: {
+    width: 140,
+    height: 140,
+    marginBottom: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   thankYou: {
     fontSize: 20,
     fontWeight: "600",

--- a/apps/mobile/app/groups/[group_id]/give-success.tsx
+++ b/apps/mobile/app/groups/[group_id]/give-success.tsx
@@ -46,6 +46,7 @@ export default function GiveSuccessScreen() {
     amount?: string;
     fund?: string;
     community?: string;
+    session_id?: string;
   }>();
 
   const reduceMotion = useReduceMotion();
@@ -53,17 +54,26 @@ export default function GiveSuccessScreen() {
   const groupId = params.group_id;
   const token = useStoredAuthToken();
 
+  // `session_id` is Stripe's, and only Stripe's: `buildGiveReturnUrls` puts it
+  // on the success_url, while the native auto-advance builds its own query
+  // (amount/fund/community) and never adds one. It is therefore the one
+  // reliable "did the browser redirect me here" signal — `canGoBack()` is NOT,
+  // because the root layout pins `(tabs)` as `initialRouteName`, so even a cold
+  // deep link has a frame underneath it.
+  const cameFromStripeRedirect = !!params.session_id;
+
   const goToFund = React.useCallback(() => {
-    // The native flow arrived as fund → give → (replaced) give-success, so the
-    // fund is still one frame down: pop back to it rather than pushing a second
-    // copy, which would leave Back revealing an identical fund screen. A cold
-    // web boot on Stripe's success_url has no stack, and gets a replace.
-    if (router.canGoBack()) {
+    // Native arrived as fund → give → (replaced) give-success, so the fund is
+    // one frame down: pop to it rather than stacking a second copy, which would
+    // leave Back revealing an identical fund screen. The redirect's stack is
+    // just `(tabs)` under this route, where popping would drop the donor on the
+    // tab bar instead — that one replaces.
+    if (!cameFromStripeRedirect && router.canGoBack()) {
       router.back();
       return;
     }
     router.replace(`/groups/${groupId}/fund` as any);
-  }, [router, groupId]);
+  }, [router, groupId, cameFromStripeRedirect]);
 
   useEffect(() => {
     // No token means this is Stripe's in-app browser, which has its own

--- a/apps/mobile/app/groups/[group_id]/give-success.tsx
+++ b/apps/mobile/app/groups/[group_id]/give-success.tsx
@@ -14,6 +14,12 @@
  * already percent-encoded by the backend and decoded by expo-router — and
  * garbage params degrade instead of breaking (see `parseGiveSuccessParams`).
  *
+ * The two return paths differ, and conflating them strands the donor: in that
+ * in-app browser there is nothing to return TO (`/fund`'s queries would all
+ * skip and leave a permanent skeleton), so the thank-you is terminal there and
+ * offers "you can close this window" instead of navigating. `useStoredAuthToken`
+ * tells the two apart — it reads storage, not Convex, so it costs no query.
+ *
  * No `expo-linear-gradient` for the gold wash, deliberately: that module is
  * disabled on Fabric in this app (see components/ui/SafeLinearGradient.tsx and
  * ADR-013), and a tinted View is the same picture with no native view in it.
@@ -22,6 +28,7 @@ import React, { useEffect } from "react";
 import { View, Text, StyleSheet, Image, Pressable } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useStoredAuthToken } from "@services/api/convex";
 import { parseGiveSuccessParams } from "@features/finance/member/giveSuccessParams";
 import { GIVING_GOLD_WASH } from "@features/finance/member/giveTheme";
 
@@ -42,15 +49,28 @@ export default function GiveSuccessScreen() {
 
   const { amountLabel, thankYouLine, fundLine } = parseGiveSuccessParams(params);
   const groupId = params.group_id;
+  const token = useStoredAuthToken();
 
   const goToFund = React.useCallback(() => {
+    // The native flow arrived as fund → give → (replaced) give-success, so the
+    // fund is still one frame down: pop back to it rather than pushing a second
+    // copy, which would leave Back revealing an identical fund screen. A cold
+    // web boot on Stripe's success_url has no stack, and gets a replace.
+    if (router.canGoBack()) {
+      router.back();
+      return;
+    }
     router.replace(`/groups/${groupId}/fund` as any);
   }, [router, groupId]);
 
   useEffect(() => {
+    // No token means this is Stripe's in-app browser, which has its own
+    // storage and no session — `/fund` there is a skeleton that never fills,
+    // so the thank-you stays put and the donor closes the sheet themselves.
+    if (!token) return;
     const timer = setTimeout(goToFund, AUTO_RETURN_MS);
     return () => clearTimeout(timer);
-  }, [goToFund]);
+  }, [goToFund, token]);
 
   return (
     <View style={[styles.screen, { paddingTop: insets.top, paddingBottom: insets.bottom + 24 }]}>
@@ -70,14 +90,20 @@ export default function GiveSuccessScreen() {
         {!!fundLine && <Text style={styles.fund}>{fundLine}</Text>}
       </View>
 
-      <Pressable
-        onPress={goToFund}
-        accessibilityRole="button"
-        accessibilityLabel="Done"
-        style={({ pressed }) => [styles.donePill, pressed && styles.pressed]}
-      >
-        <Text style={styles.doneLabel}>Done</Text>
-      </Pressable>
+      {token ? (
+        <Pressable
+          onPress={goToFund}
+          accessibilityRole="button"
+          accessibilityLabel="Done"
+          style={({ pressed }) => [styles.donePill, pressed && styles.pressed]}
+        >
+          <Text style={styles.doneLabel}>Done</Text>
+        </Pressable>
+      ) : (
+        <Text style={styles.closeHint} testID="give-success-close-hint">
+          You can close this window.
+        </Text>
+      )}
     </View>
   );
 }
@@ -134,5 +160,11 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   doneLabel: { fontSize: 17, fontWeight: "600", color: "#FFFFFF" },
+  closeHint: {
+    fontSize: 15,
+    color: "#6B6B6B",
+    textAlign: "center",
+    paddingVertical: 15,
+  },
   pressed: { opacity: 0.85 },
 });

--- a/apps/mobile/app/groups/[group_id]/give-success.tsx
+++ b/apps/mobile/app/groups/[group_id]/give-success.tsx
@@ -1,0 +1,138 @@
+/**
+ * give-success — the thank-you a donor lands on after Stripe Checkout.
+ *
+ * Reached two ways, and the constraint comes from the harder one:
+ *
+ *  - **Web/mobile web:** a plain browser redirect to Stripe's `success_url`
+ *    (built by `buildGiveReturnUrls` in apps/convex/functions/finance/giving.ts).
+ *    The app is cold-booting and auth is still restoring.
+ *  - **Native:** `GiveScreen`'s waiting step routes here itself once
+ *    `getCheckoutSessionStatus` reports the donation landed.
+ *
+ * So this screen runs ZERO authenticated queries. Everything it shows comes
+ * off the URL — amount in integer cents, fund name, community name, all
+ * already percent-encoded by the backend and decoded by expo-router — and
+ * garbage params degrade instead of breaking (see `parseGiveSuccessParams`).
+ *
+ * No `expo-linear-gradient` for the gold wash, deliberately: that module is
+ * disabled on Fabric in this app (see components/ui/SafeLinearGradient.tsx and
+ * ADR-013), and a tinted View is the same picture with no native view in it.
+ */
+import React, { useEffect } from "react";
+import { View, Text, StyleSheet, Image, Pressable } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { parseGiveSuccessParams } from "@features/finance/member/giveSuccessParams";
+import { GIVING_GOLD_WASH } from "@features/finance/member/giveTheme";
+
+const starStrikeGif = require("../../../assets/star-strike.gif");
+
+/** How long the thank-you holds before it hands the donor back to the fund. */
+const AUTO_RETURN_MS = 4000;
+
+export default function GiveSuccessScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{
+    group_id: string;
+    amount?: string;
+    fund?: string;
+    community?: string;
+  }>();
+
+  const { amountLabel, thankYouLine, fundLine } = parseGiveSuccessParams(params);
+  const groupId = params.group_id;
+
+  const goToFund = React.useCallback(() => {
+    router.replace(`/groups/${groupId}/fund` as any);
+  }, [router, groupId]);
+
+  useEffect(() => {
+    const timer = setTimeout(goToFund, AUTO_RETURN_MS);
+    return () => clearTimeout(timer);
+  }, [goToFund]);
+
+  return (
+    <View style={[styles.screen, { paddingTop: insets.top, paddingBottom: insets.bottom + 24 }]}>
+      {/* The wash is a soft gold band behind the top of the card, not a
+          full-bleed background — the page itself stays white so the amount
+          reads as the only thing on it. */}
+      <View style={styles.wash} pointerEvents="none" />
+
+      <View style={styles.content}>
+        <Image source={starStrikeGif} style={styles.gif} />
+        <Text style={styles.thankYou}>{thankYouLine}</Text>
+        {!!amountLabel && (
+          <Text style={styles.amount} testID="give-success-amount">
+            {amountLabel}
+          </Text>
+        )}
+        {!!fundLine && <Text style={styles.fund}>{fundLine}</Text>}
+      </View>
+
+      <Pressable
+        onPress={goToFund}
+        accessibilityRole="button"
+        accessibilityLabel="Done"
+        style={({ pressed }) => [styles.donePill, pressed && styles.pressed]}
+      >
+        <Text style={styles.doneLabel}>Done</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  // Fixed light palette rather than the themed one on purpose: this renders
+  // before providers have settled, and a celebration card that flips to a dark
+  // surface mid-animation reads as a glitch.
+  screen: {
+    flex: 1,
+    backgroundColor: "#FFFFFF",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+  },
+  wash: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: "45%",
+    backgroundColor: GIVING_GOLD_WASH,
+    borderBottomLeftRadius: 400,
+    borderBottomRightRadius: 400,
+    transform: [{ scaleX: 1.6 }],
+  },
+  content: { alignItems: "center", flex: 1, justifyContent: "center" },
+  gif: { width: 140, height: 140, marginBottom: 16 },
+  thankYou: {
+    fontSize: 20,
+    fontWeight: "600",
+    color: "#4A4A4A",
+    textAlign: "center",
+  },
+  amount: {
+    fontSize: 44,
+    fontWeight: "700",
+    fontVariant: ["tabular-nums"],
+    color: "#111111",
+    marginTop: 8,
+  },
+  fund: {
+    fontSize: 15,
+    color: "#6B6B6B",
+    textAlign: "center",
+    marginTop: 6,
+  },
+  donePill: {
+    alignSelf: "stretch",
+    height: 50,
+    borderRadius: 25,
+    backgroundColor: "#222224",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  doneLabel: { fontSize: 17, fontWeight: "600", color: "#FFFFFF" },
+  pressed: { opacity: 0.85 },
+});

--- a/apps/mobile/features/finance/member/FundScreen.tsx
+++ b/apps/mobile/features/finance/member/FundScreen.tsx
@@ -32,9 +32,11 @@ export function FundScreen() {
     fundId ? { fundId } : "skip",
   );
 
-  // Manager+ (or leader/community admin) viewers get a "Manage" link to the
-  // leader giving hub (approvals + roles) — the only nav entry point into it
-  // besides deep links, since the per-group toolbar config is out of scope.
+  // Manager+ (or leader/community admin) viewers get the "Fund settings" cell
+  // linking to the leader giving hub (approvals + roles) — the only nav entry
+  // point into it besides deep links, since the per-group toolbar config is
+  // out of scope. Passing `onManagePress` IS the gate: `FundScreenView`
+  // renders the whole "Fund" card only when it's set.
   const myRole = useAuthenticatedQuery(
     api.functions.finance.roles.getMyFundRole,
     fundId ? { fundId } : "skip",

--- a/apps/mobile/features/finance/member/FundScreenView.tsx
+++ b/apps/mobile/features/finance/member/FundScreenView.tsx
@@ -1,13 +1,42 @@
 /**
  * FundScreenView — presentational transparency screen for group giving
- * (ADR-032 §3/§7 Phase 1). Pure props in, no Convex/router imports, so a
- * verification harness can render it standalone with mock data.
+ * (ADR-032 §3/§7 Phase 1), restyled onto the WhatsApp shell. Pure props in, no
+ * Convex/router imports, so a verification harness can render it standalone
+ * with mock data.
+ *
+ * Shell per `docs/plans/church-migration-ui-redesign/WHATSAPP-DESIGN-SYSTEM.md`
+ * §3.1/§3.2, mirroring GroupInfoScreen: grouped-gray canvas + floating
+ * `WaSubScreenHeader`, content as `WaInsetGroup` cards. The bespoke bar header
+ * this replaced carried the gear and a header "Give" link; both moved into the
+ * page (a full-width hero pill, and a leaders-only "Fund settings" cell at the
+ * bottom) so the header is back/title only.
+ *
+ * `paddingTop: insets.top` is load-bearing, not cosmetic: this screen never
+ * applied safe-area insets, so on a notched device its top row sat under the
+ * status bar and could not be reached.
  */
 import React from "react";
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from "react-native";
+import { View, Text, StyleSheet, ScrollView, Pressable } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@hooks/useTheme";
-import { Badge, Button, Skeleton, EmptyState } from "@components/ui";
+import { Badge, Skeleton, EmptyState } from "@components/ui";
+import {
+  WaSubScreenHeader,
+  WaInsetGroup,
+  WaCell,
+  waAvatarPalette,
+  waAvatarInitials,
+  WA_GROUP_MARGIN,
+  WA_GROUP_RADIUS,
+  WA_GROUP_SPACING,
+  WA_CELL_PADDING,
+  WA_TYPE_FOOTNOTE,
+  WA_TYPE_SUBTITLE,
+  WA_TYPE_ROW_TITLE,
+  WA_WEIGHT_BOLD,
+  WA_WEIGHT_SEMIBOLD,
+} from "@components/wa";
 import { formatCents, formatSignedCents } from "../format";
 import {
   formatLedgerKind,
@@ -15,7 +44,13 @@ import {
   expenseStatusBadgeVariant,
   expenseStatusNote,
 } from "./labels";
-import type { FundOverview, MyExpense } from "./types";
+import { GIVING_GOLD, GIVING_GOLD_TINT } from "./giveTheme";
+import type { FundActivityEntry, FundOverview, MyExpense } from "./types";
+
+/** Hero balance type size — the one number this whole screen exists to show. */
+const BALANCE_SIZE = 46;
+/** Fund-glyph tile edge, sized to sit above the balance without competing. */
+const GLYPH_TILE = 44;
 
 export interface FundScreenViewProps {
   /** `undefined` while loading, `null` when giving isn't set up for this group. */
@@ -25,7 +60,11 @@ export interface FundScreenViewProps {
   onBack: () => void;
   onGivePress: () => void;
   onGetReimbursedPress: () => void;
-  /** Set for manager+ viewers — shows the "Manage" link to the leader giving hub (approvals + roles). */
+  /**
+   * Set for manager+ viewers — renders the leaders-only "Fund settings" cell
+   * that opens the leader giving hub (approvals + roles). Its presence IS the
+   * permission gate; `FundScreen` passes `undefined` for everyone else.
+   */
   onManagePress?: () => void;
 }
 
@@ -37,41 +76,23 @@ export function FundScreenView({
   onGetReimbursedPress,
   onManagePress,
 }: FundScreenViewProps) {
-  const { colors } = useTheme();
+  const { colors, isDark } = useTheme();
+  const insets = useSafeAreaInsets();
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <View
-        style={[
-          styles.header,
-          { backgroundColor: colors.surface, borderBottomColor: colors.border },
-        ]}
-      >
-        <TouchableOpacity style={styles.backButton} onPress={onBack} accessibilityLabel="Back">
-          <Ionicons name="arrow-back" size={24} color={colors.text} />
-        </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: colors.text }]}>Giving</Text>
-        {overview ? (
-          <View style={styles.headerActions}>
-            {onManagePress && (
-              <TouchableOpacity onPress={onManagePress} accessibilityLabel="Manage giving">
-                <Ionicons name="settings-outline" size={22} color={colors.link} />
-              </TouchableOpacity>
-            )}
-            <TouchableOpacity onPress={onGivePress} accessibilityLabel="Give">
-              <Text style={[styles.headerGive, { color: colors.link }]}>Give</Text>
-            </TouchableOpacity>
-          </View>
-        ) : (
-          <View style={styles.headerSpacer} />
-        )}
-      </View>
+    <View
+      style={[
+        styles.screen,
+        { backgroundColor: colors.backgroundGrouped, paddingTop: insets.top },
+      ]}
+    >
+      <WaSubScreenHeader title="Giving" onBack={onBack} />
 
       {overview === undefined ? (
         <View style={styles.loadingContainer} testID="fund-screen-loading">
-          <Skeleton height={100} borderRadius={16} style={{ marginBottom: 16 }} />
-          <Skeleton height={60} borderRadius={12} style={{ marginBottom: 16 }} />
-          <Skeleton height={200} borderRadius={12} />
+          <Skeleton height={180} borderRadius={WA_GROUP_RADIUS} style={styles.loadingBlock} />
+          <Skeleton height={90} borderRadius={WA_GROUP_RADIUS} style={styles.loadingBlock} />
+          <Skeleton height={200} borderRadius={WA_GROUP_RADIUS} />
         </View>
       ) : overview === null ? (
         <EmptyState
@@ -85,150 +106,112 @@ export function FundScreenView({
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
         >
-          {/* BALANCE */}
-          <View style={[styles.balanceCard, { backgroundColor: colors.surfaceSecondary }]}>
-            <Text style={[styles.balanceLabel, { color: colors.textSecondary }]}>
-              {overview.fund.name} balance
-            </Text>
-            <Text style={[styles.balanceAmount, { color: colors.text }]}>
-              {formatCents(overview.balanceCents)}
-            </Text>
-            <View style={styles.balanceActions}>
-              <Button onPress={onGivePress} style={styles.balanceActionButton}>
-                Give
-              </Button>
-              <Button
-                onPress={onGetReimbursedPress}
-                variant="secondary"
-                style={styles.balanceActionButton}
+          {/* HERO — glyph, fund name, balance, and the screen's single primary
+              action. "Get reimbursed" deliberately does NOT sit here: it is a
+              rare errand, and pairing it with Give made two equal-weight
+              buttons out of one obvious one. It lives in its own card below. */}
+          <WaInsetGroup>
+            <View style={styles.hero}>
+              <View style={[styles.glyphTile, { backgroundColor: GIVING_GOLD_TINT }]}>
+                <Ionicons name="cash-outline" size={24} color={GIVING_GOLD} />
+              </View>
+              <Text style={[styles.fundName, { color: colors.textSecondary }]} numberOfLines={2}>
+                {overview.fund.name}
+              </Text>
+              <Text style={[styles.balance, { color: colors.text }]}>
+                {formatCents(overview.balanceCents)}
+              </Text>
+              <Pressable
+                onPress={onGivePress}
+                accessibilityRole="button"
+                accessibilityLabel="Give"
+                style={({ pressed }) => [
+                  styles.givePill,
+                  { backgroundColor: colors.buttonPrimary },
+                  pressed && styles.pressed,
+                ]}
               >
-                Get reimbursed
-              </Button>
+                <Text style={[styles.givePillLabel, { color: colors.buttonPrimaryText }]}>
+                  Give
+                </Text>
+              </Pressable>
             </View>
-          </View>
+          </WaInsetGroup>
 
-          {/* MTD / YTD STATS */}
+          {/* STAT TILES — this month / this year, 2-up. Card fees keep their
+              own line (rather than folding into "spent") because a fee is
+              money the group never chose to spend; see summarizePeriod. */}
           <View style={styles.statsRow}>
-            <View style={[styles.statCard, { backgroundColor: colors.surfaceSecondary }]}>
-              <Text style={[styles.statHeader, { color: colors.textSecondary }]}>
-                MONTH TO DATE
-              </Text>
-              <Text style={[styles.statValue, { color: colors.text }]}>
-                {formatCents(overview.monthToDate.donationsCents)} given
-              </Text>
-              <Text style={[styles.statSubvalue, { color: colors.textSecondary }]}>
-                {formatCents(overview.monthToDate.spentCents)} spent ·{" "}
-                {overview.monthToDate.donationCount}{" "}
-                {overview.monthToDate.donationCount === 1 ? "gift" : "gifts"}
-              </Text>
-              {overview.monthToDate.feesCents > 0 && (
-                <Text style={[styles.statSubvalue, { color: colors.textSecondary }]}>
-                  {formatCents(overview.monthToDate.feesCents)} card fees
-                </Text>
-              )}
-            </View>
-            <View style={[styles.statCard, { backgroundColor: colors.surfaceSecondary }]}>
-              <Text style={[styles.statHeader, { color: colors.textSecondary }]}>
-                YEAR TO DATE
-              </Text>
-              <Text style={[styles.statValue, { color: colors.text }]}>
-                {formatCents(overview.yearToDate.donationsCents)} given
-              </Text>
-              <Text style={[styles.statSubvalue, { color: colors.textSecondary }]}>
-                {formatCents(overview.yearToDate.spentCents)} spent ·{" "}
-                {overview.yearToDate.donationCount}{" "}
-                {overview.yearToDate.donationCount === 1 ? "gift" : "gifts"}
-              </Text>
-              {overview.yearToDate.feesCents > 0 && (
-                <Text style={[styles.statSubvalue, { color: colors.textSecondary }]}>
-                  {formatCents(overview.yearToDate.feesCents)} card fees
-                </Text>
-              )}
-            </View>
+            <StatTile
+              label="This month"
+              totals={overview.monthToDate}
+              surface={colors.surfaceGrouped}
+              titleColor={colors.text}
+              subtitleColor={colors.textSecondary}
+            />
+            <StatTile
+              label="This year"
+              totals={overview.yearToDate}
+              surface={colors.surfaceGrouped}
+              titleColor={colors.text}
+              subtitleColor={colors.textSecondary}
+            />
           </View>
 
-          {/* ACTIVITY */}
-          <View style={styles.section}>
-            <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
-              RECENT ACTIVITY
-            </Text>
-            {overview.activity.length === 0 ? (
-              <View style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}>
-                <Text style={[styles.emptyRowText, { color: colors.textSecondary }]}>
-                  No activity yet
-                </Text>
-              </View>
-            ) : (
-              <View style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}>
-                {overview.activity.map((entry, index) => (
-                  <View
+          {/* RECENT ACTIVITY */}
+          <View style={styles.group}>
+            <WaInsetGroup header="Recent activity" separatorInset={0}>
+              {overview.activity.length === 0 ? (
+                <View style={styles.emptyRow}>
+                  <Text style={[styles.emptyRowText, { color: colors.textSecondary }]}>
+                    No activity yet
+                  </Text>
+                </View>
+              ) : (
+                overview.activity.map((entry) => (
+                  <ActivityRow
                     key={entry.id}
-                    style={[
-                      styles.activityRow,
-                      index > 0 && {
-                        borderTopWidth: StyleSheet.hairlineWidth,
-                        borderTopColor: colors.border,
-                      },
-                    ]}
-                  >
-                    <View style={{ flex: 1 }}>
-                      <Text style={[styles.activityKind, { color: colors.text }]}>
-                        {formatLedgerKind(entry.kind)}
-                      </Text>
-                      {!!entry.donorName && (
-                        <Text
-                          style={[styles.activityDonor, { color: colors.textSecondary }]}
-                        >
-                          {entry.donorName}
-                        </Text>
-                      )}
-                    </View>
-                    <Text
-                      style={[
-                        styles.activityAmount,
-                        { color: entry.direction === "credit" ? colors.success : colors.text },
-                      ]}
-                    >
-                      {formatSignedCents(entry.amountCents, entry.direction)}
-                    </Text>
-                  </View>
-                ))}
-              </View>
-            )}
+                    entry={entry}
+                    isDark={isDark}
+                    titleColor={colors.text}
+                    subtitleColor={colors.textSecondary}
+                    creditColor={colors.success}
+                  />
+                ))
+              )}
+            </WaInsetGroup>
           </View>
 
-          {/* MY REIMBURSEMENTS */}
-          <View style={styles.section}>
-            <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
-              MY REIMBURSEMENTS
-            </Text>
-            {myExpenses === undefined ? (
-              <Skeleton height={72} borderRadius={12} />
-            ) : myExpenses.length === 0 ? (
-              <View style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}>
-                <Text style={[styles.emptyRowText, { color: colors.textSecondary }]}>
-                  No reimbursement requests yet
-                </Text>
-              </View>
-            ) : (
-              <View style={[styles.card, { backgroundColor: colors.surfaceSecondary }]}>
-                {myExpenses.map((expense, index) => {
+          {/* REIMBURSEMENTS — the ask sits first as a normal navigational cell,
+              then the viewer's own requests below it, so "Get reimbursed" and
+              "where did my request get to" are one place instead of two. */}
+          <View style={styles.group}>
+            <WaInsetGroup header="Reimbursements" separatorInset={0}>
+              <WaCell
+                icon="receipt-outline"
+                title="Get reimbursed"
+                description="Spent for the group? Send the receipt."
+                onPress={onGetReimbursedPress}
+              />
+              {myExpenses === undefined ? (
+                <View style={styles.emptyRow}>
+                  <Skeleton height={40} borderRadius={8} />
+                </View>
+              ) : myExpenses.length === 0 ? (
+                <View style={styles.emptyRow}>
+                  <Text style={[styles.emptyRowText, { color: colors.textSecondary }]}>
+                    No requests yet
+                  </Text>
+                </View>
+              ) : (
+                myExpenses.map((expense) => {
                   // Approved-but-unpaid is the one status a member can read as
                   // "settled" when it isn't — it gets a sentence saying who
                   // still owes them the money (see labels.ts).
                   const note = expenseStatusNote(expense.status);
                   return (
-                    <View
-                      key={expense.id}
-                      style={[
-                        styles.expenseRow,
-                        index > 0 && {
-                          borderTopWidth: StyleSheet.hairlineWidth,
-                          borderTopColor: colors.border,
-                        },
-                      ]}
-                    >
-                      <View style={{ flex: 1 }}>
+                    <View key={expense.id} style={styles.expenseRow}>
+                      <View style={styles.expenseText}>
                         <Text style={[styles.expenseDescription, { color: colors.text }]}>
                           {expense.description || "Reimbursement"}
                         </Text>
@@ -249,85 +232,217 @@ export function FundScreenView({
                       </Badge>
                     </View>
                   );
-                })}
-              </View>
-            )}
+                })
+              )}
+            </WaInsetGroup>
           </View>
+
+          {/* FUND — leaders only. Last, and labelled, because it is the one row
+              on this screen most members will never see. */}
+          {!!onManagePress && (
+            <View style={styles.group}>
+              <WaInsetGroup header="Fund">
+                <WaCell
+                  icon="settings-outline"
+                  title="Fund settings"
+                  description="Leaders only"
+                  onPress={onManagePress}
+                />
+              </WaInsetGroup>
+            </View>
+          )}
         </ScrollView>
       )}
     </View>
   );
 }
 
+/** One of the two "This month" / "This year" tiles. */
+function StatTile({
+  label,
+  totals,
+  surface,
+  titleColor,
+  subtitleColor,
+}: {
+  label: string;
+  totals: FundOverview["monthToDate"];
+  surface: string;
+  titleColor: string;
+  subtitleColor: string;
+}) {
+  return (
+    <View style={[styles.statTile, { backgroundColor: surface }]}>
+      <Text style={[styles.statLabel, { color: subtitleColor }]}>{label}</Text>
+      <Text style={[styles.statValue, { color: titleColor }]}>
+        {formatCents(totals.donationsCents)}
+      </Text>
+      <Text style={[styles.statSubtitle, { color: subtitleColor }]}>
+        {totals.donationCount} {totals.donationCount === 1 ? "gift" : "gifts"} ·{" "}
+        {formatCents(totals.spentCents)} spent
+      </Text>
+      {totals.feesCents > 0 && (
+        <Text style={[styles.statSubtitle, { color: subtitleColor }]}>
+          {formatCents(totals.feesCents)} card fees
+        </Text>
+      )}
+    </View>
+  );
+}
+
+/**
+ * One ledger row: initials disc, who, what + when, signed amount.
+ *
+ * Anonymized entries (a viewer who isn't manager+ sees no donor names) fall
+ * back to the ledger kind as the title, so the row still reads as a sentence
+ * instead of leaving a blank line above the subtitle.
+ */
+function ActivityRow({
+  entry,
+  isDark,
+  titleColor,
+  subtitleColor,
+  creditColor,
+}: {
+  entry: FundActivityEntry;
+  isDark: boolean;
+  titleColor: string;
+  subtitleColor: string;
+  creditColor: string;
+}) {
+  const kind = formatLedgerKind(entry.kind);
+  const title = entry.donorName || kind;
+  const palette = waAvatarPalette(title, isDark);
+  return (
+    <View style={styles.activityRow}>
+      <View style={[styles.activityAvatar, { backgroundColor: palette.background }]}>
+        <Text style={[styles.activityInitials, { color: palette.foreground }]}>
+          {waAvatarInitials(title)}
+        </Text>
+      </View>
+      <View style={styles.activityText}>
+        <Text style={[styles.activityTitle, { color: titleColor }]} numberOfLines={1}>
+          {title}
+        </Text>
+        <Text style={[styles.activitySubtitle, { color: subtitleColor }]} numberOfLines={1}>
+          {kind} · {formatActivityDate(entry.createdAt)}
+        </Text>
+      </View>
+      <Text
+        style={[
+          styles.activityAmount,
+          { color: entry.direction === "credit" ? creditColor : titleColor },
+        ]}
+      >
+        {formatSignedCents(entry.amountCents, entry.direction)}
+      </Text>
+    </View>
+  );
+}
+
+/** "Jul 29" — the ledger's own date, never a relative "2 days ago". */
+function formatActivityDate(timestamp: number): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+const ACTIVITY_AVATAR = 40;
+
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  header: {
-    flexDirection: "row",
-    alignItems: "center",
-    padding: 16,
-    borderBottomWidth: 1,
-  },
-  backButton: { padding: 4 },
-  headerTitle: {
-    flex: 1,
-    fontSize: 18,
-    fontWeight: "600",
-    textAlign: "center",
-    marginRight: 32,
-  },
-  headerGive: { fontSize: 16, fontWeight: "600" },
-  headerActions: { flexDirection: "row", alignItems: "center", gap: 14 },
-  headerSpacer: { width: 32 },
-  loadingContainer: { padding: 16 },
+  screen: { flex: 1 },
+  loadingContainer: { padding: WA_GROUP_MARGIN },
+  loadingBlock: { marginBottom: 16 },
   emptyState: { flex: 1, justifyContent: "center" },
-  scrollContent: { padding: 16, paddingBottom: 32, gap: 16 },
-  balanceCard: {
-    borderRadius: 16,
-    padding: 20,
+  scrollContent: { paddingTop: 16, paddingBottom: 40 },
+  group: { marginTop: WA_GROUP_SPACING },
+
+  hero: { alignItems: "center", paddingHorizontal: WA_CELL_PADDING, paddingVertical: 24 },
+  glyphTile: {
+    width: GLYPH_TILE,
+    height: GLYPH_TILE,
+    borderRadius: GLYPH_TILE / 2,
     alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 12,
   },
-  balanceLabel: { fontSize: 13, fontWeight: "500" },
-  balanceAmount: { fontSize: 36, fontWeight: "700", marginTop: 4, marginBottom: 16 },
-  balanceActions: { flexDirection: "row", gap: 12, width: "100%" },
-  balanceActionButton: { flex: 1 },
-  statsRow: { flexDirection: "row", gap: 12 },
-  statCard: { flex: 1, borderRadius: 12, padding: 14 },
-  statHeader: { fontSize: 11, fontWeight: "600", letterSpacing: 0.6, marginBottom: 6 },
-  statValue: { fontSize: 16, fontWeight: "600" },
-  statSubvalue: { fontSize: 12, marginTop: 2 },
-  section: {},
-  sectionHeader: {
-    fontSize: 11,
-    fontWeight: "600",
-    letterSpacing: 0.6,
-    marginBottom: 8,
-    paddingHorizontal: 4,
+  fundName: {
+    fontSize: 13.5,
+    fontWeight: WA_WEIGHT_SEMIBOLD,
+    textAlign: "center",
   },
-  card: { borderRadius: 12, overflow: "hidden" },
-  emptyRowText: { fontSize: 14, padding: 16, textAlign: "center" },
+  balance: {
+    fontSize: BALANCE_SIZE,
+    fontWeight: WA_WEIGHT_BOLD,
+    fontVariant: ["tabular-nums"],
+    marginTop: 4,
+    marginBottom: 20,
+  },
+  givePill: {
+    alignSelf: "stretch",
+    height: 50,
+    borderRadius: 25,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  givePillLabel: { fontSize: WA_TYPE_ROW_TITLE, fontWeight: WA_WEIGHT_SEMIBOLD },
+  pressed: { opacity: 0.85 },
+
+  statsRow: {
+    flexDirection: "row",
+    gap: 12,
+    marginHorizontal: WA_GROUP_MARGIN,
+    marginTop: WA_GROUP_SPACING,
+  },
+  statTile: { flex: 1, borderRadius: WA_GROUP_RADIUS, padding: 16 },
+  statLabel: { fontSize: WA_TYPE_FOOTNOTE, fontWeight: WA_WEIGHT_SEMIBOLD },
+  statValue: {
+    fontSize: 24,
+    fontWeight: WA_WEIGHT_BOLD,
+    fontVariant: ["tabular-nums"],
+    marginTop: 4,
+  },
+  statSubtitle: { fontSize: 12, marginTop: 2 },
+
+  emptyRow: { paddingHorizontal: WA_CELL_PADDING, paddingVertical: 18 },
+  emptyRowText: { fontSize: WA_TYPE_SUBTITLE },
+
   activityRow: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    minHeight: 48,
+    paddingHorizontal: WA_CELL_PADDING,
+    paddingVertical: 10,
+    gap: 12,
   },
-  activityKind: { fontSize: 15, fontWeight: "500" },
-  activityDonor: { fontSize: 13, marginTop: 2 },
-  activityAmount: { fontSize: 15, fontWeight: "600" },
+  activityAvatar: {
+    width: ACTIVITY_AVATAR,
+    height: ACTIVITY_AVATAR,
+    borderRadius: ACTIVITY_AVATAR / 2,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  activityInitials: { fontSize: 15, fontWeight: WA_WEIGHT_SEMIBOLD },
+  activityText: { flex: 1, minWidth: 0 },
+  activityTitle: { fontSize: WA_TYPE_ROW_TITLE, fontWeight: WA_WEIGHT_SEMIBOLD },
+  activitySubtitle: { fontSize: WA_TYPE_FOOTNOTE, marginTop: 2 },
+  activityAmount: {
+    fontSize: WA_TYPE_SUBTITLE,
+    fontWeight: WA_WEIGHT_SEMIBOLD,
+    fontVariant: ["tabular-nums"],
+  },
+
   expenseRow: {
     flexDirection: "row",
-    // Top-aligned, not centered: the approved rows carry a wrapping note, and
-    // a centered badge would drift to the middle of a three-line row.
+    // Top-aligned, not centered: approved rows carry a wrapping note, and a
+    // centered badge would drift to the middle of a three-line row.
     alignItems: "flex-start",
     justifyContent: "space-between",
-    paddingHorizontal: 16,
+    paddingHorizontal: WA_CELL_PADDING,
     paddingVertical: 12,
-    minHeight: 48,
     gap: 8,
   },
-  expenseDescription: { fontSize: 15, fontWeight: "500" },
-  expenseAmount: { fontSize: 13, marginTop: 2 },
+  expenseText: { flex: 1, minWidth: 0 },
+  expenseDescription: { fontSize: WA_TYPE_SUBTITLE, fontWeight: WA_WEIGHT_SEMIBOLD },
+  expenseAmount: { fontSize: WA_TYPE_FOOTNOTE, marginTop: 2 },
   expenseNote: { fontSize: 12, lineHeight: 16, marginTop: 6 },
 });

--- a/apps/mobile/features/finance/member/GiveScreen.tsx
+++ b/apps/mobile/features/finance/member/GiveScreen.tsx
@@ -140,6 +140,12 @@ export function GiveScreen() {
   // Stripe's cancel_url inside the auth-less in-app browser. Placed after every
   // hook so the hook order never changes; the queries above already skip
   // without a token, so nothing is in flight behind this.
+  //
+  // NOTE: `useStoredAuthToken` starts at `null` and resolves from storage a
+  // frame or two later, so a signed-in donor cancelling on WEB (where the app
+  // cold-boots on this URL) sees this notice briefly before the give form
+  // takes over. That's the deliberate trade: gating it on `Platform.OS` would
+  // hand a signed-out web visitor the permanent skeleton this exists to kill.
   if (params.giving === "cancelled" && !token) {
     return <GiveCancelledNotice />;
   }

--- a/apps/mobile/features/finance/member/GiveScreen.tsx
+++ b/apps/mobile/features/finance/member/GiveScreen.tsx
@@ -39,6 +39,7 @@ import type { Id } from "@services/api/convex";
 import { formatError } from "@/utils/error-handling";
 import { GiveScreenView, GiveCancelledNotice, type GiveStep } from "./GiveScreenView";
 import { estimateCoverFeesCents, resolveGiveAmountCents } from "./amount";
+import { urlSafeName } from "./giveSuccessParams";
 import type { CheckoutSession } from "./types";
 
 /** Opens a URL in the platform's browser sheet — mirrors
@@ -124,10 +125,14 @@ export function GiveScreen() {
     const fund = checkoutStatus.fundName ?? context?.fundName ?? "";
     const community = checkoutStatus.communityName ?? context?.communityLegalName ?? "";
 
+    // `urlSafeName`, not bare `encodeURIComponent`: it throws on an unpaired
+    // surrogate, and throwing here — after `advancedRef` has latched — costs
+    // the donor the thank-you screen with no retry. Same helper shape the
+    // backend uses to build Stripe's success_url.
     const query =
       `?amount=${amountCents}` +
-      `&fund=${encodeURIComponent(fund)}` +
-      `&community=${encodeURIComponent(community)}`;
+      `&fund=${urlSafeName(fund)}` +
+      `&community=${urlSafeName(community)}`;
     router.replace(`/groups/${groupId}/give-success${query}` as any);
   }, [
     checkoutStatus,

--- a/apps/mobile/features/finance/member/GiveScreen.tsx
+++ b/apps/mobile/features/finance/member/GiveScreen.tsx
@@ -8,22 +8,36 @@
  *
  * Payment collection is a hosted Stripe Checkout page (ADR-032 §3/§7 Phase 1
  * decision: zero native dependencies, ships via OTA, Apple Pay works in the
- * browser sheet) — "Continue" creates a Checkout Session, then opens its
- * `url` via expo-web-browser, the same `openBrowserAsync` pattern
+ * browser sheet) — "Give" creates a Checkout Session, then opens its `url`
+ * via expo-web-browser, the same `openBrowserAsync` pattern
  * FinanceOnboardingStatusScreen uses for Stripe's hosted onboarding.
+ *
+ * Two things this screen owns that the view can't:
+ *
+ *  1. **Auto-advance.** On native, Stripe's `success_url` loads INSIDE the
+ *     in-app browser, which has its own storage and no session — so the app
+ *     never sees the redirect. Instead the waiting step subscribes to
+ *     `getCheckoutSessionStatus` and, the moment the webhook records the
+ *     donation, dismisses the browser itself and routes to the success screen.
+ *  2. **The cancel return.** Stripe's `cancel_url` is this same route with
+ *     `?giving=cancelled`, and on native it too opens in that auth-less
+ *     browser — where every `useAuthenticatedQuery` skips and the screen would
+ *     sit on a skeleton forever. Unauthenticated + cancelled renders a static
+ *     notice instead.
  */
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Platform } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 import {
   useAuthenticatedQuery,
   useAuthenticatedAction,
+  useStoredAuthToken,
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { formatError } from "@/utils/error-handling";
-import { GiveScreenView, type GiveStep } from "./GiveScreenView";
+import { GiveScreenView, GiveCancelledNotice, type GiveStep } from "./GiveScreenView";
 import { estimateCoverFeesCents, resolveGiveAmountCents } from "./amount";
 import type { CheckoutSession } from "./types";
 
@@ -38,9 +52,10 @@ async function openCheckoutUrl(url: string): Promise<void> {
 }
 
 export function GiveScreen() {
-  const params = useLocalSearchParams<{ group_id: string }>();
+  const params = useLocalSearchParams<{ group_id: string; giving?: string }>();
   const groupId = params.group_id;
   const router = useRouter();
+  const token = useStoredAuthToken();
 
   const context = useAuthenticatedQuery(
     api.functions.finance.giving.getGivingContext,
@@ -60,18 +75,81 @@ export function GiveScreen() {
   const [checkoutSession, setCheckoutSession] = useState<CheckoutSession | null>(null);
 
   // Minted once per give-sheet session (not per tap) so a retried/double-tapped
-  // "Continue" reuses the same Stripe idempotency key instead of creating a
+  // "Give" reuses the same Stripe idempotency key instead of creating a
   // second Checkout Session — see createDonationCheckoutSession's doc comment.
   const idempotencyNonceRef = useRef<string>(
     `${Date.now()}-${Math.random().toString(36).slice(2)}`,
   );
+
+  // Only subscribes while the donor is actually waiting AND Stripe handed back
+  // a PaymentIntent to watch. When it didn't (`paymentIntentId === null`, which
+  // that action logs), this skips and the wait degrades to manual — Reopen and
+  // Cancel still work, the gift itself is unaffected.
+  const watchedPaymentIntentId =
+    step === "confirmation" ? (checkoutSession?.paymentIntentId ?? null) : null;
+  const checkoutStatus = useAuthenticatedQuery(
+    api.functions.finance.giving.getCheckoutSessionStatus,
+    watchedPaymentIntentId ? { paymentIntentId: watchedPaymentIntentId } : "skip",
+  );
+
+  // Guards the redirect against a re-render firing it twice (the query stays
+  // "complete" once it flips, and `router.replace` isn't idempotent).
+  const advancedRef = useRef(false);
+
+  useEffect(() => {
+    if (checkoutStatus?.status !== "complete") return;
+    if (advancedRef.current) return;
+    advancedRef.current = true;
+
+    // The browser sheet is a native-only surface; on web the donor is already
+    // ON Stripe's page and its own `success_url` navigation does this job.
+    // Dismissing is a courtesy, never a precondition for the thank-you: when
+    // nothing is open this throws on some platforms and rejects on others, and
+    // the `.then` wrapper swallows both.
+    if (Platform.OS !== "web") {
+      Promise.resolve()
+        .then(() => WebBrowser.dismissBrowser())
+        .catch(() => {});
+    }
+
+    // The query's own values win over local state: they're what was actually
+    // charged and recorded, where the local total is only what was requested.
+    const giftCents = resolveGiveAmountCents(selectedPresetCents, customAmountText) ?? 0;
+    const localTotalCents =
+      giftCents + (coverFees ? estimateCoverFeesCents(giftCents) : 0);
+    const amountCents = checkoutStatus.amountCents ?? localTotalCents;
+    const fund = checkoutStatus.fundName ?? context?.fundName ?? "";
+    const community = checkoutStatus.communityName ?? context?.communityLegalName ?? "";
+
+    const query =
+      `?amount=${amountCents}` +
+      `&fund=${encodeURIComponent(fund)}` +
+      `&community=${encodeURIComponent(community)}`;
+    router.replace(`/groups/${groupId}/give-success${query}` as any);
+  }, [
+    checkoutStatus,
+    context?.fundName,
+    context?.communityLegalName,
+    coverFees,
+    customAmountText,
+    groupId,
+    router,
+    selectedPresetCents,
+  ]);
+
+  // Stripe's cancel_url inside the auth-less in-app browser. Placed after every
+  // hook so the hook order never changes; the queries above already skip
+  // without a token, so nothing is in flight behind this.
+  if (params.giving === "cancelled" && !token) {
+    return <GiveCancelledNotice />;
+  }
 
   const handleBack = () => {
     if (step === "confirmation") {
       // Editing the gift after a session was created starts a NEW submission
       // — drop the stale session so "Reopen" can't relaunch the old amount.
       // (The nonce was already rotated when that session was created, so the
-      // next Continue gets a fresh idempotency key; reusing the old key with
+      // next Give gets a fresh idempotency key; reusing the old key with
       // different params would make Stripe reject the request.)
       setCheckoutSession(null);
       setStep("amount");
@@ -114,9 +192,10 @@ export function GiveScreen() {
       setCheckoutSession(result);
       // Rotate the nonce now that this submission has its session: a failed
       // call keeps the old nonce (retry = same idempotency key = no double
-      // session), while the donor's NEXT gift — after Done/back — gets a
+      // session), while the donor's NEXT gift — after cancel/back — gets a
       // fresh key instead of colliding with this one.
       idempotencyNonceRef.current = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      advancedRef.current = false;
       setStep("confirmation");
       await openCheckoutUrl(result.url);
     } catch (err) {

--- a/apps/mobile/features/finance/member/GiveScreen.tsx
+++ b/apps/mobile/features/finance/member/GiveScreen.tsx
@@ -83,8 +83,11 @@ export function GiveScreen() {
 
   // Only subscribes while the donor is actually waiting AND Stripe handed back
   // a PaymentIntent to watch. When it didn't (`paymentIntentId === null`, which
-  // that action logs), this skips and the wait degrades to manual — Reopen and
-  // Cancel still work, the gift itself is unaffected.
+  // that action logs), this skips and the wait degrades to manual: the gift
+  // still lands via the webhook, and the waiting step swaps its pulse for a
+  // "Go to the fund" exit (`canAutoAdvance`), because with nothing watching,
+  // "Cancel this gift" would otherwise be the only way off a screen the donor
+  // may have already paid on.
   const watchedPaymentIntentId =
     step === "confirmation" ? (checkoutSession?.paymentIntentId ?? null) : null;
   const checkoutStatus = useAuthenticatedQuery(
@@ -211,6 +214,18 @@ export function GiveScreen() {
     }
   };
 
+  // Leaves for the fund without resetting anything: used only when nothing is
+  // watching this gift (no PaymentIntent), where the alternative on screen is
+  // "Cancel this gift" — which clears the form and invites a second donation
+  // after a charge that may well have succeeded.
+  const handleFinishManually = () => {
+    if (router.canGoBack()) {
+      router.back();
+      return;
+    }
+    router.replace(`/groups/${groupId}/fund` as any);
+  };
+
   const handleReopenCheckout = async () => {
     if (!checkoutSession) return;
     await openCheckoutUrl(checkoutSession.url);
@@ -226,12 +241,14 @@ export function GiveScreen() {
       submitting={submitting}
       error={error}
       checkoutSession={checkoutSession}
+      canAutoAdvance={checkoutSession?.paymentIntentId != null}
       onBack={handleBack}
       onSelectPreset={handleSelectPreset}
       onCustomAmountChange={handleCustomAmountChange}
       onToggleCoverFees={setCoverFees}
       onContinue={handleContinue}
       onReopenCheckout={handleReopenCheckout}
+      onFinishManually={handleFinishManually}
     />
   );
 }

--- a/apps/mobile/features/finance/member/GiveScreenView.tsx
+++ b/apps/mobile/features/finance/member/GiveScreenView.tsx
@@ -12,7 +12,10 @@
  * the moment the money lands, so the waiting step's own buttons (Reopen /
  * Cancel) are the manual fallback, not the happy path. There is deliberately
  * no "Done": a donor tapping it mid-payment would leave with no idea whether
- * their gift went through.
+ * their gift went through. The one exception is `canAutoAdvance === false`
+ * (Stripe returned no PaymentIntent, so nothing is watching) — there the
+ * screen can never resolve itself, and an exit that doesn't cancel the gift
+ * is the only thing standing between the donor and a duplicate donation.
  */
 import React, { useEffect, useRef, useState } from "react";
 import {
@@ -63,12 +66,20 @@ export interface GiveScreenViewProps {
   submitting: boolean;
   error: string | null;
   checkoutSession: CheckoutSession | null;
+  /**
+   * Whether the waiting step is actually watching for this gift to land.
+   * `false` when Stripe returned no PaymentIntent — nothing will ever advance
+   * the screen, so it has to offer a way out that isn't "Cancel this gift".
+   */
+  canAutoAdvance: boolean;
   onBack: () => void;
   onSelectPreset: (cents: number) => void;
   onCustomAmountChange: (text: string) => void;
   onToggleCoverFees: (value: boolean) => void;
   onContinue: () => void;
   onReopenCheckout: () => void;
+  /** Leaves the give flow for the fund without touching the gift in flight. */
+  onFinishManually: () => void;
 }
 
 export function GiveScreenView({
@@ -80,12 +91,14 @@ export function GiveScreenView({
   submitting,
   error,
   checkoutSession,
+  canAutoAdvance,
   onBack,
   onSelectPreset,
   onCustomAmountChange,
   onToggleCoverFees,
   onContinue,
   onReopenCheckout,
+  onFinishManually,
 }: GiveScreenViewProps) {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
@@ -134,8 +147,10 @@ export function GiveScreenView({
           fundName={context.fundName}
           totalCents={totalCents}
           canReopen={!!checkoutSession}
+          canAutoAdvance={canAutoAdvance}
           onReopenCheckout={onReopenCheckout}
           onCancelGift={onBack}
+          onFinishManually={onFinishManually}
           bottomInset={insets.bottom}
         />
       ) : (
@@ -272,15 +287,19 @@ function WaitingStep({
   fundName,
   totalCents,
   canReopen,
+  canAutoAdvance,
   onReopenCheckout,
   onCancelGift,
+  onFinishManually,
   bottomInset,
 }: {
   fundName: string;
   totalCents: number;
   canReopen: boolean;
+  canAutoAdvance: boolean;
   onReopenCheckout: () => void;
   onCancelGift: () => void;
+  onFinishManually: () => void;
   bottomInset: number;
 }) {
   const { colors } = useTheme();
@@ -299,9 +318,14 @@ function WaitingStep({
             Finish in the browser
           </Text>
           <Text style={[styles.waitingCopy, { color: colors.textSecondary }]}>
-            We&rsquo;ll bring you back here as soon as it goes through.
+            {canAutoAdvance
+              ? "We\u2019ll bring you back here as soon as it goes through."
+              : "We can\u2019t confirm this one automatically \u2014 finish paying, then head back to the fund and your gift will be there."}
           </Text>
-          <PulseDots color={colors.textTertiary} />
+          {/* Dots pulse for something that is actually being watched. With no
+              PaymentIntent to subscribe to, nothing will ever advance this
+              screen, and an animation that implies otherwise is a lie. */}
+          {canAutoAdvance && <PulseDots color={colors.textTertiary} />}
         </View>
       </WaInsetGroup>
 
@@ -313,6 +337,29 @@ function WaitingStep({
       </View>
 
       <View style={styles.waitingActions}>
+        {/* The escape hatch exists ONLY when nothing is watching. With the
+            subscription live, a "Done" would compete with an auto-advance that
+            actually knows the answer; without it, its absence would leave
+            "Cancel this gift" as the only way out of a screen the donor may
+            have already paid on — which resets the form and invites a second
+            gift. This goes to the fund and touches nothing. */}
+        {!canAutoAdvance && (
+          <Pressable
+            onPress={onFinishManually}
+            accessibilityRole="button"
+            accessibilityLabel="Go to the fund"
+            style={({ pressed }) => [
+              styles.secondaryPill,
+              { backgroundColor: colors.buttonPrimary },
+              pressed && styles.pressed,
+            ]}
+          >
+            <Text style={[styles.secondaryLabel, { color: colors.buttonPrimaryText }]}>
+              Go to the fund
+            </Text>
+          </Pressable>
+        )}
+
         <Pressable
           onPress={onReopenCheckout}
           disabled={!canReopen}
@@ -365,7 +412,11 @@ function KeyValueRow({ label, value }: { label: string; value: string }) {
  * screen must never be the thing that triggers someone's vestibular symptoms.
  */
 function PulseDots({ color }: { color: string }) {
-  const [reduceMotion, setReduceMotion] = useState(false);
+  // Starts `true`: the dots must not animate while detection is pending, and
+  // if `isReduceMotionEnabled()` rejects (RN-Web does) there is no answer
+  // coming, so a still dot row stays the resting state rather than a moment of
+  // motion someone asked not to be shown.
+  const [reduceMotion, setReduceMotion] = useState(true);
   // One shared clock, three dots reading different windows of it — cheaper
   // than three loops and guarantees they can never drift apart.
   const progress = useRef(new Animated.Value(0)).current;

--- a/apps/mobile/features/finance/member/GiveScreenView.tsx
+++ b/apps/mobile/features/finance/member/GiveScreenView.tsx
@@ -174,6 +174,10 @@ export function GiveScreenView({
                   <TextInput
                     value={displayText}
                     onChangeText={onCustomAmountChange}
+                    // Tapping in to type means "a different amount", not "add
+                    // digits to the one showing" — without this, focusing a
+                    // $50 preset and typing 2 gives $502.
+                    selectTextOnFocus
                     keyboardType="number-pad"
                     placeholder="0"
                     placeholderTextColor={colors.textTertiary}

--- a/apps/mobile/features/finance/member/GiveScreenView.tsx
+++ b/apps/mobile/features/finance/member/GiveScreenView.tsx
@@ -1,26 +1,57 @@
 /**
- * GiveScreenView — presentational give sheet (ADR-032 §3/§7 Phase 1). Pure
- * props in, no Convex/router imports.
+ * GiveScreenView — presentational give sheet (ADR-032 §3/§7 Phase 1),
+ * restyled onto the WhatsApp shell. Pure props in, no Convex/router imports.
  *
  * Payment is collected on a hosted Stripe Checkout page (ADR-032 §3/§7 Phase
  * 1 decision: zero native dependencies, ships via OTA, Apple Pay works in
  * the browser sheet). The "confirmation" step here isn't a payment
  * confirmation at all — it's a "finish in the browser" waypoint shown right
  * after `GiveScreen` launches the Checkout URL, since the actual payment
- * completes outside this screen (in the browser sheet, then via the
- * `success_url`/`cancel_url` universal link back to the fund screen; Convex
- * reactivity — not the redirect — is what updates the fund balance/activity).
+ * completes outside this screen. On native, `GiveScreen` watches
+ * `getCheckoutSessionStatus` and replaces this step with the success screen
+ * the moment the money lands, so the waiting step's own buttons (Reopen /
+ * Cancel) are the manual fallback, not the happy path. There is deliberately
+ * no "Done": a donor tapping it mid-payment would leave with no idea whether
+ * their gift went through.
  */
-import React from "react";
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from "react-native";
+import React, { useEffect, useRef, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  TextInput,
+  Animated,
+  Easing,
+  AccessibilityInfo,
+} from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@hooks/useTheme";
-import { Button, Input, Switch, Skeleton, EmptyState } from "@components/ui";
+import { Skeleton, EmptyState } from "@components/ui";
+import {
+  WaSubScreenHeader,
+  WaInsetGroup,
+  WaCell,
+  WA_GROUP_MARGIN,
+  WA_GROUP_SPACING,
+  WA_CELL_PADDING,
+  WA_TYPE_FOOTNOTE,
+  WA_TYPE_SUBTITLE,
+  WA_TYPE_ROW_TITLE,
+  WA_WEIGHT_BOLD,
+  WA_WEIGHT_SEMIBOLD,
+} from "@components/wa";
 import { formatCents } from "../format";
 import { estimateCoverFeesCents, resolveGiveAmountCents } from "./amount";
+import { GIVING_GOLD, GIVING_GOLD_TINT } from "./giveTheme";
 import type { CheckoutSession, GivingContext } from "./types";
 
 export type GiveStep = "amount" | "confirmation";
+
+/** Typed-amount display size — the give sheet's one hero number. */
+const AMOUNT_SIZE = 56;
 
 export interface GiveScreenViewProps {
   /** `undefined` while loading, `null` when giving isn't set up for this group. */
@@ -57,31 +88,33 @@ export function GiveScreenView({
   onReopenCheckout,
 }: GiveScreenViewProps) {
   const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
 
   const amountCents = resolveGiveAmountCents(selectedPresetCents, customAmountText);
   const feeCents = coverFees && amountCents ? estimateCoverFeesCents(amountCents) : 0;
   const totalCents = (amountCents ?? 0) + feeCents;
   const canContinue = !!amountCents && !submitting;
 
+  // The big display IS the input: a tapped preset writes its dollars into the
+  // same field the donor types in, so there is one amount on screen and one
+  // source of truth. `onCustomAmountChange` clears the preset upstream, which
+  // is what makes typing over a chip behave the way it looks like it should.
+  const displayText =
+    selectedPresetCents !== null ? String(selectedPresetCents / 100) : customAmountText;
+
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <View
-        style={[
-          styles.header,
-          { backgroundColor: colors.surface, borderBottomColor: colors.border },
-        ]}
-      >
-        <TouchableOpacity style={styles.backButton} onPress={onBack} accessibilityLabel="Back">
-          <Ionicons name="arrow-back" size={24} color={colors.text} />
-        </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: colors.text }]}>Give</Text>
-        <View style={styles.headerSpacer} />
-      </View>
+    <View
+      style={[
+        styles.screen,
+        { backgroundColor: colors.backgroundGrouped, paddingTop: insets.top },
+      ]}
+    >
+      <WaSubScreenHeader title="Give" onBack={onBack} />
 
       {context === undefined ? (
         <View style={styles.loadingContainer} testID="give-screen-loading">
-          <Skeleton height={80} borderRadius={12} style={{ marginBottom: 16 }} />
-          <Skeleton height={160} borderRadius={12} />
+          <Skeleton height={200} borderRadius={24} style={styles.loadingBlock} />
+          <Skeleton height={90} borderRadius={24} />
         </View>
       ) : context === null ? (
         <EmptyState
@@ -97,161 +130,441 @@ export function GiveScreenView({
           style={styles.emptyState}
         />
       ) : step === "confirmation" ? (
-        <ScrollView contentContainerStyle={styles.scrollContent}>
-          <View style={[styles.confirmationPanel, { backgroundColor: colors.surfaceSecondary }]}>
-            <Ionicons name="lock-closed" size={40} color={colors.success} />
-            <Text style={[styles.confirmationTitle, { color: colors.text }]}>
-              Finish your gift in the browser
-            </Text>
-            <Text style={[styles.confirmationSubtitle, { color: colors.textSecondary }]}>
-              Complete your gift in the secure Stripe page that just opened.
-              Once it's done, you can close that page and come back here.
-            </Text>
-            <View style={styles.confirmationRow}>
-              <Text style={[styles.confirmationLabel, { color: colors.textSecondary }]}>
-                Amount
-              </Text>
-              <Text style={[styles.confirmationValue, { color: colors.text }]}>
-                {formatCents(totalCents)}
-              </Text>
-            </View>
-            <View style={styles.confirmationRow}>
-              <Text style={[styles.confirmationLabel, { color: colors.textSecondary }]}>
-                Fund
-              </Text>
-              <Text style={[styles.confirmationValue, { color: colors.text }]}>
-                {context.fundName}
-              </Text>
-            </View>
-          </View>
-
-          <Button
-            onPress={onReopenCheckout}
-            disabled={!checkoutSession}
-            variant="secondary"
-          >
-            Reopen payment page
-          </Button>
-
-          <Button onPress={onBack}>Done</Button>
-        </ScrollView>
+        <WaitingStep
+          fundName={context.fundName}
+          totalCents={totalCents}
+          canReopen={!!checkoutSession}
+          onReopenCheckout={onReopenCheckout}
+          onCancelGift={onBack}
+          bottomInset={insets.bottom}
+        />
       ) : (
-        <ScrollView contentContainerStyle={styles.scrollContent}>
-          <Text style={[styles.legalLine, { color: colors.textSecondary }]}>
-            Tax-deductible gift to {context.communityLegalName}
-          </Text>
+        <>
+          <ScrollView
+            contentContainerStyle={[
+              styles.scrollContent,
+              { paddingBottom: insets.bottom + CTA_CLEARANCE },
+            ]}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            <Text style={[styles.kicker, { color: colors.textSecondary }]}>
+              Tax-deductible gift to {context.communityLegalName}
+            </Text>
 
-          <View style={styles.presetRow}>
-            {context.suggestedAmountsCents.map((cents) => {
-              const selected = selectedPresetCents === cents;
-              return (
-                <TouchableOpacity
-                  key={cents}
-                  onPress={() => onSelectPreset(cents)}
-                  accessibilityLabel={`${formatCents(cents)} preset`}
-                  style={[
-                    styles.presetChip,
-                    {
-                      backgroundColor: selected ? colors.buttonPrimary : colors.surfaceSecondary,
-                      borderColor: selected ? colors.buttonPrimary : colors.border,
-                    },
-                  ]}
-                >
-                  <Text
-                    style={[
-                      styles.presetChipText,
-                      { color: selected ? colors.textInverse : colors.text },
-                    ]}
-                  >
-                    {formatCents(cents)}
-                  </Text>
-                </TouchableOpacity>
-              );
-            })}
-          </View>
+            <WaInsetGroup>
+              <View style={styles.amountCard}>
+                <View style={styles.amountRow}>
+                  <Text style={[styles.amountPrefix, { color: colors.textSecondary }]}>$</Text>
+                  <TextInput
+                    value={displayText}
+                    onChangeText={onCustomAmountChange}
+                    keyboardType="number-pad"
+                    placeholder="0"
+                    placeholderTextColor={colors.textTertiary}
+                    accessibilityLabel="Gift amount in dollars"
+                    testID="give-amount-input"
+                    style={[styles.amountInput, { color: colors.text }]}
+                  />
+                </View>
 
-          <Input
-            label="Custom amount"
-            placeholder="$0"
-            value={customAmountText}
-            onChangeText={onCustomAmountChange}
-            style={styles.customAmountInput}
-          />
+                <View style={styles.presetRow}>
+                  {context.suggestedAmountsCents.map((cents) => {
+                    const selected = selectedPresetCents === cents;
+                    return (
+                      <Pressable
+                        key={cents}
+                        onPress={() => onSelectPreset(cents)}
+                        accessibilityRole="button"
+                        accessibilityLabel={`${formatCents(cents)} preset`}
+                        accessibilityState={{ selected }}
+                        style={({ pressed }) => [
+                          styles.presetChip,
+                          {
+                            backgroundColor: selected
+                              ? colors.buttonPrimary
+                              : colors.backgroundGrouped,
+                          },
+                          pressed && styles.pressed,
+                        ]}
+                      >
+                        <Text
+                          style={[
+                            styles.presetChipText,
+                            { color: selected ? colors.buttonPrimaryText : colors.text },
+                          ]}
+                        >
+                          {formatCents(cents)}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </View>
+            </WaInsetGroup>
 
-          <View style={[styles.feeCard, { backgroundColor: colors.surfaceSecondary }]}>
-            <Switch
-              value={coverFees}
-              onValueChange={onToggleCoverFees}
-              label="Cover the processing fee"
-            />
-            {coverFees && !!amountCents && (
-              <Text style={[styles.feeText, { color: colors.textSecondary }]}>
-                +{formatCents(feeCents)} added — {formatCents(totalCents)} total
-              </Text>
+            <View style={styles.group}>
+              <WaInsetGroup>
+                <WaCell
+                  variant="toggle"
+                  title="Cover the processing fee"
+                  description={
+                    amountCents
+                      ? `+${formatCents(estimateCoverFeesCents(amountCents))} so the fund gets the full ${formatCents(amountCents)}`
+                      : "Stripe's cut comes out of the gift unless you cover it."
+                  }
+                  toggleValue={coverFees}
+                  onToggleChange={onToggleCoverFees}
+                  accent={GIVING_GOLD}
+                />
+              </WaInsetGroup>
+            </View>
+
+            {!!error && (
+              <Text style={[styles.errorText, { color: colors.error }]}>{error}</Text>
             )}
+          </ScrollView>
+
+          {/* Pinned rather than `WaFloatingCta`: that component positions itself
+              against the floating tab island's band, which this sub-screen
+              doesn't have, and it fills with the community accent where the
+              approved design calls for the neutral dark primary. */}
+          <View style={[styles.ctaBar, { paddingBottom: insets.bottom + 12 }]}>
+            <Pressable
+              onPress={onContinue}
+              disabled={!canContinue}
+              accessibilityRole="button"
+              accessibilityLabel={amountCents ? `Give ${formatCents(totalCents)}` : "Give"}
+              accessibilityState={{ disabled: !canContinue }}
+              style={({ pressed }) => [
+                styles.ctaPill,
+                {
+                  backgroundColor: canContinue ? colors.buttonPrimary : colors.buttonDisabled,
+                },
+                pressed && styles.pressed,
+              ]}
+            >
+              <Text
+                style={[
+                  styles.ctaLabel,
+                  { color: canContinue ? colors.buttonPrimaryText : colors.textSecondary },
+                ]}
+              >
+                {amountCents ? `Give ${formatCents(totalCents)}` : "Give"}
+              </Text>
+            </Pressable>
           </View>
-
-          {!!error && (
-            <Text style={[styles.errorText, { color: colors.error }]}>{error}</Text>
-          )}
-
-          <Button onPress={onContinue} disabled={!canContinue} loading={submitting}>
-            Continue
-          </Button>
-        </ScrollView>
+        </>
       )}
     </View>
   );
 }
 
+/**
+ * The waiting step — shown while the donor is in the Stripe browser sheet.
+ *
+ * On native this screen is transient: `GiveScreen` subscribes to
+ * `getCheckoutSessionStatus` and routes to the success screen the moment the
+ * donation is recorded. The pulse is what tells a donor staring at a static
+ * page that something is still happening.
+ */
+function WaitingStep({
+  fundName,
+  totalCents,
+  canReopen,
+  onReopenCheckout,
+  onCancelGift,
+  bottomInset,
+}: {
+  fundName: string;
+  totalCents: number;
+  canReopen: boolean;
+  onReopenCheckout: () => void;
+  onCancelGift: () => void;
+  bottomInset: number;
+}) {
+  const { colors } = useTheme();
+
+  return (
+    <ScrollView
+      contentContainerStyle={[styles.scrollContent, { paddingBottom: bottomInset + 32 }]}
+      showsVerticalScrollIndicator={false}
+    >
+      <WaInsetGroup>
+        <View style={styles.waitingCard}>
+          <View style={[styles.lockTile, { backgroundColor: GIVING_GOLD_TINT }]}>
+            <Ionicons name="lock-closed" size={26} color={GIVING_GOLD} />
+          </View>
+          <Text style={[styles.waitingTitle, { color: colors.text }]}>
+            Finish in the browser
+          </Text>
+          <Text style={[styles.waitingCopy, { color: colors.textSecondary }]}>
+            We&rsquo;ll bring you back here as soon as it goes through.
+          </Text>
+          <PulseDots color={colors.textTertiary} />
+        </View>
+      </WaInsetGroup>
+
+      <View style={styles.group}>
+        <WaInsetGroup separatorInset={0}>
+          <KeyValueRow label="Amount" value={formatCents(totalCents)} />
+          <KeyValueRow label="Fund" value={fundName} />
+        </WaInsetGroup>
+      </View>
+
+      <View style={styles.waitingActions}>
+        <Pressable
+          onPress={onReopenCheckout}
+          disabled={!canReopen}
+          accessibilityRole="button"
+          accessibilityLabel="Reopen payment page"
+          accessibilityState={{ disabled: !canReopen }}
+          style={({ pressed }) => [
+            styles.secondaryPill,
+            { backgroundColor: colors.surfaceGrouped, opacity: canReopen ? 1 : 0.5 },
+            pressed && styles.pressed,
+          ]}
+        >
+          <Text style={[styles.secondaryLabel, { color: colors.text }]}>
+            Reopen payment page
+          </Text>
+        </Pressable>
+
+        <Pressable
+          onPress={onCancelGift}
+          accessibilityRole="button"
+          accessibilityLabel="Cancel this gift"
+          style={({ pressed }) => [styles.ghostPill, pressed && styles.pressed]}
+        >
+          <Text style={[styles.ghostLabel, { color: colors.textSecondary }]}>
+            Cancel this gift
+          </Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}
+
+function KeyValueRow({ label, value }: { label: string; value: string }) {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.kvRow}>
+      <Text style={[styles.kvLabel, { color: colors.textSecondary }]}>{label}</Text>
+      <Text style={[styles.kvValue, { color: colors.text }]} numberOfLines={1}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * Three dots pulsing in sequence.
+ *
+ * The app has no reduced-motion helper, so this asks `AccessibilityInfo`
+ * directly and renders the dots at rest when the setting is on — a waiting
+ * screen must never be the thing that triggers someone's vestibular symptoms.
+ */
+function PulseDots({ color }: { color: string }) {
+  const [reduceMotion, setReduceMotion] = useState(false);
+  // One shared clock, three dots reading different windows of it — cheaper
+  // than three loops and guarantees they can never drift apart.
+  const progress = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    let cancelled = false;
+    AccessibilityInfo.isReduceMotionEnabled()
+      .then((enabled) => {
+        if (!cancelled) setReduceMotion(enabled);
+      })
+      .catch(() => {
+        // Some platforms (RN-Web) reject rather than resolve; a still dot
+        // row is the safe default.
+      });
+    const subscription = AccessibilityInfo.addEventListener(
+      "reduceMotionChanged",
+      setReduceMotion,
+    );
+    return () => {
+      cancelled = true;
+      subscription?.remove?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (reduceMotion) return;
+    const loop = Animated.loop(
+      Animated.timing(progress, {
+        toValue: 3,
+        duration: 1200,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      }),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [progress, reduceMotion]);
+
+  return (
+    <View style={styles.dots} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+      {[0, 1, 2].map((index) => (
+        <Animated.View
+          key={index}
+          style={[
+            styles.dot,
+            { backgroundColor: color },
+            reduceMotion
+              ? { opacity: 0.4 }
+              : {
+                  opacity: progress.interpolate({
+                    inputRange: [index - 1, index, index + 1, index + 3],
+                    outputRange: [0.25, 1, 0.25, 0.25],
+                    extrapolate: "clamp",
+                  }),
+                },
+          ]}
+        />
+      ))}
+    </View>
+  );
+}
+
+/**
+ * The static "you cancelled" page — what the Stripe `cancel_url` lands on
+ * INSIDE the in-app browser on native, where the app has no auth token (that
+ * browser has its own storage). Every query on the give screen would skip and
+ * sit at `undefined` forever, so the donor would watch a permanent skeleton.
+ * This renders instead: no queries, no spinner, and no instruction the donor
+ * can't follow from inside a browser sheet.
+ */
+export function GiveCancelledNotice() {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  return (
+    <View
+      style={[
+        styles.screen,
+        styles.cancelled,
+        { backgroundColor: colors.backgroundGrouped, paddingTop: insets.top },
+      ]}
+      testID="give-cancelled-notice"
+    >
+      <Ionicons name="close-circle-outline" size={44} color={colors.textSecondary} />
+      <Text style={[styles.cancelledTitle, { color: colors.text }]}>Gift cancelled</Text>
+      <Text style={[styles.cancelledCopy, { color: colors.textSecondary }]}>
+        You can close this window.
+      </Text>
+    </View>
+  );
+}
+
+/** Room the scroll content leaves for the pinned CTA bar above it. */
+const CTA_CLEARANCE = 86;
+
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  header: {
-    flexDirection: "row",
-    alignItems: "center",
-    padding: 16,
-    borderBottomWidth: 1,
-  },
-  backButton: { padding: 4 },
-  headerTitle: {
-    flex: 1,
-    fontSize: 18,
-    fontWeight: "600",
-    textAlign: "center",
-    marginRight: 32,
-  },
-  headerSpacer: { width: 32 },
-  loadingContainer: { padding: 16 },
+  screen: { flex: 1 },
+  loadingContainer: { padding: WA_GROUP_MARGIN },
+  loadingBlock: { marginBottom: 16 },
   emptyState: { flex: 1, justifyContent: "center" },
-  scrollContent: { padding: 16, gap: 16, paddingBottom: 32 },
-  legalLine: { fontSize: 14, textAlign: "center" },
-  presetRow: { flexDirection: "row", gap: 10 },
+  scrollContent: { paddingTop: 8 },
+  group: { marginTop: WA_GROUP_SPACING },
+  pressed: { opacity: 0.85 },
+
+  kicker: {
+    fontSize: WA_TYPE_FOOTNOTE,
+    textAlign: "center",
+    marginBottom: 16,
+    paddingHorizontal: WA_GROUP_MARGIN,
+  },
+
+  amountCard: { paddingHorizontal: WA_CELL_PADDING, paddingTop: 20, paddingBottom: 16 },
+  amountRow: { flexDirection: "row", alignItems: "flex-start", justifyContent: "center" },
+  amountPrefix: {
+    fontSize: 24,
+    fontWeight: WA_WEIGHT_SEMIBOLD,
+    marginTop: 12,
+    marginRight: 2,
+  },
+  amountInput: {
+    fontSize: AMOUNT_SIZE,
+    fontWeight: WA_WEIGHT_BOLD,
+    fontVariant: ["tabular-nums"],
+    minWidth: 80,
+    paddingVertical: 0,
+    textAlign: "center",
+  },
+  presetRow: { flexDirection: "row", gap: 10, marginTop: 20 },
   presetChip: {
     flex: 1,
-    borderRadius: 12,
-    borderWidth: 1,
-    paddingVertical: 14,
+    borderRadius: 22,
+    paddingVertical: 12,
     alignItems: "center",
   },
-  presetChipText: { fontSize: 16, fontWeight: "600" },
-  customAmountInput: { marginTop: 0 },
-  feeCard: { borderRadius: 12, padding: 14, gap: 6 },
-  feeText: { fontSize: 13 },
-  errorText: { fontSize: 14, textAlign: "center" },
-  confirmationPanel: {
-    borderRadius: 16,
-    padding: 24,
-    alignItems: "center",
-    gap: 8,
+  presetChipText: { fontSize: WA_TYPE_SUBTITLE, fontWeight: WA_WEIGHT_SEMIBOLD },
+
+  errorText: {
+    fontSize: WA_TYPE_SUBTITLE,
+    textAlign: "center",
+    marginTop: 16,
+    paddingHorizontal: WA_GROUP_MARGIN,
   },
-  confirmationTitle: { fontSize: 18, fontWeight: "700", marginTop: 4 },
-  confirmationSubtitle: { fontSize: 13, textAlign: "center", marginBottom: 8 },
-  confirmationRow: {
+
+  ctaBar: {
+    paddingHorizontal: WA_GROUP_MARGIN,
+    paddingTop: 12,
+  },
+  ctaPill: {
+    height: 50,
+    borderRadius: 25,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  ctaLabel: {
+    fontSize: WA_TYPE_ROW_TITLE,
+    fontWeight: WA_WEIGHT_SEMIBOLD,
+    fontVariant: ["tabular-nums"],
+  },
+
+  waitingCard: { alignItems: "center", paddingHorizontal: WA_CELL_PADDING, paddingVertical: 28 },
+  lockTile: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 16,
+  },
+  waitingTitle: { fontSize: 20, fontWeight: WA_WEIGHT_BOLD },
+  waitingCopy: {
+    fontSize: WA_TYPE_SUBTITLE,
+    textAlign: "center",
+    marginTop: 6,
+  },
+  dots: { flexDirection: "row", gap: 6, marginTop: 20 },
+  dot: { width: 7, height: 7, borderRadius: 3.5 },
+
+  kvRow: {
     flexDirection: "row",
+    alignItems: "center",
     justifyContent: "space-between",
-    width: "100%",
-    paddingVertical: 6,
+    paddingHorizontal: WA_CELL_PADDING,
+    minHeight: 54,
+    gap: 12,
   },
-  confirmationLabel: { fontSize: 14 },
-  confirmationValue: { fontSize: 14, fontWeight: "600" },
+  kvLabel: { fontSize: WA_TYPE_ROW_TITLE },
+  kvValue: { fontSize: WA_TYPE_ROW_TITLE, fontWeight: WA_WEIGHT_SEMIBOLD, flexShrink: 1 },
+
+  waitingActions: { marginTop: WA_GROUP_SPACING, paddingHorizontal: WA_GROUP_MARGIN, gap: 8 },
+  secondaryPill: {
+    height: 50,
+    borderRadius: 25,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  secondaryLabel: { fontSize: WA_TYPE_ROW_TITLE, fontWeight: WA_WEIGHT_SEMIBOLD },
+  ghostPill: { height: 44, alignItems: "center", justifyContent: "center" },
+  ghostLabel: { fontSize: WA_TYPE_SUBTITLE },
+
+  cancelled: { alignItems: "center", justifyContent: "center", padding: 32 },
+  cancelledTitle: { fontSize: 22, fontWeight: WA_WEIGHT_BOLD, marginTop: 16 },
+  cancelledCopy: { fontSize: WA_TYPE_SUBTITLE, marginTop: 6, textAlign: "center" },
 });

--- a/apps/mobile/features/finance/member/__tests__/FundScreenView.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/FundScreenView.test.tsx
@@ -24,7 +24,12 @@ jest.mock("@hooks/useTheme", () => ({
       link: "#06f",
       destructive: "#c00",
       iconSecondary: "#999",
+      separator: "#e0e0e0",
+      backgroundGrouped: "#F2F2F2",
+      surfaceGrouped: "#FFFFFF",
+      buttonPrimaryText: "#fff",
     },
+    isDark: false,
   }),
 }));
 
@@ -179,7 +184,7 @@ describe("FundScreenView", () => {
     expect(screen.queryByText(/card fees/)).toBeNull();
   });
 
-  it("labels activity kinds and formats signed amounts, showing donor names when present", () => {
+  it("titles an activity row with the donor and captions it with kind + date", () => {
     render(
       <FundScreenView
         overview={baseOverview}
@@ -189,12 +194,26 @@ describe("FundScreenView", () => {
         onGetReimbursedPress={noop}
       />,
     );
-    expect(screen.getByText("Donation")).toBeTruthy();
-    expect(screen.getByText(formatSignedCents(5000, "credit"))).toBeTruthy();
     expect(screen.getByText("Jane Smith")).toBeTruthy();
-
-    expect(screen.getByText("Card purchase")).toBeTruthy();
+    expect(screen.getByText(/^Donation · /)).toBeTruthy();
+    expect(screen.getByText(formatSignedCents(5000, "credit"))).toBeTruthy();
     expect(screen.getByText(formatSignedCents(1200, "debit"))).toBeTruthy();
+  });
+
+  // An anonymized debit has no name to lead with, so the kind has to serve as
+  // the title — otherwise the row opens with a blank line.
+  it("falls back to the ledger kind as the title when there's no donor name", () => {
+    render(
+      <FundScreenView
+        overview={baseOverview}
+        myExpenses={baseExpenses}
+        onBack={noop}
+        onGivePress={noop}
+        onGetReimbursedPress={noop}
+      />,
+    );
+    expect(screen.getByText("Card purchase")).toBeTruthy();
+    expect(screen.getByText(/^Card purchase · /)).toBeTruthy();
   });
 
   it("hides donor names when the overview omits them (viewer isn't manager+)", () => {
@@ -227,6 +246,64 @@ describe("FundScreenView", () => {
     );
     expect(screen.getByText("Snacks")).toBeTruthy();
     expect(screen.getByText("Pending")).toBeTruthy();
+  });
+
+  it("offers 'Get reimbursed' as a cell in the reimbursements card, not in the hero", () => {
+    const onGetReimbursedPress = jest.fn();
+    render(
+      <FundScreenView
+        overview={baseOverview}
+        myExpenses={baseExpenses}
+        onBack={noop}
+        onGivePress={noop}
+        onGetReimbursedPress={onGetReimbursedPress}
+      />,
+    );
+    fireEvent.press(screen.getByText("Get reimbursed"));
+    expect(onGetReimbursedPress).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Spent for the group? Send the receipt.")).toBeTruthy();
+  });
+
+  it("says so plainly when the viewer has no reimbursement requests", () => {
+    render(
+      <FundScreenView
+        overview={baseOverview}
+        myExpenses={[]}
+        onBack={noop}
+        onGivePress={noop}
+        onGetReimbursedPress={noop}
+      />,
+    );
+    expect(screen.getByText("No requests yet")).toBeTruthy();
+  });
+
+  // `onManagePress` IS the permission gate — a member without it must not see
+  // the leader hub exists at all.
+  describe("Fund settings", () => {
+    const renderWithManage = (onManagePress?: () => void) =>
+      render(
+        <FundScreenView
+          overview={baseOverview}
+          myExpenses={baseExpenses}
+          onBack={noop}
+          onGivePress={noop}
+          onGetReimbursedPress={noop}
+          onManagePress={onManagePress}
+        />,
+      );
+
+    it("is hidden for a viewer who can't manage the fund", () => {
+      renderWithManage(undefined);
+      expect(screen.queryByText("Fund settings")).toBeNull();
+    });
+
+    it("opens the leader hub for a manager", () => {
+      const onManagePress = jest.fn();
+      renderWithManage(onManagePress);
+      expect(screen.getByText("Leaders only")).toBeTruthy();
+      fireEvent.press(screen.getByText("Fund settings"));
+      expect(onManagePress).toHaveBeenCalledTimes(1);
+    });
   });
 
   // An approved reimbursement is NOT money in flight: the ACH payout is still
@@ -282,7 +359,7 @@ describe("FundScreenView", () => {
     });
   });
 
-  it("fires onGivePress from the header Give button", () => {
+  it("fires onGivePress from the hero's single primary pill", () => {
     const onGivePress = jest.fn();
     render(
       <FundScreenView

--- a/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * GiveScreen (container) — the wiring the view can't be asked about.
+ *
+ * Everything here is a regression guard on the post-Stripe return path, which
+ * is unobservable in `GiveScreenView`'s tests because it lives entirely in the
+ * container: which id the waiting step subscribes with, that it navigates
+ * exactly once, and that the auth-less cancel return short-circuits before any
+ * loading UI.
+ */
+import React from "react";
+import { render, fireEvent, act } from "@testing-library/react-native";
+import * as WebBrowser from "expo-web-browser";
+import { useAuthenticatedQuery, useStoredAuthToken } from "@services/api/convex";
+import { useLocalSearchParams } from "expo-router";
+import { GiveScreen } from "../GiveScreen";
+
+const GET_GIVING_CONTEXT = "api.functions.finance.giving.getGivingContext";
+const GET_CHECKOUT_STATUS = "api.functions.finance.giving.getCheckoutSessionStatus";
+
+jest.mock("@services/api/convex", () => ({
+  api: {
+    functions: {
+      finance: {
+        giving: {
+          getGivingContext: "api.functions.finance.giving.getGivingContext",
+          getCheckoutSessionStatus:
+            "api.functions.finance.giving.getCheckoutSessionStatus",
+          createDonationCheckoutSession:
+            "api.functions.finance.giving.createDonationCheckoutSession",
+        },
+      },
+    },
+  },
+  useAuthenticatedQuery: jest.fn(),
+  useAuthenticatedAction: jest.fn(),
+  useStoredAuthToken: jest.fn(),
+}));
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+jest.mock("expo-web-browser", () => ({
+  openBrowserAsync: jest.fn().mockResolvedValue(undefined),
+  dismissBrowser: jest.fn().mockResolvedValue(undefined),
+}));
+
+// The view is stubbed to the handful of affordances the container drives, so
+// these tests fail for container reasons only.
+jest.mock("../GiveScreenView", () => {
+  const { Text, Pressable } = require("react-native");
+  return {
+    GiveScreenView: ({ step, onContinue, onBack, onSelectPreset }: any) => (
+      <>
+        <Text testID="give-step">{step}</Text>
+        <Pressable testID="give-preset" onPress={() => onSelectPreset(5000)}>
+          <Text>$50</Text>
+        </Pressable>
+        <Pressable testID="give-continue" onPress={onContinue}>
+          <Text>Give</Text>
+        </Pressable>
+        <Pressable testID="give-back" onPress={onBack}>
+          <Text>Back</Text>
+        </Pressable>
+      </>
+    ),
+    GiveCancelledNotice: () => <Text testID="give-cancelled-notice">Gift cancelled</Text>,
+  };
+});
+
+const { useAuthenticatedAction } = jest.requireMock("@services/api/convex");
+const { useRouter } = jest.requireMock("expo-router");
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+const mockCreateSession = jest.fn();
+
+const liveContext = {
+  fundId: "fund_1",
+  fundName: "Young Adults — Manhattan",
+  communityLegalName: "First Church Inc.",
+  givingLive: true,
+  suggestedAmountsCents: [2500, 5000],
+};
+
+/** Convex hands back a fresh object per update; identity churn is what the
+ * navigate-once guard has to survive. */
+let checkoutStatus: Record<string, unknown> | undefined;
+
+function mockQueries() {
+  (useAuthenticatedQuery as jest.Mock).mockImplementation(
+    (fn: string, args: unknown) => {
+      if (fn === GET_GIVING_CONTEXT) return liveContext;
+      if (fn === GET_CHECKOUT_STATUS) {
+        return args === "skip" || !checkoutStatus ? undefined : { ...checkoutStatus };
+      }
+      return undefined;
+    },
+  );
+}
+
+/** The args the waiting step passed to `getCheckoutSessionStatus`, last call. */
+function lastStatusArgs() {
+  const calls = (useAuthenticatedQuery as jest.Mock).mock.calls.filter(
+    ([fn]) => fn === GET_CHECKOUT_STATUS,
+  );
+  return calls[calls.length - 1]?.[1];
+}
+
+/** Picks an amount, then submits — `handleContinue` no-ops without one. */
+async function pressGive(getByTestId: (id: string) => unknown) {
+  await act(async () => {
+    fireEvent.press(getByTestId("give-preset") as never);
+  });
+  await act(async () => {
+    fireEvent.press(getByTestId("give-continue") as never);
+  });
+}
+
+describe("GiveScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    checkoutStatus = undefined;
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ group_id: "group_1" });
+    (useStoredAuthToken as jest.Mock).mockReturnValue("token_abc");
+    (useRouter as jest.Mock).mockReturnValue({
+      replace: mockReplace,
+      push: mockPush,
+      back: jest.fn(),
+      canGoBack: () => true,
+    });
+    (useAuthenticatedAction as jest.Mock).mockReturnValue(mockCreateSession);
+    mockCreateSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/c/pay/cs_test_123",
+      sessionId: "cs_test_123",
+      paymentIntentId: "pi_test_123",
+    });
+    mockQueries();
+  });
+
+  it("does not watch anything until the donor is actually waiting", () => {
+    render(<GiveScreen />);
+    expect(lastStatusArgs()).toBe("skip");
+  });
+
+  // The Checkout Session id (`cs_...`) is not stored anywhere — subscribing
+  // with it would report "pending" forever and the donor would never advance.
+  it("watches the PaymentIntent id, never the Checkout Session id", async () => {
+    const { getByTestId } = render(<GiveScreen />);
+    await pressGive(getByTestId);
+
+    expect(lastStatusArgs()).toEqual({ paymentIntentId: "pi_test_123" });
+    expect(JSON.stringify(lastStatusArgs())).not.toContain("cs_test_123");
+  });
+
+  // Stripe can defer creating the PaymentIntent; the gift still lands via the
+  // webhook, so the wait degrades to manual rather than subscribing to garbage.
+  it("skips the watch when Stripe returned no PaymentIntent", async () => {
+    mockCreateSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/c/pay/cs_test_123",
+      sessionId: "cs_test_123",
+      paymentIntentId: null,
+    });
+    const { getByTestId } = render(<GiveScreen />);
+    await pressGive(getByTestId);
+
+    expect(getByTestId("give-step").props.children).toBe("confirmation");
+    expect(lastStatusArgs()).toBe("skip");
+  });
+
+  it("routes to the thank-you screen with the recorded amount once the gift lands", async () => {
+    checkoutStatus = {
+      status: "complete",
+      amountCents: 5300,
+      fundName: "Young Adults — Manhattan",
+      communityName: "First Church Inc.",
+    };
+    const { getByTestId } = render(<GiveScreen />);
+    await pressGive(getByTestId);
+
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/groups/group_1/give-success?amount=5300" +
+        `&fund=${encodeURIComponent("Young Adults — Manhattan")}` +
+        `&community=${encodeURIComponent("First Church Inc.")}`,
+    );
+  });
+
+  // The status query keeps reporting "complete" with a fresh object every
+  // update; `router.replace` is not idempotent, so the guard is load-bearing.
+  it("navigates exactly once no matter how many times 'complete' re-renders", async () => {
+    checkoutStatus = { status: "complete", amountCents: 5000 };
+    const { getByTestId, rerender } = render(<GiveScreen />);
+    await pressGive(getByTestId);
+
+    await act(async () => {
+      rerender(<GiveScreen />);
+      rerender(<GiveScreen />);
+    });
+
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays put while the gift is still pending", async () => {
+    checkoutStatus = { status: "pending" };
+    const { getByTestId } = render(<GiveScreen />);
+    await pressGive(getByTestId);
+
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(getByTestId("give-step").props.children).toBe("confirmation");
+  });
+
+  it("dismisses the browser sheet it opened before handing over to the thank-you", async () => {
+    checkoutStatus = { status: "complete", amountCents: 5000 };
+    const { getByTestId } = render(<GiveScreen />);
+    await pressGive(getByTestId);
+
+    expect(WebBrowser.openBrowserAsync).toHaveBeenCalledWith(
+      "https://checkout.stripe.com/c/pay/cs_test_123",
+    );
+    expect(WebBrowser.dismissBrowser).toHaveBeenCalled();
+  });
+
+  describe("the cancel return", () => {
+    // Stripe's cancel_url loads inside the in-app browser, which has its own
+    // storage and no token: every query skips, so the give screen would sit on
+    // a skeleton forever. The notice must render instead — and immediately.
+    it("renders the static notice, with no loading state, when there is no auth", () => {
+      (useLocalSearchParams as jest.Mock).mockReturnValue({
+        group_id: "group_1",
+        giving: "cancelled",
+      });
+      (useStoredAuthToken as jest.Mock).mockReturnValue(null);
+
+      const { getByTestId, queryByTestId } = render(<GiveScreen />);
+      expect(getByTestId("give-cancelled-notice")).toBeTruthy();
+      expect(queryByTestId("give-step")).toBeNull();
+    });
+
+    it("returns an authenticated donor to the give form instead", () => {
+      (useLocalSearchParams as jest.Mock).mockReturnValue({
+        group_id: "group_1",
+        giving: "cancelled",
+      });
+
+      const { getByTestId, queryByTestId } = render(<GiveScreen />);
+      expect(queryByTestId("give-cancelled-notice")).toBeNull();
+      expect(getByTestId("give-step").props.children).toBe("amount");
+    });
+  });
+});

--- a/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
@@ -190,6 +190,25 @@ describe("GiveScreen", () => {
     );
   });
 
+  // A lone surrogate in a fund/community name makes `encodeURIComponent` throw,
+  // and it would throw here — inside the effect, after the navigate-once guard
+  // has latched — costing the donor the thank-you with no retry.
+  it("survives a name that would make encodeURIComponent throw", async () => {
+    checkoutStatus = {
+      status: "complete",
+      amountCents: 5000,
+      fundName: "Fund \ud800",
+      communityName: "First Church",
+    };
+    const { getByTestId } = render(<GiveScreen />);
+    await pressGive(getByTestId);
+
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/groups/group_1/give-success?amount=5000&fund=Fund%20&community=First%20Church",
+    );
+  });
+
   // The status query keeps reporting "complete" with a fresh object every
   // update; `router.replace` is not idempotent, so the guard is load-bearing.
   it("navigates exactly once no matter how many times 'complete' re-renders", async () => {

--- a/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
@@ -51,9 +51,10 @@ jest.mock("expo-web-browser", () => ({
 jest.mock("../GiveScreenView", () => {
   const { Text, Pressable } = require("react-native");
   return {
-    GiveScreenView: ({ step, onContinue, onBack, onSelectPreset }: any) => (
+    GiveScreenView: ({ step, onContinue, onBack, onSelectPreset, canAutoAdvance }: any) => (
       <>
         <Text testID="give-step">{step}</Text>
+        <Text testID="give-can-auto-advance">{String(canAutoAdvance)}</Text>
         <Pressable testID="give-preset" onPress={() => onSelectPreset(5000)}>
           <Text>$50</Text>
         </Pressable>
@@ -167,6 +168,8 @@ describe("GiveScreen", () => {
 
     expect(getByTestId("give-step").props.children).toBe("confirmation");
     expect(lastStatusArgs()).toBe("skip");
+    // ...and the view is told, so it can offer an exit that isn't "Cancel".
+    expect(getByTestId("give-can-auto-advance").props.children).toBe("false");
   });
 
   it("routes to the thank-you screen with the recorded amount once the gift lands", async () => {

--- a/apps/mobile/features/finance/member/__tests__/GiveScreenView.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/GiveScreenView.test.tsx
@@ -152,6 +152,14 @@ describe("GiveScreenView", () => {
     expect(screen.getByTestId("give-amount-input").props.value).toBe("37");
   });
 
+  // Focusing a $50 preset and typing 2 must mean $2, not $502 — the caret
+  // sitting after the preset's digits would otherwise turn a replacement into
+  // a ten-times-larger gift.
+  it("selects the showing amount on focus so typing replaces it", () => {
+    render(<GiveScreenView {...baseProps} selectedPresetCents={5000} />);
+    expect(screen.getByTestId("give-amount-input").props.selectTextOnFocus).toBe(true);
+  });
+
   it("routes typing through onCustomAmountChange (which clears the preset upstream)", () => {
     const onCustomAmountChange = jest.fn();
     render(

--- a/apps/mobile/features/finance/member/__tests__/GiveScreenView.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/GiveScreenView.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react-native";
-import { GiveScreenView } from "../GiveScreenView";
+import { GiveScreenView, GiveCancelledNotice } from "../GiveScreenView";
 import { estimateCoverFeesCents } from "../amount";
 import { formatCents } from "../../format";
 import type { GivingContext } from "../types";
@@ -24,7 +24,12 @@ jest.mock("@hooks/useTheme", () => ({
       link: "#06f",
       destructive: "#c00",
       iconSecondary: "#999",
+      separator: "#e0e0e0",
+      backgroundGrouped: "#F2F2F2",
+      surfaceGrouped: "#FFFFFF",
+      buttonPrimaryText: "#fff",
     },
+    isDark: false,
   }),
 }));
 
@@ -116,7 +121,7 @@ describe("GiveScreenView", () => {
       <GiveScreenView {...baseProps} context={{ ...liveContext, givingLive: false }} />,
     );
     expect(screen.getByText("Giving isn't available right now")).toBeTruthy();
-    expect(screen.queryByText("Continue")).toBeNull();
+    expect(screen.queryByLabelText("Give")).toBeNull();
   });
 
   it("shows the tax-deductible legal line with the community's legal name", () => {
@@ -133,76 +138,114 @@ describe("GiveScreenView", () => {
     expect(onSelectPreset).toHaveBeenCalledWith(5000);
   });
 
-  it("disables Continue until an amount is chosen", () => {
-    render(<GiveScreenView {...baseProps} />);
-    const continueButton = screen.getByLabelText("Continue");
-    expect(continueButton.props.accessibilityState.disabled).toBe(true);
-  });
-
-  it("enables Continue once a preset is selected", () => {
+  // The big display and the chips are one field: a tapped chip writes its
+  // dollars into the same input the donor types in.
+  it("shows a tapped preset's dollars in the typed-amount display", () => {
     render(<GiveScreenView {...baseProps} selectedPresetCents={5000} />);
-    const continueButton = screen.getByLabelText("Continue");
-    expect(continueButton.props.accessibilityState.disabled).toBe(false);
+    expect(screen.getByTestId("give-amount-input").props.value).toBe("50");
   });
 
-  it("shows the estimated cover-fees amount when the toggle is on", () => {
+  it("shows what the donor typed when no preset is selected", () => {
+    render(<GiveScreenView {...baseProps} customAmountText="37" />);
+    expect(screen.getByTestId("give-amount-input").props.value).toBe("37");
+  });
+
+  it("routes typing through onCustomAmountChange (which clears the preset upstream)", () => {
+    const onCustomAmountChange = jest.fn();
     render(
-      <GiveScreenView {...baseProps} selectedPresetCents={5000} coverFees />,
+      <GiveScreenView {...baseProps} onCustomAmountChange={onCustomAmountChange} />,
     );
+    fireEvent.changeText(screen.getByTestId("give-amount-input"), "75");
+    expect(onCustomAmountChange).toHaveBeenCalledWith("75");
+  });
+
+  it("disables the CTA until an amount is chosen, and labels it plainly", () => {
+    render(<GiveScreenView {...baseProps} />);
+    const cta = screen.getByLabelText("Give");
+    expect(cta.props.accessibilityState.disabled).toBe(true);
+  });
+
+  // The pill carries the number so nobody taps it without knowing the total.
+  it("enables the CTA once a preset is selected and labels it with the total", () => {
+    render(<GiveScreenView {...baseProps} selectedPresetCents={5000} />);
+    const cta = screen.getByLabelText(`Give ${formatCents(5000)}`);
+    expect(cta.props.accessibilityState.disabled).toBe(false);
+  });
+
+  it("adds the covered fee to the CTA's total", () => {
+    render(<GiveScreenView {...baseProps} selectedPresetCents={5000} coverFees />);
+    const fee = estimateCoverFeesCents(5000);
+    expect(screen.getByLabelText(`Give ${formatCents(5000 + fee)}`)).toBeTruthy();
+  });
+
+  it("explains the fee toggle in terms of what the fund ends up with", () => {
+    render(<GiveScreenView {...baseProps} selectedPresetCents={5000} coverFees />);
     const fee = estimateCoverFeesCents(5000);
     expect(
       screen.getByText(
-        `+${formatCents(fee)} added — ${formatCents(5000 + fee)} total`,
+        `+${formatCents(fee)} so the fund gets the full ${formatCents(5000)}`,
       ),
     ).toBeTruthy();
   });
 
-  it("shows the 'finish in the browser' confirmation panel with amount and fund after Checkout launches", () => {
-    render(
-      <GiveScreenView
-        {...baseProps}
-        step="confirmation"
-        selectedPresetCents={5000}
-        checkoutSession={{ url: "https://checkout.stripe.com/c/pay/cs_test_123", sessionId: "cs_test_123" }}
-      />,
-    );
-    expect(screen.getByText("Finish your gift in the browser")).toBeTruthy();
-    expect(
-      screen.getByText(
-        "Complete your gift in the secure Stripe page that just opened. Once it's done, you can close that page and come back here.",
-      ),
-    ).toBeTruthy();
-    expect(screen.getByText(formatCents(5000))).toBeTruthy();
-    expect(screen.getByText("Young Adults — Manhattan")).toBeTruthy();
+  describe("waiting step", () => {
+    const waitingProps = {
+      ...baseProps,
+      step: "confirmation" as const,
+      selectedPresetCents: 5000,
+      checkoutSession: {
+        url: "https://checkout.stripe.com/c/pay/cs_test_123",
+        sessionId: "cs_test_123",
+        paymentIntentId: "pi_test_123",
+      },
+    };
+
+    it("says where the gift is being finished, with the amount and fund", () => {
+      render(<GiveScreenView {...waitingProps} />);
+      expect(screen.getByText("Finish in the browser")).toBeTruthy();
+      expect(screen.getByText(formatCents(5000))).toBeTruthy();
+      expect(screen.getByText("Young Adults — Manhattan")).toBeTruthy();
+    });
+
+    it("calls onReopenCheckout when 'Reopen payment page' is tapped", () => {
+      const onReopenCheckout = jest.fn();
+      render(
+        <GiveScreenView {...waitingProps} onReopenCheckout={onReopenCheckout} />,
+      );
+      fireEvent.press(screen.getByLabelText("Reopen payment page"));
+      expect(onReopenCheckout).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns to the amount step from 'Cancel this gift'", () => {
+      const onBack = jest.fn();
+      render(<GiveScreenView {...waitingProps} onBack={onBack} />);
+      fireEvent.press(screen.getByLabelText("Cancel this gift"));
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+
+    // A donor tapping "Done" mid-payment would leave with no idea whether the
+    // gift went through — the screen advances itself, or not at all.
+    it("offers no 'Done' escape hatch", () => {
+      render(<GiveScreenView {...waitingProps} />);
+      expect(screen.queryByLabelText("Done")).toBeNull();
+      expect(screen.queryByText("Done")).toBeNull();
+    });
+  });
+});
+
+describe("GiveCancelledNotice", () => {
+  // Stripe's cancel_url loads in the in-app browser, which has no auth — the
+  // give screen's queries would skip and spin forever. This is what renders
+  // instead, and it must not need anything.
+  it("tells the donor the gift was cancelled and that they can close the window", () => {
+    render(<GiveCancelledNotice />);
+    expect(screen.getByText("Gift cancelled")).toBeTruthy();
+    expect(screen.getByText("You can close this window.")).toBeTruthy();
   });
 
-  it("calls onReopenCheckout when 'Reopen payment page' is tapped", () => {
-    const onReopenCheckout = jest.fn();
-    render(
-      <GiveScreenView
-        {...baseProps}
-        step="confirmation"
-        selectedPresetCents={5000}
-        checkoutSession={{ url: "https://checkout.stripe.com/c/pay/cs_test_123", sessionId: "cs_test_123" }}
-        onReopenCheckout={onReopenCheckout}
-      />,
-    );
-    fireEvent.press(screen.getByLabelText("Reopen payment page"));
-    expect(onReopenCheckout).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls onBack when 'Done' is tapped on the confirmation step", () => {
-    const onBack = jest.fn();
-    render(
-      <GiveScreenView
-        {...baseProps}
-        step="confirmation"
-        selectedPresetCents={5000}
-        checkoutSession={{ url: "https://checkout.stripe.com/c/pay/cs_test_123", sessionId: "cs_test_123" }}
-        onBack={onBack}
-      />,
-    );
-    fireEvent.press(screen.getByLabelText("Done"));
-    expect(onBack).toHaveBeenCalledTimes(1);
+  it("shows no loading state at all", () => {
+    render(<GiveCancelledNotice />);
+    expect(screen.queryByTestId("skeleton")).toBeNull();
+    expect(screen.queryByTestId("give-screen-loading")).toBeNull();
   });
 });

--- a/apps/mobile/features/finance/member/__tests__/GiveScreenView.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/GiveScreenView.test.tsx
@@ -103,6 +103,8 @@ const baseProps = {
   onToggleCoverFees: noop,
   onContinue: noop,
   onReopenCheckout: noop,
+  onFinishManually: noop,
+  canAutoAdvance: true,
 };
 
 describe("GiveScreenView", () => {
@@ -224,11 +226,41 @@ describe("GiveScreenView", () => {
     });
 
     // A donor tapping "Done" mid-payment would leave with no idea whether the
-    // gift went through — the screen advances itself, or not at all.
-    it("offers no 'Done' escape hatch", () => {
+    // gift went through — while something IS watching, the screen advances
+    // itself or not at all.
+    it("offers no 'Done' escape hatch while the gift is being watched", () => {
       render(<GiveScreenView {...waitingProps} />);
       expect(screen.queryByLabelText("Done")).toBeNull();
       expect(screen.queryByText("Done")).toBeNull();
+      expect(screen.queryByLabelText("Go to the fund")).toBeNull();
+    });
+
+    // Stripe can hand back no PaymentIntent, and then nothing will ever advance
+    // this screen. Leaving "Cancel this gift" as the only way out of a screen
+    // the donor may have already paid on is how you get a second donation.
+    describe("when nothing is watching the gift", () => {
+      const unwatched = { ...waitingProps, canAutoAdvance: false };
+
+      it("offers a way to the fund that doesn't cancel anything", () => {
+        const onFinishManually = jest.fn();
+        const onBack = jest.fn();
+        render(
+          <GiveScreenView
+            {...unwatched}
+            onFinishManually={onFinishManually}
+            onBack={onBack}
+          />,
+        );
+        fireEvent.press(screen.getByLabelText("Go to the fund"));
+        expect(onFinishManually).toHaveBeenCalledTimes(1);
+        expect(onBack).not.toHaveBeenCalled();
+      });
+
+      it("says plainly that it can't confirm, instead of promising a return", () => {
+        render(<GiveScreenView {...unwatched} />);
+        expect(screen.getByText(/can’t confirm this one automatically/)).toBeTruthy();
+        expect(screen.queryByText(/as soon as it goes through/)).toBeNull();
+      });
     });
   });
 });

--- a/apps/mobile/features/finance/member/__tests__/giveSuccessParams.test.ts
+++ b/apps/mobile/features/finance/member/__tests__/giveSuccessParams.test.ts
@@ -1,4 +1,4 @@
-import { parseGiveSuccessParams } from "../giveSuccessParams";
+import { parseGiveSuccessParams, urlSafeName } from "../giveSuccessParams";
 
 describe("parseGiveSuccessParams", () => {
   it("formats the charged total from integer cents", () => {
@@ -68,5 +68,32 @@ describe("parseGiveSuccessParams", () => {
     expect(result.amountLabel).toBeNull();
     expect(result.thankYouLine).toBe("Thank you 🎉");
     expect(result.fundLine).toBeNull();
+  });
+});
+
+// The native auto-advance builds this query string itself (the backend's copy
+// only covers Stripe's success_url), and it does so inside the effect that has
+// already latched the navigate-once guard — a throw there costs the donor the
+// thank-you with no retry.
+describe("urlSafeName", () => {
+  it("percent-encodes the way the query string needs", () => {
+    expect(urlSafeName("Young Adults — Manhattan")).toBe(
+      encodeURIComponent("Young Adults — Manhattan"),
+    );
+  });
+
+  it("keeps emoji and other valid surrogate pairs intact", () => {
+    expect(decodeURIComponent(urlSafeName("Kids 🎉"))).toBe("Kids 🎉");
+  });
+
+  it("drops an unpaired surrogate instead of throwing", () => {
+    expect(() => encodeURIComponent("Fund \ud800")).toThrow(URIError);
+    expect(decodeURIComponent(urlSafeName("Fund \ud800"))).toBe("Fund ");
+  });
+
+  it("caps the length, without leaving a half pair behind at the cut", () => {
+    const name = "🎉".repeat(80);
+    const out = decodeURIComponent(urlSafeName(name));
+    expect(out).toBe("🎉".repeat(50));
   });
 });

--- a/apps/mobile/features/finance/member/__tests__/giveSuccessParams.test.ts
+++ b/apps/mobile/features/finance/member/__tests__/giveSuccessParams.test.ts
@@ -1,0 +1,72 @@
+import { parseGiveSuccessParams } from "../giveSuccessParams";
+
+describe("parseGiveSuccessParams", () => {
+  it("formats the charged total from integer cents", () => {
+    expect(
+      parseGiveSuccessParams({ amount: "5000" }).amountLabel,
+    ).toBe("$50.00");
+  });
+
+  it("keeps sub-dollar cents rather than rounding them away", () => {
+    expect(parseGiveSuccessParams({ amount: "5175" }).amountLabel).toBe("$51.75");
+    expect(parseGiveSuccessParams({ amount: "7" }).amountLabel).toBe("$0.07");
+  });
+
+  it("groups thousands", () => {
+    expect(parseGiveSuccessParams({ amount: "123456" }).amountLabel).toBe("$1,234.56");
+  });
+
+  // The whole point of the null: a hand-typed or truncated URL must thank the
+  // donor without ever rendering "$NaN".
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["not a number", "abc"],
+    ["a float", "50.5"],
+    ["negative", "-100"],
+    ["zero", "0"],
+    ["padded with junk", "50abc"],
+  ])("hides the amount line when the param is %s", (_label, amount) => {
+    expect(parseGiveSuccessParams({ amount }).amountLabel).toBeNull();
+  });
+
+  it("names the community in the thank-you when it's present", () => {
+    expect(
+      parseGiveSuccessParams({ community: "First Church Inc." }).thankYouLine,
+    ).toBe("First Church Inc. says thank you");
+  });
+
+  it("falls back to a community-agnostic thank-you when it isn't", () => {
+    expect(parseGiveSuccessParams({}).thankYouLine).toBe("Thank you 🎉");
+    expect(parseGiveSuccessParams({ community: "   " }).thankYouLine).toBe("Thank you 🎉");
+  });
+
+  it("names the fund when it's present, and omits the line when it isn't", () => {
+    expect(parseGiveSuccessParams({ fund: "Young Adults" }).fundLine).toBe(
+      "to Young Adults",
+    );
+    expect(parseGiveSuccessParams({}).fundLine).toBeNull();
+  });
+
+  // expo-router hands repeated query keys back as an array.
+  it("takes the first value when a param repeats", () => {
+    expect(
+      parseGiveSuccessParams({
+        amount: ["5000", "999999"],
+        fund: ["Real Fund", "Fake"],
+        community: ["Real Church", "Fake"],
+      }),
+    ).toEqual({
+      amountLabel: "$50.00",
+      thankYouLine: "Real Church says thank you",
+      fundLine: "to Real Fund",
+    });
+  });
+
+  it("still thanks when every param is garbage", () => {
+    const result = parseGiveSuccessParams({ amount: "NaN" });
+    expect(result.amountLabel).toBeNull();
+    expect(result.thankYouLine).toBe("Thank you 🎉");
+    expect(result.fundLine).toBeNull();
+  });
+});

--- a/apps/mobile/features/finance/member/giveSuccessParams.ts
+++ b/apps/mobile/features/finance/member/giveSuccessParams.ts
@@ -1,0 +1,81 @@
+/**
+ * URL-param parsing for the give-success screen
+ * (`app/groups/[group_id]/give-success.tsx`).
+ *
+ * Extracted as a pure function because the screen itself is a route component
+ * that renders BEFORE auth has restored (it is reached by a plain browser
+ * redirect from Stripe), so there is nothing to assert about it in jest beyond
+ * this parsing — and everything worth asserting lives here.
+ *
+ * The params come off `success_url`, built by `buildGiveReturnUrls` in
+ * apps/convex/functions/finance/giving.ts:
+ *
+ *   /groups/<id>/give-success?session_id=cs_...&amount=<cents>&fund=<enc>&community=<enc>
+ *
+ * They are attacker-adjacent in exactly one sense: anyone can type this URL
+ * with any values. Nothing here is trusted for authorization — the screen only
+ * ever thanks someone — so the whole contract is "never crash, never lie":
+ * an unparseable amount hides the amount line rather than rendering "$NaN".
+ */
+
+/** What the give-success screen renders, derived from the URL alone. */
+export interface GiveSuccessDisplay {
+  /**
+   * Formatted total charged (e.g. "$50.00"), or `null` when the `amount` param
+   * is missing/garbage — in which case the screen shows no amount at all.
+   */
+  amountLabel: string | null;
+  /** e.g. "First Church Inc. says thank you", or the community-agnostic fallback. */
+  thankYouLine: string;
+  /** e.g. "to Young Adults — Manhattan", or `null` when `fund` is missing. */
+  fundLine: string | null;
+}
+
+/**
+ * expo-router hands each param back as `string | string[] | undefined`
+ * (repeated query keys become an array). Take the first value and nothing else.
+ */
+function firstParam(value: string | string[] | undefined): string | undefined {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Formats integer cents as US dollars. Local rather than reusing
+ * `../format`'s `formatCents` because this one has to reject non-integers and
+ * negatives outright (a hand-typed `?amount=-1` must hide the line, not print
+ * "-$0.01"), where `formatCents` faithfully renders whatever it is given.
+ */
+function formatAmountCents(cents: number): string {
+  const dollars = Math.floor(cents / 100);
+  const remainder = cents % 100;
+  return `$${dollars.toLocaleString("en-US")}.${remainder.toString().padStart(2, "0")}`;
+}
+
+export function parseGiveSuccessParams(params: {
+  amount?: string | string[];
+  fund?: string | string[];
+  community?: string | string[];
+}): GiveSuccessDisplay {
+  const amountRaw = firstParam(params.amount);
+  const fund = firstParam(params.fund);
+  const community = firstParam(params.community);
+
+  // `Number("")` is 0 and `Number(" 12 ")` is 12, so the string is validated by
+  // shape first — only digits — rather than by whatever Number() tolerates.
+  const amountCents =
+    amountRaw && /^\d+$/.test(amountRaw) ? Number(amountRaw) : NaN;
+  const amountLabel =
+    Number.isSafeInteger(amountCents) && amountCents > 0
+      ? formatAmountCents(amountCents)
+      : null;
+
+  return {
+    amountLabel,
+    // "Thank you 🎉" is the community-agnostic fallback: with no community
+    // name there is no one to speak for, so the screen thanks in its own voice.
+    thankYouLine: community ? `${community} says thank you` : "Thank you 🎉",
+    fundLine: fund ? `to ${fund}` : null,
+  };
+}

--- a/apps/mobile/features/finance/member/giveSuccessParams.ts
+++ b/apps/mobile/features/finance/member/giveSuccessParams.ts
@@ -18,6 +18,30 @@
  * an unparseable amount hides the amount line rather than rendering "$NaN".
  */
 
+/**
+ * Percent-encodes a fund/community name for the give-success query string.
+ *
+ * A deliberate mirror of `urlSafeName` in
+ * apps/convex/functions/finance/giving.ts, which builds the same two params for
+ * Stripe's `success_url`. Both ends need it because the native flow never sees
+ * that URL — `GiveScreen` builds its own from the status query's raw names —
+ * and `encodeURIComponent` throws `URIError` on an unpaired surrogate. Thrown
+ * from inside the auto-advance effect, that would swallow the thank-you AFTER
+ * the navigate-once guard has latched, so the donor gets nothing at all.
+ *
+ * `for...of` walks whole code points, so valid pairs survive and only true
+ * orphans (including one the slice may have just created) are dropped.
+ */
+export function urlSafeName(value: string): string {
+  let safe = "";
+  for (const char of value.slice(0, 100)) {
+    const code = char.codePointAt(0)!;
+    if (code >= 0xd800 && code <= 0xdfff) continue;
+    safe += char;
+  }
+  return encodeURIComponent(safe);
+}
+
 /** What the give-success screen renders, derived from the URL alone. */
 export interface GiveSuccessDisplay {
   /**

--- a/apps/mobile/features/finance/member/giveTheme.ts
+++ b/apps/mobile/features/finance/member/giveTheme.ts
@@ -1,0 +1,17 @@
+/**
+ * The one non-neutral hue the member giving surfaces are allowed.
+ *
+ * Giving is money, not brand: the fund glyph tile and the success screen's
+ * wash read as gold everywhere, independent of a community's `primaryColor`
+ * (which the WA kit reserves for the "one accent thing per screen" rule).
+ * Deliberately NOT sourced from `useCommunityTheme()` — the success screen
+ * renders while auth is still restoring after the Stripe redirect and has no
+ * community to read.
+ */
+export const GIVING_GOLD = "#B8860B";
+
+/** Same gold at card-tint strength (glyph tiles, the success-screen wash). */
+export const GIVING_GOLD_TINT = "rgba(184, 134, 11, 0.12)";
+
+/** A hair stronger, for the success screen's radial-ish wash panel. */
+export const GIVING_GOLD_WASH = "rgba(184, 134, 11, 0.16)";

--- a/apps/mobile/features/finance/member/types.ts
+++ b/apps/mobile/features/finance/member/types.ts
@@ -66,4 +66,14 @@ export interface GivingContext {
 export interface CheckoutSession {
   url: string;
   sessionId: string;
+  /**
+   * The PaymentIntent the Checkout Session will charge, and the ONLY join key
+   * between this attempt and the eventual `donations` row (nothing stores a
+   * Checkout Session id). The native waiting screen subscribes to
+   * `getCheckoutSessionStatus` with it to auto-dismiss the in-app browser.
+   *
+   * `null` when Stripe deferred creating the PaymentIntent — the gift still
+   * lands via the webhook, but the wait degrades to manual (Reopen/Cancel).
+   */
+  paymentIntentId: string | null;
 }

--- a/apps/mobile/features/groups/components/GroupInfoScreen.tsx
+++ b/apps/mobile/features/groups/components/GroupInfoScreen.tsx
@@ -788,32 +788,37 @@ export function GroupInfoScreen() {
           </View>
         )}
 
-        {/* 5. CHANNELS — rendered exactly as-is; not modified (out of
-            scope for this restyle pass — see file-header deferral note). */}
-        {group._id && <ChannelsSection groupId={group._id} userRole={group.user_role} />}
-
-        {/* 5b. GIVING — every member's door into the fund: give, and see the
+        {/* 5. GIVING — every member's door into the fund: give, and see the
             transparency summary (ADR-032 §4 grants both at Member level).
-            Sits here, in the member band between Channels and Leader tools,
-            because that's where this screen keeps everything a member can
-            actually use — below the leader block it would be buried under a
-            card most members never render, and in Details it would read as
-            metadata rather than a place to go. Mirrors the flag-off
-            GroupDetailScreen, where the same tile sits above leader-only
-            Rostering. The Leader tools "Giving" row stays as-is: it opens the
-            management hub, this opens the member surface. */}
+            Sits directly under MEMBERS, above Channels, because giving is now
+            a headline member action rather than an afterthought: the member
+            band reads people → money → conversations, and a donor who opened
+            this screen to give shouldn't have to scroll past a channel list to
+            find the door. (It previously sat below Channels; the owner's
+            giving-flow redesign moved it up.) Still above the leader block,
+            which most members never render. The Leader tools "Giving" row
+            stays as-is: it opens the management hub, this opens the member
+            surface. */}
         {group._id && groupGivingFlag === true && hasGivingFund && (
           <View style={styles.waSection}>
             <WaInsetGroup header="Giving">
               <WaCell
                 icon="cash-outline"
                 title="Group fund"
+                // No balance in the whisper: `getGivingContext` (what this
+                // screen already subscribes to) doesn't carry one, and the
+                // only query that does is `getFundOverview`, which pulls the
+                // whole ledger for a one-line subtitle.
                 description="Give, and see where the money goes."
                 onPress={() => router.push(`/groups/${group._id}/fund` as any)}
               />
             </WaInsetGroup>
           </View>
         )}
+
+        {/* 5b. CHANNELS — rendered exactly as-is; not modified (out of
+            scope for this restyle pass — see file-header deferral note). */}
+        {group._id && <ChannelsSection groupId={group._id} userRole={group.user_role} />}
 
         {/* 6. LEADER TOOLS — leader/admin only, WaInsetGroup of navigational
             WaCells (plain monochrome glyphs per §3.2), reusing today's


### PR DESCRIPTION
## Summary

Phase 2 of the approved giving redesign (design artifact v4) — the member-facing wave. Pairs with #731 (merged): its redirect now lands somewhere real.

- **Giving dashboard**: WA sub-screen header (gear and duplicate header "Give" gone), fund hero with one full-width Give, stat tiles, avatar activity rows, a Reimbursements section headed by "Get reimbursed", and a leaders-only "Fund settings" row at the bottom (existing `canManage` gate). Safe-area insets applied — **fixes the unreachable top on mobile web**.
- **Give form**: big typed amount with preset chips, fee toggle ("+$0.59 so the fund gets the full $10"), pinned "Give $X.XX" total pill.
- **Waiting step**: no more "Done" (it only reset the form); subscribes to `getCheckoutSessionStatus` and on completion dismisses the in-app browser and navigates itself. Reopen / "Cancel this gift" remain.
- **NEW gift-success screen** (`/groups/[id]/give-success`): star-strike GIF, "«community» says thank you", the amount huge, auto-return to the fund in ~4s. Renders from URL params with **zero authenticated queries** — cannot crash during post-Stripe auth restore. Garbage params degrade gracefully.
- **Cancel return**: with `?giving=cancelled` and no auth (Stripe's native browser), renders a static "Gift cancelled — you can close this window" instead of an infinite spinner.
- **Group info**: Giving block moved directly under Members (balance whisper deliberately skipped — the only balance-bearing query pulls the full ledger; noted inline).

## Evidence
```
jest features/finance/member: 73/73 (5 suites) · features/groups: 196/196
apps/mobile tsc: zero errors in touched files · eslint clean
```
Judgment calls documented in-diff: no LinearGradient (disabled on Fabric here — tinted View instead), pinned pill over WaFloatingCta (no tab island on sub-screens), card-fees stat line kept.

> ⚠️ Staging verify wanted: safe-area top, the full give→Stripe→success round-trip on mobile web, and the native browser auto-dismiss are device-level behaviors nobody has eyeballed.

No convex changes, no deps, no native views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcamCRXMUU1DhocRpr59YD