### PR TITLE
fix(finance): fee cover grosses up, and can no longer bypass the donation cap

### DIFF
--- a/apps/convex/__tests__/finance-giving.test.ts
+++ b/apps/convex/__tests__/finance-giving.test.ts
@@ -643,6 +643,43 @@ describe("prepareDonationIntent", () => {
       }
     });
 
+    // The bound is a ceiling, not a match: a fee UNDER the quote can't inflate
+    // the charge past MAX_DONATION_CENTS, it just under-covers the fund — which
+    // is exactly what a donor still on the pre-gross-up JS bundle sends. A
+    // symmetric check would have refused those gifts outright for the length of
+    // the OTA rollout.
+    test("accepts a fee below the quote, including the pre-gross-up estimate an old client still sends", async () => {
+      const t = convexTest(schema, modules);
+      const s = await seedGivingFixture(t);
+      const token = await tokenFor(s.donorUserId);
+
+      /** The estimate shipped before this PR: the fee on the base amount only. */
+      const preGrossUpFee = (amountCents: number) => Math.round(amountCents * 0.029 + 30);
+
+      // $12.93 is where the old estimate first falls more than 2c short of the
+      // new one, so every amount at or above it is a gift an old client could
+      // no longer make under a symmetric check.
+      for (const amountCents of [1293, 2000, 5000, 30000, 2_000_000]) {
+        expect(computeCoverFeesCents(amountCents) - preGrossUpFee(amountCents)).toBeGreaterThan(2);
+
+        const result = await t.query(internal.functions.finance.giving.prepareDonationIntent, {
+          token,
+          fundId: s.fundId,
+          amountCents,
+          coverFeesCents: preGrossUpFee(amountCents),
+        });
+        expect(result.feeCoverCents).toBe(preGrossUpFee(amountCents));
+      }
+
+      // …and a 1c fee on a large gift is fine too — it's the donor's own money,
+      // and it lowers the charge rather than raising it.
+      const barelyCovered = await t.query(
+        internal.functions.finance.giving.prepareDonationIntent,
+        { token, fundId: s.fundId, amountCents: 100_000, coverFeesCents: 1 },
+      );
+      expect(barelyCovered.feeCoverCents).toBe(1);
+    });
+
     test("rejects a fee padded past the tolerance, however small the padding", async () => {
       const t = convexTest(schema, modules);
       const s = await seedGivingFixture(t);
@@ -655,7 +692,7 @@ describe("prepareDonationIntent", () => {
           amountCents: 5000,
           coverFeesCents: computeCoverFeesCents(5000) + 3,
         }),
-      ).rejects.toThrow("doesn't match the processing fee");
+      ).rejects.toThrow("couldn't confirm the processing fee");
 
       await expect(
         t.query(internal.functions.finance.giving.prepareDonationIntent, {
@@ -664,7 +701,7 @@ describe("prepareDonationIntent", () => {
           amountCents: 5000,
           coverFeesCents: computeCoverFeesCents(5000) + 1000,
         }),
-      ).rejects.toThrow("doesn't match the processing fee");
+      ).rejects.toThrow("couldn't confirm the processing fee");
     });
 
     test("rejects an enormous fee on a tiny gift — the cap is not smugglable through the fee field", async () => {
@@ -679,7 +716,7 @@ describe("prepareDonationIntent", () => {
           amountCents: 100,
           coverFeesCents: 99_000_000,
         }),
-      ).rejects.toThrow("doesn't match the processing fee");
+      ).rejects.toThrow("couldn't confirm the processing fee");
     });
 
     test("caps the total charge at the donation cap plus the fee on the cap", async () => {
@@ -698,7 +735,18 @@ describe("prepareDonationIntent", () => {
         amountCents: capCents,
         coverFeesCents: computeCoverFeesCents(capCents) + 2,
       });
-      expect(capCents + atCap.feeCoverCents).toBeLessThanOrEqual(maxTotal + 2);
+      expect(capCents + atCap.feeCoverCents).toBe(maxTotal + 2);
+
+      // …and that is the ceiling: one cent more is refused, so the largest
+      // charge this endpoint can ever authorise is exactly maxTotal + 2c.
+      await expect(
+        t.query(internal.functions.finance.giving.prepareDonationIntent, {
+          token,
+          fundId: s.fundId,
+          amountCents: capCents,
+          coverFeesCents: computeCoverFeesCents(capCents) + 3,
+        }),
+      ).rejects.toThrow("couldn't confirm the processing fee");
 
       // Anything bigger fails on one bound or the other.
       await expect(
@@ -717,7 +765,7 @@ describe("prepareDonationIntent", () => {
           amountCents: capCents,
           coverFeesCents: maxTotal,
         }),
-      ).rejects.toThrow("doesn't match the processing fee");
+      ).rejects.toThrow("couldn't confirm the processing fee");
     });
   });
 

