### PR TITLE
feat(finance): recurring-giving foundations — schema + Connect event routing

### DIFF
--- a/apps/convex/__tests__/finance-webhook-routing.test.ts
+++ b/apps/convex/__tests__/finance-webhook-routing.test.ts
@@ -19,27 +19,48 @@
  */
 
 import { convexTest } from "convex-test";
-import { expect, test, describe, beforeAll } from "vitest";
+import { expect, test, describe, beforeAll, afterAll } from "vitest";
 import schema from "../schema";
 import { modules } from "../test.setup";
 import { isConnectEvent } from "../lib/finance/webhookRouting";
 
 const WEBHOOK_SECRET = "whsec_test_routing_secret";
 
+const priorWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
 beforeAll(() => {
   process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
+});
+
+afterAll(() => {
+  // Restore rather than leak — these tests share the process with every other
+  // suite, and a stray STRIPE_WEBHOOK_SECRET changes how other webhook tests
+  // verify signatures.
+  if (priorWebhookSecret === undefined) {
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+  } else {
+    process.env.STRIPE_WEBHOOK_SECRET = priorWebhookSecret;
+  }
 });
 
 /**
  * Build the `stripe-signature` header the route verifies (HMAC-SHA256 over
  * `{timestamp}.{payload}`, same construction as verifyStripeSignature).
+ *
+ * `secret` and `timestamp` are overridable so the signature-enforcement tests
+ * below can produce headers the route must REJECT.
  */