--- a/apps/convex/__tests__/finance-giving.test.ts
+++ b/apps/convex/__tests__/finance-giving.test.ts
@@ -784,6 +784,9 @@ describe("prepareDonationIntent", () => {
       userId: s.donorUserId,
       communityId: s.communityId,
       groupId: s.groupId,
+      // Both halves of the validated pair come back, because the actions build
+      // the Stripe charge from these and never from their own args.
+      amountCents: 1000,
       // The legal name the receipt is issued under wins over the community's
       // display name ("Test Church"), matching getGivingContext.
       communityName: "Test Church Inc.",

--- a/apps/convex/__tests__/finance-giving.test.ts
+++ b/apps/convex/__tests__/finance-giving.test.ts
@@ -25,6 +25,7 @@ import type { Id } from "../_generated/dataModel";
 import { generateTokens } from "../lib/auth";
 import { buildDonationReceiptEmail } from "../lib/finance/receipts";
 import { buildGiveReturnUrls } from "../functions/finance/giving";
+import { computeCoverFeesCents } from "../lib/finance/fees";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
 
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
@@ -597,6 +598,127 @@ describe("prepareDonationIntent", () => {
         coverFeesCents: -5,
       }),
     ).rejects.toThrow("Invalid fee-cover amount");
+  });
+
+  // The card is charged amountCents + coverFeesCents, so a fee field that only
+  // had to be non-negative made MAX_DONATION_CENTS bypassable — see
+  // validateDonationAmount.
+  describe("coverFeesCents bounds", () => {
+    test("accepts the server-computed gross-up fee, and 0 for the toggle being off", async () => {
+      const t = convexTest(schema, modules);
+      const s = await seedGivingFixture(t);
+      const token = await tokenFor(s.donorUserId);
+
+      const expectedFee = computeCoverFeesCents(5000);
+      const covered = await t.query(internal.functions.finance.giving.prepareDonationIntent, {
+        token,
+        fundId: s.fundId,
+        amountCents: 5000,
+        coverFeesCents: expectedFee,
+      });
+      expect(covered.feeCoverCents).toBe(expectedFee);
+
+      const uncovered = await t.query(internal.functions.finance.giving.prepareDonationIntent, {
+        token,
+        fundId: s.fundId,
+        amountCents: 5000,
+        coverFeesCents: 0,
+      });
+      expect(uncovered.feeCoverCents).toBe(0);
+    });
+
+    test("tolerates a couple of cents of client rounding drift", async () => {
+      const t = convexTest(schema, modules);
+      const s = await seedGivingFixture(t);
+      const token = await tokenFor(s.donorUserId);
+
+      for (const drift of [-2, -1, 1, 2]) {
+        const result = await t.query(internal.functions.finance.giving.prepareDonationIntent, {
+          token,
+          fundId: s.fundId,
+          amountCents: 5000,
+          coverFeesCents: computeCoverFeesCents(5000) + drift,
+        });
+        expect(result.feeCoverCents).toBe(computeCoverFeesCents(5000) + drift);
+      }
+    });
+
+    test("rejects a fee padded past the tolerance, however small the padding", async () => {
+      const t = convexTest(schema, modules);
+      const s = await seedGivingFixture(t);
+      const token = await tokenFor(s.donorUserId);
+
+      await expect(
+        t.query(internal.functions.finance.giving.prepareDonationIntent, {
+          token,
+          fundId: s.fundId,
+          amountCents: 5000,
+          coverFeesCents: computeCoverFeesCents(5000) + 3,
+        }),
+      ).rejects.toThrow("doesn't match the processing fee");
+
+      await expect(
+        t.query(internal.functions.finance.giving.prepareDonationIntent, {
+          token,
+          fundId: s.fundId,
+          amountCents: 5000,
+          coverFeesCents: computeCoverFeesCents(5000) + 1000,
+        }),
+      ).rejects.toThrow("doesn't match the processing fee");
+    });
+
+    test("rejects an enormous fee on a tiny gift — the cap is not smugglable through the fee field", async () => {
+      const t = convexTest(schema, modules);
+      const s = await seedGivingFixture(t);
+      const token = await tokenFor(s.donorUserId);
+
+      await expect(
+        t.query(internal.functions.finance.giving.prepareDonationIntent, {
+          token,
+          fundId: s.fundId,
+          amountCents: 100,
+          coverFeesCents: 99_000_000,
+        }),
+      ).rejects.toThrow("doesn't match the processing fee");
+    });
+
+    test("caps the total charge at the donation cap plus the fee on the cap", async () => {
+      const t = convexTest(schema, modules);
+      const s = await seedGivingFixture(t);
+      const token = await tokenFor(s.donorUserId);
+
+      const capCents = 2_000_000; // MAX_DONATION_CENTS
+      const maxTotal = capCents + computeCoverFeesCents(capCents);
+
+      // The largest request that gets through: the cap, fully fee-covered,
+      // with the tolerance leaned on.
+      const atCap = await t.query(internal.functions.finance.giving.prepareDonationIntent, {
+        token,
+        fundId: s.fundId,
+        amountCents: capCents,
+        coverFeesCents: computeCoverFeesCents(capCents) + 2,
+      });
+      expect(capCents + atCap.feeCoverCents).toBeLessThanOrEqual(maxTotal + 2);
+
+      // Anything bigger fails on one bound or the other.
+      await expect(
+        t.query(internal.functions.finance.giving.prepareDonationIntent, {
+          token,
+          fundId: s.fundId,
+          amountCents: capCents + 1,
+          coverFeesCents: 0,
+        }),
+      ).rejects.toThrow("Donation amount must be between");
+
+      await expect(
+        t.query(internal.functions.finance.giving.prepareDonationIntent, {
+          token,
+          fundId: s.fundId,
+          amountCents: capCents,
+          coverFeesCents: maxTotal,
+        }),
+      ).rejects.toThrow("doesn't match the processing fee");
+    });
   });
 
   test("returns the connected-account context, fund/community names, and groupId for a valid request", async () => {
@@ -1625,5 +1747,43 @@ describe("buildDonationReceiptEmail", () => {
     expect(email.html).toContain("$1.50");
     // Headline total is amountCents + feeCoverCents ($25.00 + $1.50 = $26.50).
     expect(email.text).toContain("$26.50");
+  });
+});
+
+// ============================================================================
+// computeCoverFeesCents — lib/finance/fees.ts
+// ============================================================================
+
+describe("computeCoverFeesCents", () => {
+  /** What Stripe actually takes off a charge of `totalCents` (2.9% + 30c). */
+  const stripeTakesCents = (totalCents: number) => Math.round(totalCents * 0.029 + 30);
+
+  test.each([1000, 5000, 10000, 30000, 2_000_000])(
+    "grosses up so a %i-cent gift nets the fund the full amount",
+    (amountCents) => {
+      const total = amountCents + computeCoverFeesCents(amountCents);
+      const net = total - stripeTakesCents(total);
+      expect(net).toBeGreaterThanOrEqual(amountCents);
+      expect(net).toBeLessThanOrEqual(amountCents + 1);
+    },
+  );
+
+  test("charges more than a fee on the base amount alone — that's the bug it fixes", () => {
+    // Naive: round(5000 * 0.029 + 30) = 175, which nets the fund only $49.95.
+    expect(computeCoverFeesCents(5000)).toBe(180);
+  });
+
+  test("never decreases as the gift grows", () => {
+    let previous = 0;
+    for (let amountCents = 100; amountCents <= 2_000_000; amountCents += 997) {
+      const fee = computeCoverFeesCents(amountCents);
+      expect(fee).toBeGreaterThanOrEqual(previous);
+      previous = fee;
+    }
+  });
+
+  test("is 0 for a non-positive amount", () => {
+    expect(computeCoverFeesCents(0)).toBe(0);
+    expect(computeCoverFeesCents(-100)).toBe(0);
   });
 });

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -30,7 +30,7 @@
  * layer in `functions/finance/jobs.ts`.
  */
 
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import {
   query,
   action,
@@ -46,6 +46,7 @@ import { isCommunityAdmin } from "../../lib/permissions";
 import { postLedgerEntry } from "../../lib/finance/ledger";
 import { logFinanceAudit } from "../../lib/finance/audit";
 import { buildDonationReceiptEmail } from "../../lib/finance/receipts";
+import { computeCoverFeesCents, COVER_FEE_TOLERANCE_CENTS } from "../../lib/finance/fees";
 import { getResendClient } from "../../lib/resend";
 import { now, getDisplayName } from "../../lib/utils";
 import {
@@ -364,12 +365,19 @@ export const getGivingContext = query({
 // ============================================================================
 
 /**
- * Validates the donor-chosen amount is within Stripe/our own bounds and
- * normalizes `coverFeesCents` to a non-negative integer. Pure (no `ctx`) so
- * it's trivial to unit test directly, but only called from
+ * Validates the donor-chosen amount is within Stripe/our own bounds and that
+ * `coverFeesCents` is a fee we'd actually have quoted for that amount. Pure (no
+ * `ctx`) so it's trivial to unit test directly, but only called from
  * `prepareDonationIntent` — the ONE place that gates every donation-creating
  * action, per the ADR-032 rule that money-initiating actions share one
  * validation path rather than duplicating checks per Stripe surface.
+ *
+ * The fee check is a bound, not a nicety: the card is charged
+ * `amountCents + feeCoverCents`, so a fee field that only had to be
+ * non-negative made `MAX_DONATION_CENTS` a fiction — any total was reachable by
+ * putting the money in the fee. Pinning the fee to the server's own gross-up
+ * (or zero, for the toggle being off) caps the actual charge at
+ * `MAX_DONATION_CENTS + computeCoverFeesCents(MAX_DONATION_CENTS)`.
  */
 function validateDonationAmount(
   amountCents: number,
@@ -386,7 +394,19 @@ function validateDonationAmount(
   }
   const feeCoverCents = coverFeesCents ?? 0;
   if (!Number.isInteger(feeCoverCents) || feeCoverCents < 0) {
-    throw new Error("Invalid fee-cover amount");
+    throw new ConvexError("Invalid fee-cover amount");
+  }
+  // Zero means the donor left the "cover the fees" toggle off. Anything else
+  // must be the fee we'd have quoted, within a couple of cents of rounding
+  // drift between the client's estimate and this calculation.
+  const expectedFeeCents = computeCoverFeesCents(amountCents);
+  if (
+    feeCoverCents !== 0 &&
+    Math.abs(feeCoverCents - expectedFeeCents) > COVER_FEE_TOLERANCE_CENTS
+  ) {
+    throw new ConvexError(
+      `Fee-cover amount doesn't match the processing fee for this gift (expected ${expectedFeeCents} cents or 0)`,
+    );
   }
   return { feeCoverCents };
 }

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -382,7 +382,7 @@ export const getGivingContext = query({
 function validateDonationAmount(
   amountCents: number,
   coverFeesCents: number | undefined,
-): { feeCoverCents: number } {
+): { amountCents: number; feeCoverCents: number } {
   if (
     !Number.isInteger(amountCents) ||
     amountCents < MIN_DONATION_CENTS ||
@@ -419,7 +419,7 @@ function validateDonationAmount(
       "We couldn't confirm the processing fee for this gift. Please reopen the give screen and try again.",
     );
   }
-  return { feeCoverCents };
+  return { amountCents, feeCoverCents };
 }
 
 /**
@@ -442,7 +442,10 @@ export const prepareDonationIntent = internalQuery({
     const userId = await requireAuth(ctx, args.token);
     await requireGroupGivingEnabled(ctx); // Gate donation creation at the source.
 
-    const { feeCoverCents } = validateDonationAmount(args.amountCents, args.coverFeesCents);
+    const { amountCents, feeCoverCents } = validateDonationAmount(
+      args.amountCents,
+      args.coverFeesCents,
+    );
 
     const fund = await ctx.db.get(args.fundId);
     if (!fund) {
@@ -480,6 +483,12 @@ export const prepareDonationIntent = internalQuery({
       communityName: communityFinance.legalName ?? community?.name ?? "",
       fundName: fund.name,
       stripeConnectedAccountId: communityFinance.stripeConnectedAccountId,
+      // BOTH halves of the validated pair come back, and the actions build the
+      // Stripe charge from these — never from their own `args`. Handing back
+      // only the fee would leave the amount side of the cap resting on the
+      // caller's discipline, which is the opposite of what a single
+      // "everything money-initiating goes through here" seam is for.
+      amountCents,
       feeCoverCents,
     };
   },
@@ -541,7 +550,7 @@ export const createDonationIntent = action({
     // per the acquiring topology in ADR-032 §1.
     const paymentIntent = await stripe.paymentIntents.create(
       {
-        amount: args.amountCents + context.feeCoverCents,
+        amount: context.amountCents + context.feeCoverCents,
         currency: "usd",
         automatic_payment_methods: { enabled: true },
         metadata: {
@@ -712,7 +721,7 @@ export const createDonationCheckoutSession = action({
       apiVersion: "2026-02-25.clover",
     });
 
-    const totalCents = args.amountCents + context.feeCoverCents;
+    const totalCents = context.amountCents + context.feeCoverCents;
     const { successUrl, cancelUrl } = buildGiveReturnUrls({
       groupId: context.groupId,
       totalCents,

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -375,9 +375,9 @@ export const getGivingContext = query({
  * The fee check is a bound, not a nicety: the card is charged
  * `amountCents + feeCoverCents`, so a fee field that only had to be
  * non-negative made `MAX_DONATION_CENTS` a fiction — any total was reachable by
- * putting the money in the fee. Pinning the fee to the server's own gross-up
- * (or zero, for the toggle being off) caps the actual charge at
- * `MAX_DONATION_CENTS + computeCoverFeesCents(MAX_DONATION_CENTS)`.
+ * putting the money in the fee. Ceiling the fee at the server's own gross-up
+ * caps the actual charge at
+ * `MAX_DONATION_CENTS + computeCoverFeesCents(MAX_DONATION_CENTS) + COVER_FEE_TOLERANCE_CENTS`.
  */
 function validateDonationAmount(
   amountCents: number,
@@ -388,7 +388,7 @@ function validateDonationAmount(
     amountCents < MIN_DONATION_CENTS ||
     amountCents > MAX_DONATION_CENTS
   ) {
-    throw new Error(
+    throw new ConvexError(
       `Donation amount must be between $${MIN_DONATION_CENTS / 100} and $${MAX_DONATION_CENTS / 100}`,
     );
   }
@@ -396,16 +396,27 @@ function validateDonationAmount(
   if (!Number.isInteger(feeCoverCents) || feeCoverCents < 0) {
     throw new ConvexError("Invalid fee-cover amount");
   }
-  // Zero means the donor left the "cover the fees" toggle off. Anything else
-  // must be the fee we'd have quoted, within a couple of cents of rounding
-  // drift between the client's estimate and this calculation.
+  // The bound is deliberately ONE-SIDED — a ceiling, not a match. Only an
+  // over-large fee moves money it shouldn't: the card is charged
+  // `amountCents + feeCoverCents`, so it's the upper edge that keeps
+  // MAX_DONATION_CENTS honest. A fee *below* the quote just under-covers the
+  // fund, which is what every client did before this gross-up landed and is
+  // the donor's own money either way.
+  //
+  // That asymmetry is also what makes this safe to ship: the pre-gross-up
+  // estimate diverges from this one by more than the tolerance from $12.93 up,
+  // so a symmetric match would have rejected every fee-covered mid-size gift
+  // from a donor still on the old JS bundle for the whole length of the OTA
+  // rollout. The tolerance absorbs rounding drift on the high side only.
   const expectedFeeCents = computeCoverFeesCents(amountCents);
-  if (
-    feeCoverCents !== 0 &&
-    Math.abs(feeCoverCents - expectedFeeCents) > COVER_FEE_TOLERANCE_CENTS
-  ) {
+  if (feeCoverCents > expectedFeeCents + COVER_FEE_TOLERANCE_CENTS) {
+    // Logged with the numbers because the donor-facing copy deliberately has
+    // none: a spike here is how we'd notice the two fee implementations drifting.
+    console.warn(
+      `[finance] fee-cover above the quoted fee — amount=${amountCents} submitted=${feeCoverCents} expected=${expectedFeeCents}`,
+    );
     throw new ConvexError(
-      `Fee-cover amount doesn't match the processing fee for this gift (expected ${expectedFeeCents} cents or 0)`,
+      "We couldn't confirm the processing fee for this gift. Please reopen the give screen and try again.",
     );
   }
   return { feeCoverCents };

--- a/apps/convex/lib/finance/fees.ts
+++ b/apps/convex/lib/finance/fees.ts
@@ -7,8 +7,8 @@
  * finance surface in `packages/shared` today, and one wasn't worth inventing
  * for two constants). The client estimate is a *display* number; this copy is
  * the authority: `validateDonationAmount` re-derives the fee here and rejects a
- * client-supplied `coverFeesCents` that doesn't match, which is also what keeps
- * the donation cap from being bypassable through the fee field.
+ * client-supplied `coverFeesCents` that exceeds it, which is what keeps the
+ * donation cap from being bypassable through the fee field.
  */
 
 /** Stripe's typical US card rate, charged on the amount that hits the card. */
@@ -40,9 +40,13 @@ export function computeCoverFeesCents(amountCents: number): number {
 }
 
 /**
- * How far a client's fee number may sit from the server's own before we refuse
+ * How far ABOVE the server's own number a client's fee may sit before we refuse
  * it: two cents, covering rounding drift between the two implementations (and
  * a future tweak to one of them) without leaving room to smuggle real money
  * past the donation cap.
+ *
+ * There is no matching floor — see `validateDonationAmount`. A fee under the
+ * quote cannot bypass the cap, and rejecting one would lock out every donor
+ * still running a pre-gross-up client.
  */
 export const COVER_FEE_TOLERANCE_CENTS = 2;

--- a/apps/convex/lib/finance/fees.ts
+++ b/apps/convex/lib/finance/fees.ts
@@ -1,0 +1,48 @@
+/**
+ * Processor-fee math for donations (ADR-032 §3, the give sheet's "cover the
+ * fees" toggle).
+ *
+ * NOTE: deliberately duplicated from `apps/mobile/features/finance/member/
+ * amount.ts` — the mobile app and Convex share no finance module (there is no
+ * finance surface in `packages/shared` today, and one wasn't worth inventing
+ * for two constants). The client estimate is a *display* number; this copy is
+ * the authority: `validateDonationAmount` re-derives the fee here and rejects a
+ * client-supplied `coverFeesCents` that doesn't match, which is also what keeps
+ * the donation cap from being bypassable through the fee field.
+ */
+
+/** Stripe's typical US card rate, charged on the amount that hits the card. */
+const STRIPE_FEE_RATE = 0.029;
+const STRIPE_FEE_FIXED_CENTS = 30;
+
+/** What Stripe takes off a charge of `totalCents`. */
+function stripeFeeCents(totalCents: number): number {
+  return Math.round(totalCents * STRIPE_FEE_RATE + STRIPE_FEE_FIXED_CENTS);
+}
+
+/**
+ * The cents to ADD to a gift of `amountCents` so the fund still nets the full
+ * amount after Stripe's cut.
+ *
+ * Stripe's percentage applies to the whole charge, fee included, so charging
+ * `amount + fee(amount)` still leaves the fund short by the percentage of the
+ * fee. Solving `total - (total * rate + fixed) = amount` gives the closed form
+ * `total = (amount + fixed) / (1 - rate)`; the add-on is `total - amount`,
+ * rounded to the nearest cent and nudged up a cent whenever rounding down would
+ * leave the fund short.
+ */
+export function computeCoverFeesCents(amountCents: number): number {
+  if (!Number.isFinite(amountCents) || amountCents <= 0) return 0;
+  const grossedUpTotal = (amountCents + STRIPE_FEE_FIXED_CENTS) / (1 - STRIPE_FEE_RATE);
+  const fee = Math.round(grossedUpTotal - amountCents);
+  const netToFund = amountCents + fee - stripeFeeCents(amountCents + fee);
+  return netToFund < amountCents ? fee + 1 : fee;
+}
+
+/**
+ * How far a client's fee number may sit from the server's own before we refuse
+ * it: two cents, covering rounding drift between the two implementations (and
+ * a future tweak to one of them) without leaving room to smuggle real money
+ * past the donation cap.
+ */
+export const COVER_FEE_TOLERANCE_CENTS = 2;

--- a/apps/mobile/features/finance/member/__tests__/validateReimbursement.test.ts
+++ b/apps/mobile/features/finance/member/__tests__/validateReimbursement.test.ts
@@ -88,10 +88,37 @@ describe("resolveGiveAmountCents", () => {
   });
 });
 
+/** What Stripe actually takes off a charge of `totalCents` (2.9% + 30c). */
+function stripeTakesCents(totalCents: number): number {
+  return Math.round(totalCents * 0.029 + 30);
+}
+
 describe("estimateCoverFeesCents", () => {
-  it("computes ~2.9% + 30 cents", () => {
-    // 5000 * 0.029 = 145, + 30 = 175
-    expect(estimateCoverFeesCents(5000)).toBe(175);
+  it("grosses up so the fund nets the full amount, not amount-minus-the-fee-on-the-fee", () => {
+    // Naive (fee on the base only) would be round(5000 * 0.029 + 30) = 175,
+    // which leaves the fund $49.95 on a $50 gift. The gross-up is
+    // (5000 + 30) / (1 - 0.029) - 5000 = 180.2c.
+    expect(estimateCoverFeesCents(5000)).toBe(180);
+  });
+
+  it.each([1000, 5000, 10000, 30000, 2_000_000])(
+    "leaves the fund with at least %i cents after Stripe's cut",
+    (amountCents) => {
+      const total = amountCents + estimateCoverFeesCents(amountCents);
+      const net = total - stripeTakesCents(total);
+      expect(net).toBeGreaterThanOrEqual(amountCents);
+      // …and never overshoots by more than a rounding cent.
+      expect(net).toBeLessThanOrEqual(amountCents + 1);
+    },
+  );
+
+  it("never decreases as the amount grows", () => {
+    let previous = 0;
+    for (let amountCents = 100; amountCents <= 2_000_000; amountCents += 997) {
+      const fee = estimateCoverFeesCents(amountCents);
+      expect(fee).toBeGreaterThanOrEqual(previous);
+      previous = fee;
+    }
   });
 
   it("returns 0 for a non-positive amount", () => {

--- a/apps/mobile/features/finance/member/amount.ts
+++ b/apps/mobile/features/finance/member/amount.ts
@@ -28,10 +28,44 @@ export function parseDollarsToCents(
   return Math.round(dollars * 100);
 }
 
-/** Stripe's typical US card rate: 2.9% + 30 cents, rounded to the nearest cent. */
+/**
+ * Stripe's typical US card rate, charged on the amount that actually hits the
+ * card — 2.9% + 30 cents.
+ *
+ * NOTE: deliberately duplicated in `apps/convex/lib/finance/fees.ts`. There is
+ * no shared finance module in `packages/shared` to hold them, and inventing one
+ * for two constants isn't worth a new cross-app import path. The server
+ * re-derives the fee from its own copy and validates the client's number
+ * against it (±2c), so a drift between the two surfaces fails loudly at the
+ * donation-creation seam rather than silently shortchanging a fund.
+ */
+const STRIPE_FEE_RATE = 0.029;
+const STRIPE_FEE_FIXED_CENTS = 30;
+
+/** What Stripe takes off a charge of `totalCents`. */
+function stripeFeeCents(totalCents: number): number {
+  return Math.round(totalCents * STRIPE_FEE_RATE + STRIPE_FEE_FIXED_CENTS);
+}
+
+/**
+ * The cents to ADD to a gift so the fund still nets `amountCents` after
+ * Stripe's cut — the number behind the give sheet's "+$X so the fund gets the
+ * full $Y" toggle.
+ *
+ * Stripe's percentage applies to the whole charge, fee included, so charging
+ * `amount + fee(amount)` still leaves the fund short by the percentage of the
+ * fee. Solving `total - (total * rate + fixed) = amount` gives the closed form
+ * `total = (amount + fixed) / (1 - rate)`; the add-on is `total - amount`.
+ * Rounded to the nearest cent, then nudged up a cent in the rare case that
+ * rounding down would leave the fund a cent short — the toggle's promise is a
+ * floor, not an approximation.
+ */
 export function estimateCoverFeesCents(amountCents: number): number {
   if (!Number.isFinite(amountCents) || amountCents <= 0) return 0;
-  return Math.round(amountCents * 0.029 + 30);
+  const grossedUpTotal = (amountCents + STRIPE_FEE_FIXED_CENTS) / (1 - STRIPE_FEE_RATE);
+  const fee = Math.round(grossedUpTotal - amountCents);
+  const netToFund = amountCents + fee - stripeFeeCents(amountCents + fee);
+  return netToFund < amountCents ? fee + 1 : fee;
 }
 
 /**

--- a/apps/mobile/features/finance/member/amount.ts
+++ b/apps/mobile/features/finance/member/amount.ts
@@ -35,9 +35,11 @@ export function parseDollarsToCents(
  * NOTE: deliberately duplicated in `apps/convex/lib/finance/fees.ts`. There is
  * no shared finance module in `packages/shared` to hold them, and inventing one
  * for two constants isn't worth a new cross-app import path. The server
- * re-derives the fee from its own copy and validates the client's number
- * against it (±2c), so a drift between the two surfaces fails loudly at the
- * donation-creation seam rather than silently shortchanging a fund.
+ * re-derives the fee from its own copy and refuses a client number more than
+ * 2c ABOVE it, so this copy drifting upward fails loudly at the
+ * donation-creation seam instead of overcharging a card. Drifting downward is
+ * allowed on purpose — that's what lets an old client keep giving through a
+ * rollout — and is caught by the shared tests below, not at runtime.
  */
 const STRIPE_FEE_RATE = 0.029;
 const STRIPE_FEE_FIXED_CENTS = 30;


### PR DESCRIPTION
## Summary

**Protected finance path — needs your merge.** Fixes the two fee-cover defects found in the #731/#733 reviews. This changes what donors who tick "Cover the processing fee" are charged — by cents, to make the existing promise true.

- **Gross-up**: the toggle says *"so the fund gets the full $X"*, but the old estimate computed the fee on the base amount, so Stripe's percentage ate into the fee itself and the fund netted less. Now `total = (amount + 30¢)/(1 − 2.9%)`, rounded so the fund never nets under the gift. Brute-forced every integer amount $1–$20,000: 0 shortfalls, 0 overshoots > 1¢.

| gift | old charge | fund netted | new charge | fund nets |
|---|---|---|---|---|
| $10 | $10.59 | $9.98 | $10.61 | **$10.00** |
| $50 | $51.75 | $49.95 | $51.80 | **$50.00** |
| $300 | $309.00 | $299.73 | $309.27 | **$300.00** |

- **Cap bypass closed**: server-side, `feeCoverCents` may now be no more than 2¢ above the server-computed fee for that amount — previously it only had to be ≥ 0 while the card was charged the sum, making `MAX_DONATION_CENTS` a fiction. Max possible charge is now cap + fee(cap) + 2¢.
- **The bound is a ceiling, not a match** (added in review, `b478668`). A fee *below* the quote can't inflate the charge — it just under-covers the fund, which is the pre-PR behaviour and the donor's own money. Matching exactly would have rejected every fee-covered gift ≥ $12.93 from a donor still on the pre-OTA JS bundle, for the whole length of the rollout. One-sided costs nothing on the cap and needs no deploy window.
- Constants deliberately not consolidated (no finance module exists in packages/shared); both copies cross-reference, and the server validates against its own math so drift fails loudly at the donation seam.

## Evidence
```
apps/convex finance-giving.test.ts: 59 passed (+13 new: tolerance band, rejections,
  cap-total invariant, gross-up unit block)  ·  tsc clean
apps/mobile features/finance/member: 96 passed / 6 suites  ·  tsc = main baseline
```

### Deploy note
Function logic + one new lib file — no schema/crons/webhooks/migrations. Merge deploys staging immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcamCRXMUU1DhocRpr59YD