-async function signedHeader(payload: string): Promise<string> {
-  const timestamp = Math.floor(Date.now() / 1000);
+async function signedHeader(
+  payload: string,
+  {
+    secret = WEBHOOK_SECRET,
+    timestamp = Math.floor(Date.now() / 1000),
+  }: { secret?: string; timestamp?: number } = {},
+): Promise<string> {
   const encoder = new TextEncoder();
   const key = await crypto.subtle.importKey(
     "raw",
-    encoder.encode(WEBHOOK_SECRET),
+    encoder.encode(secret),
     { name: "HMAC", hash: "SHA-256" },
     false,
     ["sign"],
@@ -68,6 +89,23 @@ async function postEvent(
     },
     body,
   });
+}
+
+/**
+ * Post with a caller-supplied `stripe-signature` (or none at all), for the
+ * tests that assert the route REJECTS bad signatures.
+ */
+async function postRaw(
+  t: ReturnType<typeof convexTest>,
+  event: Record<string, unknown>,
+  signature: string | null,
+): Promise<Response> {
+  const body = JSON.stringify(event);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (signature !== null) headers["stripe-signature"] = signature;
+  return await t.fetch("/stripe-webhook", { method: "POST", headers, body });
 }
 
 async function seedSubscribedCommunity(t: ReturnType<typeof convexTest>) {
@@ -204,6 +242,17 @@ describe("/stripe-webhook routes shared event types by event.account", () => {
     // Guard against over-broad routing: only the three ambiguous cases check
     // event.account. A Connect-flagged checkout.session.completed must still
     // reach billing exactly as before.
+    //
+    // This asserts TODAY's behavior, and today it is safe: nothing creates a
+    // Checkout Session on a connected account (one-off giving uses
+    // PaymentIntents), and the Connect event destination does not subscribe
+    // to checkout.session.completed at all. It stops being safe the moment
+    // recurring giving opens Checkout on the connected account — that session
+    // completes with `event.account` set and donor metadata, and billing's
+    // handleCheckoutCompleted requires `communityId: v.string()`, so it would
+    // throw -> 500 -> Stripe retries forever. The PR that adds the
+    // subscription Checkout action MUST gate this case on isConnectEvent too
+    // and flip this assertion.
     const t = convexTest(schema, modules);
     const communityId = await seedSubscribedCommunity(t);
     await t.run(async (ctx) => {
@@ -226,6 +275,102 @@ describe("/stripe-webhook routes shared event types by event.account", () => {
     });
 
     expect(response.status).toBe(200);
+    expect(await subscriptionStatusOf(t, communityId)).toBe("active");
+  });
+
+  test("invoice.paid falls through to the finance dispatcher and no-ops", async () => {
+    // The PR claim being pinned: billing never owned invoice.paid, so it hits
+    // the `default:` arm and reaches handleFinanceStripeEvent, which returns
+    // silently for event types group giving doesn't own yet. 200, and billing
+    // state untouched — with or without event.account.
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+
+    for (const account of [undefined, "acct_connected_123"]) {
+      const response = await postEvent(t, {
+        type: "invoice.paid",
+        ...(account ? { account } : {}),
+        data: { object: { customer: "cus_platform_123", id: "in_123" } },
+      });
+
+      expect(response.status).toBe(200);
+      expect(await subscriptionStatusOf(t, communityId)).toBe("active");
+    }
+  });
+});
+
+// ============================================================================
+// Signature verification — the routing tests above are only meaningful if the
+// route they drive actually rejects unsigned/forged bodies. Without these, a
+// verifyStripeSignature weakened to always-true would leave every test above
+// green while making `event.account` attacker-controlled.
+// ============================================================================
+
+describe("/stripe-webhook rejects anything it cannot verify", () => {
+  const event = {
+    type: "customer.subscription.deleted",
+    data: { object: { id: "sub_platform_123", status: "canceled" } },
+  };
+
+  test("400s when the stripe-signature header is missing", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+
+    const response = await postRaw(t, event, null);
+
+    expect(response.status).toBe(400);
+    expect(await subscriptionStatusOf(t, communityId)).toBe("active");
+  });
+
+  test("400s when the signature was made with the wrong secret", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+    const body = JSON.stringify(event);
+
+    const response = await postRaw(
+      t,
+      event,
+      await signedHeader(body, { secret: "whsec_not_the_real_secret" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await subscriptionStatusOf(t, communityId)).toBe("active");
+  });
+
+  test("400s on a validly-signed but stale payload (replay window)", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+    const body = JSON.stringify(event);
+
+    // Correct HMAC, timestamp 10 minutes old — outside the route's 300s
+    // tolerance.
+    const response = await postRaw(
+      t,
+      event,
+      await signedHeader(body, {
+        timestamp: Math.floor(Date.now() / 1000) - 600,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await subscriptionStatusOf(t, communityId)).toBe("active");
+  });
+
+  test("400s when the signed body is tampered with after signing", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+
+    // Sign the honest body, then send one with `account` injected — the exact
+    // forgery the routing predicate would be vulnerable to if the signature
+    // covered anything less than the whole body.
+    const signature = await signedHeader(JSON.stringify(event));
+    const response = await postRaw(
+      t,
+      { ...event, account: "acct_attacker" },
+      signature,
+    );
+
+    expect(response.status).toBe(400);
     expect(await subscriptionStatusOf(t, communityId)).toBe("active");
   });
 });

--- a/apps/convex/__tests__/finance-webhook-routing.test.ts
+++ b/apps/convex/__tests__/finance-webhook-routing.test.ts
@@ -1,0 +1,231 @@
+/**
+ * /stripe-webhook routing between SaaS billing and group giving.
+ *
+ * Three Stripe event types are ambiguous between the two systems, because a
+ * recurring donation is a Stripe Subscription just like a community's
+ * Togather subscription: `customer.subscription.updated`,
+ * `customer.subscription.deleted`, `invoice.payment_failed`. A recurring
+ * donation lives on the community's CONNECTED account, so its events arrive
+ * with `event.account` set — those must NOT reach the billing handlers,
+ * which would otherwise match a donor's subscription id against a
+ * community's own row.
+ *
+ * These tests drive the real HTTP route (signature and all) and assert the
+ * only externally-observable thing billing does: patching
+ * `communities.subscriptionStatus`. A Connect-flagged event must leave that
+ * field untouched; a platform event must keep behaving exactly as before.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/finance-webhook-routing.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, beforeAll } from "vitest";
+import schema from "../schema";
+import { modules } from "../test.setup";
+import { isConnectEvent } from "../lib/finance/webhookRouting";
+
+const WEBHOOK_SECRET = "whsec_test_routing_secret";
+
+beforeAll(() => {
+  process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
+});
+
+/**
+ * Build the `stripe-signature` header the route verifies (HMAC-SHA256 over
+ * `{timestamp}.{payload}`, same construction as verifyStripeSignature).
+ */
+async function signedHeader(payload: string): Promise<string> {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(WEBHOOK_SECRET),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const bytes = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(`${timestamp}.${payload}`),
+  );
+  const sig = Array.from(new Uint8Array(bytes))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `t=${timestamp},v1=${sig}`;
+}
+
+async function postEvent(
+  t: ReturnType<typeof convexTest>,
+  event: Record<string, unknown>,
+): Promise<Response> {
+  const body = JSON.stringify(event);
+  return await t.fetch("/stripe-webhook", {
+    method: "POST",
+    headers: {
+      "stripe-signature": await signedHeader(body),
+      "Content-Type": "application/json",
+    },
+    body,
+  });
+}
+
+async function seedSubscribedCommunity(t: ReturnType<typeof convexTest>) {
+  const now = Date.now();
+  return await t.run(async (ctx) => {
+    return await ctx.db.insert("communities", {
+      name: "Routing Test Community",
+      slug: "ROUTE001",
+      stripeCustomerId: "cus_platform_123",
+      stripeSubscriptionId: "sub_platform_123",
+      subscriptionStatus: "active",
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+}
+
+async function subscriptionStatusOf(
+  t: ReturnType<typeof convexTest>,
+  communityId: Awaited<ReturnType<typeof seedSubscribedCommunity>>,
+) {
+  return await t.run(async (ctx) => {
+    const community = await ctx.db.get(communityId);
+    return community?.subscriptionStatus;
+  });
+}
+
+// ============================================================================
+// The routing predicate itself
+// ============================================================================
+
+describe("isConnectEvent (lib/finance/webhookRouting.ts)", () => {
+  test("true only when the event carries a connected-account id", () => {
+    expect(isConnectEvent({ account: "acct_connected_123" })).toBe(true);
+    expect(isConnectEvent({})).toBe(false);
+    expect(isConnectEvent({ account: undefined })).toBe(false);
+    expect(isConnectEvent({ account: null })).toBe(false);
+    // An empty string is not an account id — treat it as a platform event
+    // rather than routing a billing event into the finance handler.
+    expect(isConnectEvent({ account: "" })).toBe(false);
+  });
+});
+
+// ============================================================================
+// The route
+// ============================================================================
+
+describe("/stripe-webhook routes shared event types by event.account", () => {
+  test("customer.subscription.deleted WITH event.account does not touch billing", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+
+    const response = await postEvent(t, {
+      type: "customer.subscription.deleted",
+      account: "acct_connected_123",
+      // Deliberately the community's OWN subscription id: if routing were
+      // wrong, billing would cancel a paying community because a donor
+      // canceled a monthly gift.
+      data: { object: { id: "sub_platform_123", status: "canceled" } },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await subscriptionStatusOf(t, communityId)).toBe("active");
+  });
+
+  test("customer.subscription.deleted WITHOUT event.account still cancels (unchanged)", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+
+    const response = await postEvent(t, {
+      type: "customer.subscription.deleted",
+      data: { object: { id: "sub_platform_123", status: "canceled" } },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await subscriptionStatusOf(t, communityId)).toBe("canceled");
+  });
+
+  test("customer.subscription.updated WITH event.account does not touch billing", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+
+    const response = await postEvent(t, {
+      type: "customer.subscription.updated",
+      account: "acct_connected_123",
+      data: { object: { id: "sub_platform_123", status: "past_due" } },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await subscriptionStatusOf(t, communityId)).toBe("active");
+  });
+
+  test("customer.subscription.updated WITHOUT event.account still syncs status (unchanged)", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+
+    const response = await postEvent(t, {
+      type: "customer.subscription.updated",
+      data: { object: { id: "sub_platform_123", status: "past_due" } },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await subscriptionStatusOf(t, communityId)).toBe("past_due");
+  });
+
+  test("invoice.payment_failed WITH event.account does not touch billing", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+
+    const response = await postEvent(t, {
+      type: "invoice.payment_failed",
+      account: "acct_connected_123",
+      data: { object: { customer: "cus_platform_123" } },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await subscriptionStatusOf(t, communityId)).toBe("active");
+  });
+
+  test("invoice.payment_failed WITHOUT event.account still marks past_due (unchanged)", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+
+    const response = await postEvent(t, {
+      type: "invoice.payment_failed",
+      data: { object: { customer: "cus_platform_123" } },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await subscriptionStatusOf(t, communityId)).toBe("past_due");
+  });
+
+  test("checkout.session.completed is untouched by the routing change", async () => {
+    // Guard against over-broad routing: only the three ambiguous cases check
+    // event.account. A Connect-flagged checkout.session.completed must still
+    // reach billing exactly as before.
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(communityId, {
+        subscriptionStatus: undefined,
+        stripeSubscriptionId: undefined,
+      });
+    });
+
+    const response = await postEvent(t, {
+      type: "checkout.session.completed",
+      account: "acct_connected_123",
+      data: {
+        object: {
+          customer: "cus_platform_123",
+          subscription: "sub_new_123",
+          metadata: { communityId },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await subscriptionStatusOf(t, communityId)).toBe("active");
+  });
+});

--- a/apps/convex/http.ts
+++ b/apps/convex/http.ts
@@ -23,6 +23,7 @@ import {
   handleFinanceStripeEvent,
   handleIncreaseWebhookRequest,
 } from "./functions/finance/webhooks";
+import { isConnectEvent } from "./lib/finance/webhookRouting";
 
 const http = httpRouter();
 
@@ -408,6 +409,11 @@ http.route({
  * - customer.subscription.updated -> syncs subscription status
  * - customer.subscription.deleted -> marks subscription as canceled
  * - invoice.payment_failed -> marks subscription as past_due
+ *
+ * The last three are shared with recurring giving (a monthly donation is a
+ * Stripe Subscription on the community's CONNECTED account): when
+ * `event.account` is set the event is a Connect event and goes to the finance
+ * handler instead of billing. See lib/finance/webhookRouting.ts.
  */
 http.route({
   path: "/stripe-webhook",
@@ -468,7 +474,18 @@ http.route({
           );
           break;
         }
+        // The next three cases are AMBIGUOUS: a recurring donation is a
+        // Stripe Subscription too, so these event types arrive for both SaaS
+        // billing (platform account) and group giving (connected account).
+        // `event.account` is what tells them apart — without this check the
+        // billing handlers swallow a donor's subscription event and, worse,
+        // could match a Connect subscription id against a community's own
+        // (see lib/finance/webhookRouting.ts).
         case "customer.subscription.updated": {
+          if (isConnectEvent(event)) {
+            await handleFinanceStripeEvent(ctx, event);
+            break;
+          }
           const subscription = event.data.object;
           await ctx.runMutation(
             internal.functions.ee.billing.handleSubscriptionUpdated,
@@ -480,6 +497,10 @@ http.route({
           break;
         }
         case "customer.subscription.deleted": {
+          if (isConnectEvent(event)) {
+            await handleFinanceStripeEvent(ctx, event);
+            break;
+          }
           const subscription = event.data.object;
           await ctx.runMutation(
             internal.functions.ee.billing.handleSubscriptionUpdated,
@@ -491,6 +512,10 @@ http.route({
           break;
         }
         case "invoice.payment_failed": {
+          if (isConnectEvent(event)) {
+            await handleFinanceStripeEvent(ctx, event);
+            break;
+          }
           const invoice = event.data.object;
           await ctx.runMutation(
             internal.functions.ee.billing.handlePaymentFailed,

--- a/apps/convex/lib/finance/webhookRouting.ts
+++ b/apps/convex/lib/finance/webhookRouting.ts
@@ -1,0 +1,22 @@
+/**
+ * Which handler owns a Stripe event that BOTH billing and giving can receive.
+ *
+ * `/stripe-webhook` (http.ts) is a single endpoint fed by two Stripe event
+ * destinations: the platform account (SaaS billing — a community's Togather
+ * subscription) and "Events from: Connected accounts" (group giving —
+ * ADR-032 §6). Three event types are ambiguous between them, because a
+ * recurring donation is also a Stripe Subscription:
+ * `customer.subscription.updated`, `customer.subscription.deleted`, and
+ * `invoice.payment_failed`.
+ *
+ * Stripe disambiguates them for us: an event delivered for a connected
+ * account carries that account's id in `event.account`, and a platform-account
+ * event never does. So the account field — not the event type, and not
+ * metadata we set — is the routing key.
+ *
+ * Lives here rather than inline in http.ts so the routing rule is testable
+ * without standing up the whole signature-verified HTTP route.
+ */
+export function isConnectEvent(event: { account?: string | null }): boolean {
+  return typeof event.account === "string" && event.account.length > 0;
+}

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -3955,7 +3955,12 @@ export default defineSchema({
     // The `recurringDonations` row this gift was billed under, when it came
     // from a monthly subscription rather than a one-off gift. Reserved: no
     // code writes it yet — the `invoice.paid` handler that records a monthly
-    // charge as a donation is the PR that starts stamping it.
+    // charge as a donation is the PR that starts stamping it, and it will
+    // store that row's `_id` stringified. NOTE: the type stays `v.string()`
+    // rather than `v.id("recurringDonations")` because the field predates the
+    // table and re-typing an existing validator is not an additive schema
+    // change; readers must `ctx.db.get(recurringId as Id<"recurringDonations">)`
+    // and cannot rely on Convex to type- or existence-check the reference.
     recurringId: v.optional(v.string()),
     receiptEmailStatus: v.string(), // "pending" | "sent" | "failed" — Resend receipt from the church's name/EIN
     // The Stripe payout this donation was matched into by planAllocations
@@ -4004,8 +4009,11 @@ export default defineSchema({
    * the same account one-off donations charge on.
    *
    * `communityId` is denormalized from the fund at write time, following
-   * `ledgerEntries`' precedent, so donor- and community-scoped queries don't
-   * have to fan out over funds first.
+   * `ledgerEntries`' precedent, so a row carries its community without a
+   * lookup through `funds`. NOTE: there is deliberately no `by_community`
+   * index yet — nothing queries this table community-wide, and an index costs
+   * write throughput on every subscription event. The first community-scoped
+   * read must add one rather than filter the table.
    */
   recurringDonations: defineTable({
     fundId: v.id("funds"),
@@ -4040,12 +4048,22 @@ export default defineSchema({
   })
     // Webhook entry point: Connect subscription/invoice events identify
     // themselves by subscription id and nothing else.
+    //
+    // CAUTION: the field is optional, so every `pending` row shares the same
+    // missing value on this index. `q.eq("stripeSubscriptionId", undefined)`
+    // matches all of them, which means a lookup with an absent id would
+    // return an arbitrary stranger's pending subscription. Every reader MUST
+    // guard on a non-empty id before querying this index.
     .index("by_stripeSubscriptionId", ["stripeSubscriptionId"])
-    // One active monthly gift per donor per fund — this index is what the
-    // create path checks before starting a second Checkout.
+    // One active monthly gift per donor per fund. Convex has no unique
+    // constraint — this index is only the lookup the create path checks
+    // before starting a second Checkout; the rule lives in that code.
     .index("by_donor_fund", ["donorUserId", "fundId"])
     .index("by_fund", ["fundId"]) // Fund's recurring-giving view
-    .index("by_donor", ["donorUserId"]) // Donor's "my giving" management list
+    // Donor's "my giving" management list. Not redundant with by_donor_fund
+    // despite the shared prefix: this one orders a donor's subscriptions by
+    // _creationTime, where by_donor_fund orders by fundId first.
+    .index("by_donor", ["donorUserId"])
     // Resolves the Checkout return/webhook before stripeSubscriptionId exists.
     .index("by_checkoutSessionId", ["checkoutSessionId"]),
 

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -3952,7 +3952,11 @@ export default defineSchema({
     // so a partially-refunded gift is only ever transferred/counted at what
     // is actually left of it.
     refundedCents: v.optional(v.number()),
-    recurringId: v.optional(v.string()), // Stripe subscription/recurring-donation id, if recurring
+    // The `recurringDonations` row this gift was billed under, when it came
+    // from a monthly subscription rather than a one-off gift. Reserved: no
+    // code writes it yet — the `invoice.paid` handler that records a monthly
+    // charge as a donation is the PR that starts stamping it.
+    recurringId: v.optional(v.string()),
     receiptEmailStatus: v.string(), // "pending" | "sent" | "failed" — Resend receipt from the church's name/EIN
     // The Stripe payout this donation was matched into by planAllocations
     // (functions/finance/jobs.ts). Stamped once, at plan time, and never
@@ -3989,6 +3993,61 @@ export default defineSchema({
     .index("by_fund", ["fundId"])
     .index("by_stripePaymentIntentId", ["stripePaymentIntentId"])
     .index("by_allocationStatus", ["allocationStatus"]),
+
+  /**
+   * A donor's standing monthly gift to a fund — the Stripe Subscription
+   * behind it, not the money it has moved. Individual monthly charges are
+   * recorded as ordinary `donations` rows when `invoice.paid` fires, so the
+   * ledger, receipts, allocation and transparency views all keep working
+   * unchanged and this table never needs a balance of its own. Everything
+   * Stripe-side lives on the community's CONNECTED account (ADR-032 §1) —
+   * the same account one-off donations charge on.
+   *
+   * `communityId` is denormalized from the fund at write time, following
+   * `ledgerEntries`' precedent, so donor- and community-scoped queries don't
+   * have to fan out over funds first.
+   */
+  recurringDonations: defineTable({
+    fundId: v.id("funds"),
+    communityId: v.id("communities"), // Denormalized from funds.communityId
+    donorUserId: v.id("users"), // Required: a subscription needs an account to manage/cancel it
+    amountCents: v.number(), // Base monthly gift
+    feeCoverCents: v.number(), // Donor's voluntary fee-cover add-on, billed with each invoice (never a mandatory surcharge — ADR-031)
+    // Absent until Checkout completes — the Subscription doesn't exist while
+    // the donor is still on Stripe's hosted page.
+    stripeSubscriptionId: v.optional(v.string()),
+    // Customer on the CONNECTED account, NOT the platform account. Donors
+    // have no platform Customer at all (only communities do, for SaaS
+    // billing — `communities.stripeCustomerId`), so this id is only ever
+    // meaningful when used with `stripeAccount: stripeConnectedAccountId`.
+    // Absent until Checkout creates the Customer.
+    stripeCustomerId: v.optional(v.string()),
+    stripeConnectedAccountId: v.string(), // The community's Connect account this subscription lives on
+    // Binds the Checkout return (and the completed-session webhook) to this
+    // row in the window before a subscription id exists — it is the only
+    // handle we have between "row created" and "subscription created".
+    checkoutSessionId: v.string(),
+    status: v.union(
+      v.literal("pending"), // Row created, donor still in Checkout
+      v.literal("active"),
+      v.literal("past_due"),
+      v.literal("canceled"), // Terminal
+    ),
+    currentPeriodEnd: v.optional(v.number()), // Unix timestamp ms — next bill date, mirrored from Stripe
+    canceledAt: v.optional(v.number()), // Unix timestamp ms
+    createdAt: v.number(), // Unix timestamp ms
+    updatedAt: v.number(), // Unix timestamp ms
+  })
+    // Webhook entry point: Connect subscription/invoice events identify
+    // themselves by subscription id and nothing else.
+    .index("by_stripeSubscriptionId", ["stripeSubscriptionId"])
+    // One active monthly gift per donor per fund — this index is what the
+    // create path checks before starting a second Checkout.
+    .index("by_donor_fund", ["donorUserId", "fundId"])
+    .index("by_fund", ["fundId"]) // Fund's recurring-giving view
+    .index("by_donor", ["donorUserId"]) // Donor's "my giving" management list
+    // Resolves the Checkout return/webhook before stripeSubscriptionId exists.
+    .index("by_checkoutSessionId", ["checkoutSessionId"]),
 
   /**
    * An Increase virtual/physical card bound to a fund's Increase Account.

--- a/docs/architecture/decisions/ADR-032-group-giving.md
+++ b/docs/architecture/decisions/ADR-032-group-giving.md
@@ -373,8 +373,10 @@ there is a real window — donor on Stripe's hosted page — in which the row
 exists and the subscription id does not; it is the only handle binding the
 Checkout return and its webhook back to the row, hence
 `by_checkoutSessionId`. Indexes are deliberately five and no more:
-`by_stripeSubscriptionId` (webhook entry), `by_donor_fund` (enforces one
-active monthly gift per donor per fund), `by_fund`, `by_donor`,
+`by_stripeSubscriptionId` (webhook entry), `by_donor_fund` (the lookup the
+create path checks to keep one active monthly gift per donor per fund —
+Convex has no unique constraint, so that rule is enforced in code, not by the
+index), `by_fund`, `by_donor`,
 `by_checkoutSessionId`. `donations.recurringId` — reserved since the original
 schema and never written — is where a charge points back at its subscription.
 
@@ -406,6 +408,24 @@ canceled. The predicate lives in `lib/finance/webhookRouting.ts`
 (`isConnectEvent`) so the rule is testable without the signature-verified
 route. `invoice.paid` needs no such branch — billing never claimed it, so it
 already falls through to the finance dispatcher.
+
+Two boundaries of this foundation are worth stating plainly, because both are
+"correct today, wrong the moment the next PR lands":
+
+- **Routed is not yet handled.** `handleFinanceStripeEvent` has no case for
+  `customer.subscription.updated/deleted` or `invoice.payment_failed` yet, so
+  today a Connect-flagged one is routed away from billing and then returns
+  silently from the dispatcher's `default`. That is the intended landing — the
+  point of this PR is that these events stop corrupting SaaS billing, not that
+  they do anything yet. The subscription-handler PR adds the cases.
+- **`checkout.session.completed` is deliberately NOT gated.** It stays on the
+  billing path regardless of `event.account`, which is safe only while nothing
+  opens a Checkout Session on a connected account (one-off giving uses
+  PaymentIntents, and the Connect destination doesn't subscribe to the event).
+  The PR that adds recurring-giving Checkout must gate this case too:
+  otherwise a donation session completes with `event.account` set and donor
+  metadata, `handleCheckoutCompleted` rejects the missing required
+  `communityId`, and the route 500s into an endless Stripe retry loop.
 
 ## Open questions
 

--- a/docs/architecture/decisions/ADR-032-group-giving.md
+++ b/docs/architecture/decisions/ADR-032-group-giving.md
@@ -349,6 +349,64 @@ already flagged in `functions/finance/ARCHITECTURE.md`:
    deliberately left drifting (a refund arriving after allocation needs a
    bank-side clawback that is not designed yet).
 
+## Addendum (2026-08-02): Recurring giving (monthly)
+
+Giving so far is one-off: a donor taps Give, a PaymentIntent settles, a
+`donations` row and a ledger credit follow. Monthly recurring giving is the
+same money flow on a Stripe **Subscription**, and the guiding decision is that
+it stays the same money flow — recurring adds a *schedule*, not a second
+accounting path.
+
+**Schema.** One new table, `recurringDonations` (`fundId`, `communityId`
+denormalized per `ledgerEntries`, `donorUserId`, `amountCents`,
+`feeCoverCents`, `stripeSubscriptionId?`, `stripeCustomerId?`,
+`stripeConnectedAccountId`, `checkoutSessionId`, `status: pending | active |
+past_due | canceled`, `currentPeriodEnd?`, `canceledAt?`, timestamps). It
+models the *standing instruction*, never a balance: it has no `balanceCents`
+and posts nothing to the ledger itself. Two fields deserve their reasons
+written down. `stripeCustomerId` is a Customer on the **connected** account,
+not the platform — donors have no platform Customer at all (only communities
+do, for SaaS billing), so that id is meaningless without
+`stripeAccount: stripeConnectedAccountId`; conflating the two is the mistake
+this table's comments exist to prevent. `checkoutSessionId` exists because
+there is a real window — donor on Stripe's hosted page — in which the row
+exists and the subscription id does not; it is the only handle binding the
+Checkout return and its webhook back to the row, hence
+`by_checkoutSessionId`. Indexes are deliberately five and no more:
+`by_stripeSubscriptionId` (webhook entry), `by_donor_fund` (enforces one
+active monthly gift per donor per fund), `by_fund`, `by_donor`,
+`by_checkoutSessionId`. `donations.recurringId` — reserved since the original
+schema and never written — is where a charge points back at its subscription.
+
+**Recording: `invoice.paid`, not the subscription.** Each successful monthly
+charge is recorded as an ordinary `donations` row from the `invoice.paid`
+event, stamped with `recurringId`. Nothing downstream learns a new concept:
+the ledger credit, the receipt from the church's EIN, allocation into the
+group's Increase Account, and the member transparency view all run on
+`donations` exactly as they do for one-off gifts. The subscription row only
+ever mirrors *state* (active / past_due / canceled, next bill date). This is
+the §5 invariant restated — money is only ever real when a provider event says
+it moved, and the object that says a monthly gift moved is the paid invoice,
+not the subscription.
+
+**Webhook routing: `event.account` disambiguates.** `/stripe-webhook` is one
+endpoint fed by two Stripe destinations (§6): the platform account for SaaS
+billing and "Events from: Connected accounts" for giving. Recurring giving
+makes three event types genuinely ambiguous —
+`customer.subscription.updated`, `customer.subscription.deleted`,
+`invoice.payment_failed` — because a monthly donation is a Stripe
+Subscription just like a community's Togather subscription. The rule: **if
+`event.account` is present the event belongs to a connected account and goes
+to the finance handler; otherwise it is a platform billing event and routes
+as before.** Stripe sets that field itself, so the routing key is the
+provider's, not metadata of ours. Getting this wrong is not a missing feature
+but a live billing bug: unrouted, a donor canceling a $20/month gift can carry
+a subscription id into `handleSubscriptionUpdated` and mark a paying community
+canceled. The predicate lives in `lib/finance/webhookRouting.ts`
+(`isConnectEvent`) so the rule is testable without the signature-verified
+route. `invoice.paid` needs no such branch — billing never claimed it, so it
+already falls through to the finance dispatcher.
+
 ## Open questions
 
 - Increase program structure: confirm during underwriting that

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -234,6 +234,8 @@ The group giving feature (ADR-032) enables communities to accept donations via S
 1. **Events from: Your account** (billing — the pre-existing destination): `checkout.session.completed`, `customer.subscription.updated/deleted`, `invoice.payment_failed`. Its signing secret is `STRIPE_WEBHOOK_SECRET`.
 2. **Events from: Connected accounts** (group giving): `account.updated`, `payment_intent.succeeded`, `payout.paid`, `charge.refunded`, `charge.dispute.created`. Its signing secret is `STRIPE_CONNECT_WEBHOOK_SECRET`.
 
+**Recurring giving adds four more to destination 2** (ADR-032 addendum): `invoice.paid`, `invoice.payment_failed`, `customer.subscription.updated`, `customer.subscription.deleted`. A monthly donation is a Stripe Subscription on the *connected* account, so these arrive with `event.account` set and are routed to the finance handler rather than SaaS billing (`apps/convex/lib/finance/webhookRouting.ts`). Note the overlap with destination 1: the same three subscription/invoice event types are subscribed on **both** destinations, which is correct — the platform copies drive billing, the connected-account copies drive giving, and `event.account` is what separates them. Until this subscription is added, recurring gifts can be charged by Stripe while their status and donation rows silently never update, so it must be configured **before** recurring giving is switched on in an environment — not after.
+
 The endpoint verifies an incoming signature against either secret (`apps/convex/http.ts`).
 
 **Revoking `STRIPE_CONNECT_WEBHOOK_SECRET`**: the sync script deliberately skips


### PR DESCRIPTION
## Summary

**Foundation PR for monthly recurring giving** (approved design, artifact v5 screens R1–R3). Protected path (`lib/finance/`) — needs your merge. Two surgical changes:

- **New `recurringDonations` table** (additive-only; no existing table/field/index changed — the staging deploy on merge is safe): donor + fund + amounts, `stripeSubscriptionId?`/`stripeCustomerId?` (Customer lives on the **connected** account — donors have no platform Customer), `checkoutSessionId` to bind the Checkout return, status lifecycle `pending→active→past_due→canceled`. Five indexes incl. `by_stripeSubscriptionId` (webhook entry) and `by_donor_fund` (one active monthly per donor per fund). `donations.recurringId`'s reserved-field comment updated to point here.
- **Webhook routing fix for a real landmine**: `customer.subscription.updated/deleted` and `invoice.payment_failed` were routed unconditionally to the SaaS-billing handlers — a donor canceling a monthly gift (a Connect event) would have been processed as a *community's Togather subscription* cancelation. New `isConnectEvent()` (`lib/finance/webhookRouting.ts`): events carrying `event.account` now reach the finance handler; platform events unchanged. `invoice.paid` already falls through untouched.

ADR-032 gains a dated addendum recording the table, the invoice.paid-not-payment_intent recording decision, and the routing rule.

## Evidence
```
finance-webhook-routing.test.ts: 8 passed — incl. 6 end-to-end t.fetch('/stripe-webhook')
  with real HMAC signatures; each ambiguous event tested with AND without event.account;
  mutation-verified (stashing http.ts fails exactly the 3 Connect cases)
billing + finance suites: 146/146 · apps/convex tsc clean
```

Next in the stack (after this merges): the subscription checkout/manage/cancel actions + invoice.paid handler (giving.ts/webhooks.ts — also your merge), then the three UI screens (self-merging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcamCRXMUU1DhocRpr59YD