### PR TITLE
feat(finance): monthly recurring giving on Stripe Subscriptions

### DIFF
--- a/apps/convex/__tests__/finance-giving.test.ts
+++ b/apps/convex/__tests__/finance-giving.test.ts
@@ -407,6 +407,9 @@ describe("getGivingContext", () => {
       communityLegalName: "Test Church Inc.",
       suggestedAmountsCents: [1000, 5000, 10000],
       givingLive: true,
+      // No monthly gift to this fund — see finance-recurring-giving.test.ts
+      // for the populated case.
+      existingRecurring: null,
     });
 
     await t.run(async (ctx) => {

--- a/apps/convex/__tests__/finance-recurring-giving.test.ts
+++ b/apps/convex/__tests__/finance-recurring-giving.test.ts
@@ -38,6 +38,7 @@ import {
   mapStripeSubscriptionStatus,
   resolveInvoicePaymentIntentId,
   resolveInvoicePeriodEndMs,
+  resolveInvoiceRecurringDonationId,
   resolveInvoiceSubscriptionId,
   resolveSubscriptionAmounts,
   resolveSubscriptionPeriodEndMs,
@@ -69,6 +70,13 @@ const stripeStub = vi.hoisted(() => ({
   portalConfigs: [] as Array<{ id: string }>,
   sessionCreateError: null as Error | null,
   subscriptionCancelError: null as Error | null,
+  subscriptionRetrieveError: null as (Error & { code?: string }) | null,
+  // What `checkout.sessions.retrieve` reports for a stale session. The create
+  // path only supersedes a row once Stripe CONFIRMS the session can never
+  // complete, so this drives every abandoned-Checkout branch.
+  sessionStatus: "expired" as string,
+  sessionRetrieveError: null as Error | null,
+  sessionExpireError: null as Error | null,
   // Returned by subscriptions.retrieve — one item, whose price carries the
   // product id updateRecurringAmount must reuse.
   subscription: {
@@ -94,7 +102,15 @@ vi.mock("stripe", () => {
         },
         expire: async (id: string, options: unknown) => {
           record("checkout.sessions.expire", id, options);
+          if (stripeStub.sessionExpireError) throw stripeStub.sessionExpireError;
           return { id };
+        },
+        retrieve: async (id: string, options: unknown) => {
+          record("checkout.sessions.retrieve", id, options);
+          if (stripeStub.sessionRetrieveError) {
+            throw stripeStub.sessionRetrieveError;
+          }
+          return { id, status: stripeStub.sessionStatus };
         },
       },
     };
@@ -107,6 +123,9 @@ vi.mock("stripe", () => {
     subscriptions = {
       retrieve: async (id: string, params: unknown, options: unknown) => {
         record("subscriptions.retrieve", { id, params }, options);
+        if (stripeStub.subscriptionRetrieveError) {
+          throw stripeStub.subscriptionRetrieveError;
+        }
         return stripeStub.subscription;
       },
       update: async (id: string, params: unknown, options: unknown) => {
@@ -154,6 +173,10 @@ beforeEach(() => {
   stripeStub.portalConfigs.length = 0;
   stripeStub.sessionCreateError = null;
   stripeStub.subscriptionCancelError = null;
+  stripeStub.subscriptionRetrieveError = null;
+  stripeStub.sessionRetrieveError = null;
+  stripeStub.sessionExpireError = null;
+  stripeStub.sessionStatus = "expired";
   stripeStub.subscription = {
     id: "sub_test_1",
     items: {
@@ -621,6 +644,9 @@ describe("createRecurringDonationCheckoutSession", () => {
       ctx.db.patch(stale._id, { createdAt: Date.now() - 60 * 60 * 1000 }),
     );
 
+    // Still OPEN at Stripe — the tab is sitting there. This is the branch that
+    // has to expire it before superseding, or it could still complete later.
+    stripeStub.sessionStatus = "open";
     await createRecurring(t, s, { sessionId: "cs_fresh" });
 
     expect(callsTo("checkout.sessions.expire").map((c) => c.params)).toEqual([
@@ -1244,6 +1270,12 @@ describe("cancelRecurringDonation", () => {
     await completeCheckout(t, "cs_c2", "sub_c2");
     const [row] = await rowsFor(t, s.donorUserId);
     stripeStub.subscriptionCancelError = new Error("No such subscription");
+    // …and Stripe CONFIRMS it's gone when we go back to check. That
+    // confirmation is what makes swallowing the error safe.
+    stripeStub.subscriptionRetrieveError = Object.assign(
+      new Error("No such subscription"),
+      { code: "resource_missing" },
+    );
 
     await t.action(api.functions.finance.giving.cancelRecurringDonation, {
       token: await tokenFor(s.donorUserId),
@@ -1482,5 +1514,451 @@ describe("getGivingContext.existingRecurring", () => {
         })
       )?.existingRecurring,
     ).toEqual({ amountCents: GIFT_CENTS, feeCoverCents: FEE_CENTS });
+  });
+});
+
+// ============================================================================
+// Adversarial money-flow invariants.
+//
+// Everything below is a way real money goes wrong that a happy-path test can't
+// see: Stripe delivering events out of order, two tabs racing, a cancel that
+// didn't take, an event from the wrong connected account. Each one is here
+// because it charges a real card if it regresses.
+// ============================================================================
+
+/** `invoice.paid` carrying the subscription-metadata snapshot Stripe puts on
+ * every invoice — the locator that survives out-of-order delivery. */
+function paidInvoiceWithMetadata(params: {
+  invoiceId: string;
+  subscriptionId: string;
+  paymentIntentId: string;
+  amountPaid: number;
+  recurringDonationId: string;
+}) {
+  return {
+    id: params.invoiceId,
+    amount_paid: params.amountPaid,
+    parent: {
+      subscription_details: {
+        subscription: params.subscriptionId,
+        metadata: { recurringDonationId: params.recurringDonationId },
+      },
+    },
+    payments: {
+      data: [{ payment: { payment_intent: params.paymentIntentId } }],
+    },
+    lines: { data: [{ period: { end: 1_800_000 } }] },
+  };
+}
+
+describe("invoice.paid is not allowed to depend on webhook ORDER", () => {
+  test("reads the recurring row id out of the invoice's subscription metadata", () => {
+    expect(
+      resolveInvoiceRecurringDonationId({
+        subscription_details: { metadata: { recurringDonationId: "rec_legacy" } },
+      }),
+    ).toBe("rec_legacy");
+    expect(
+      resolveInvoiceRecurringDonationId({
+        parent: {
+          subscription_details: { metadata: { recurringDonationId: "rec_new" } },
+        },
+      }),
+    ).toBe("rec_new");
+    expect(resolveInvoiceRecurringDonationId({ parent: null })).toBeNull();
+    expect(
+      resolveInvoiceRecurringDonationId({
+        parent: { subscription_details: { metadata: {} } },
+      }),
+    ).toBeNull();
+  });
+
+  test("credits the first month even when invoice.paid beats checkout.session.completed", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_race" });
+    const [pending] = await rowsFor(t, s.donorUserId);
+    // The row exists but nothing has bound a subscription to it yet — exactly
+    // the window Stripe's unordered delivery can land invoice.paid in.
+    expect(pending.stripeSubscriptionId).toBeUndefined();
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.paid",
+      account: CONNECTED_ACCOUNT,
+      data: {
+        object: paidInvoiceWithMetadata({
+          invoiceId: "in_race",
+          subscriptionId: "sub_race",
+          paymentIntentId: "pi_race",
+          amountPaid: TOTAL_CENTS,
+          recurringDonationId: pending._id,
+        }),
+      },
+    });
+
+    const donations = await donationsFor(t, s.fundId);
+    expect(donations).toHaveLength(1);
+    expect(donations[0].stripePaymentIntentId).toBe("pi_race");
+    // The subscription is stamped on now, so every later event resolves the
+    // ordinary way.
+    const [bound] = await rowsFor(t, s.donorUserId);
+    expect(bound.stripeSubscriptionId).toBe("sub_race");
+    expect(bound.status).toBe("active");
+
+    // The late checkout.session.completed must not credit anything a second
+    // time, and must not knock the row back to pending.
+    await completeCheckout(t, "cs_race", "sub_race");
+    expect(await donationsFor(t, s.fundId)).toHaveLength(1);
+    expect((await rowsFor(t, s.donorUserId))[0].status).toBe("active");
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("never re-points a row that already belongs to a different subscription", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_bound" });
+    await completeCheckout(t, "cs_bound", "sub_real");
+    const [row] = await rowsFor(t, s.donorUserId);
+
+    // A metadata hint pointing at an already-bound row: honouring it would let
+    // one subscription's invoices credit against another's gift.
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.paid",
+      account: CONNECTED_ACCOUNT,
+      data: {
+        object: paidInvoiceWithMetadata({
+          invoiceId: "in_other",
+          subscriptionId: "sub_impostor",
+          paymentIntentId: "pi_impostor",
+          amountPaid: TOTAL_CENTS,
+          recurringDonationId: row._id,
+        }),
+      },
+    });
+
+    expect(await donationsFor(t, s.fundId)).toHaveLength(0);
+    expect((await rowsFor(t, s.donorUserId))[0].stripeSubscriptionId).toBe(
+      "sub_real",
+    );
+  });
+
+  test("a $0 invoice credits nothing instead of failing the webhook forever", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_zero" });
+    await completeCheckout(t, "cs_zero", "sub_zero");
+
+    // Must not throw: a throw here 500s the webhook and Stripe redelivers the
+    // same $0 invoice forever.
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.paid",
+      account: CONNECTED_ACCOUNT,
+      data: {
+        object: paidInvoice({
+          invoiceId: "in_zero",
+          subscriptionId: "sub_zero",
+          paymentIntentId: "pi_zero",
+          amountPaid: 0,
+        }),
+      },
+    });
+
+    expect(await donationsFor(t, s.fundId)).toHaveLength(0);
+    expect((await t.run((ctx) => ctx.db.get(s.fundId)))?.balanceCents).toBe(
+      10_000,
+    );
+  });
+
+  test("settles a final invoice on a canceled row without reviving the gift", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_final" });
+    await completeCheckout(t, "cs_final", "sub_final");
+    await t.action(api.functions.finance.giving.cancelRecurringDonation, {
+      token: await tokenFor(s.donorUserId),
+      recurringDonationId: (await rowsFor(t, s.donorUserId))[0]._id,
+    });
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.paid",
+      account: CONNECTED_ACCOUNT,
+      data: {
+        object: paidInvoice({
+          invoiceId: "in_final",
+          subscriptionId: "sub_final",
+          paymentIntentId: "pi_final",
+          amountPaid: TOTAL_CENTS,
+        }),
+      },
+    });
+
+    // The money was really collected, so it is really credited…
+    expect(await donationsFor(t, s.fundId)).toHaveLength(1);
+    // …but "canceled" is terminal.
+    expect((await rowsFor(t, s.donorUserId))[0].status).toBe("canceled");
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+});
+
+describe("one monthly gift per donor per fund, under a race", () => {
+  test("the INSERT itself refuses a second pending row, not just the read-only check", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_first" });
+
+    // Two tabs both clear `prepareRecurringDonation` and reach the mutation.
+    // The mutation is the only thing that can serialize them, so it — not the
+    // query — has to be what says no.
+    await expect(
+      t.mutation(internal.functions.finance.giving.beginRecurringDonation, {
+        token: await tokenFor(s.donorUserId),
+        fundId: s.fundId,
+        amountCents: GIFT_CENTS,
+        feeCoverCents: FEE_CENTS,
+        stripeConnectedAccountId: CONNECTED_ACCOUNT,
+        stripeCustomerId: "cus_donor_1",
+      }),
+    ).rejects.toThrow(/just started setting up/i);
+
+    expect(await rowsFor(t, s.donorUserId)).toHaveLength(1);
+  });
+
+  test("a pending row that already has a subscription blocks a second gift forever, not for 30 minutes", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_slow" });
+    await completeCheckout(t, "cs_slow", "sub_slow");
+    const [row] = await rowsFor(t, s.donorUserId);
+    // Bound but still `pending` — invoice.paid hasn't landed. Age it well past
+    // the grace window: the donor IS being billed, so the window is irrelevant.
+    expect(row.status).toBe("pending");
+    await t.run((ctx) =>
+      ctx.db.patch(row._id, { createdAt: Date.now() - 60 * 60 * 1000 }),
+    );
+
+    await expect(createRecurring(t, s, { sessionId: "cs_second" })).rejects.toThrow(
+      /already have a monthly gift|just started setting up/i,
+    );
+    expect(await rowsFor(t, s.donorUserId)).toHaveLength(1);
+    expect(callsTo("checkout.sessions.expire")).toHaveLength(0);
+  });
+});
+
+describe("superseding a stale Checkout never orphans a live subscription", () => {
+  async function agedStaleGift() {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_aged" });
+    const [stale] = await rowsFor(t, s.donorUserId);
+    await t.run((ctx) =>
+      ctx.db.patch(stale._id, { createdAt: Date.now() - 60 * 60 * 1000 }),
+    );
+    return { t, s };
+  }
+
+  test("refuses the new attempt when the stale session actually COMPLETED", async () => {
+    const { t, s } = await agedStaleGift();
+    // The donor finished that Checkout; a subscription exists at Stripe and
+    // checkout.session.completed simply hasn't arrived. Superseding here would
+    // cancel the row and leave that subscription billing forever with nothing
+    // in the app able to stop it.
+    stripeStub.sessionStatus = "complete";
+
+    await expect(createRecurring(t, s, { sessionId: "cs_new" })).rejects.toThrow(
+      /already have a monthly gift/i,
+    );
+    expect(callsTo("checkout.sessions.expire")).toHaveLength(0);
+    const rows = await rowsFor(t, s.donorUserId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("pending"); // still bindable
+  });
+
+  test("refuses the new attempt when Stripe cannot tell us the session's state", async () => {
+    const { t, s } = await agedStaleGift();
+    stripeStub.sessionRetrieveError = new Error("connection reset");
+
+    await expect(createRecurring(t, s, { sessionId: "cs_new" })).rejects.toThrow(
+      /just started setting up/i,
+    );
+    expect((await rowsFor(t, s.donorUserId))[0].status).toBe("pending");
+  });
+
+  test("refuses the new attempt when the still-open session could not be expired", async () => {
+    const { t, s } = await agedStaleGift();
+    stripeStub.sessionStatus = "open";
+    stripeStub.sessionExpireError = new Error("rate limited");
+
+    await expect(createRecurring(t, s, { sessionId: "cs_new" })).rejects.toThrow(
+      /just started setting up/i,
+    );
+    expect((await rowsFor(t, s.donorUserId))[0].status).toBe("pending");
+  });
+});
+
+describe("cancel only reports success when the card really stops being charged", () => {
+  test("a transient Stripe failure surfaces instead of falsely marking the gift stopped", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_flaky" });
+    await completeCheckout(t, "cs_flaky", "sub_flaky");
+    const [row] = await rowsFor(t, s.donorUserId);
+
+    stripeStub.subscriptionCancelError = new Error("Stripe is down");
+    // …and the follow-up read shows the subscription very much alive.
+    stripeStub.subscription = { id: "sub_flaky", status: "active", items: { data: [] } };
+
+    await expect(
+      t.action(api.functions.finance.giving.cancelRecurringDonation, {
+        token: await tokenFor(s.donorUserId),
+        recurringDonationId: row._id,
+      }),
+    ).rejects.toThrow(/Stripe is down/);
+
+    // The row must NOT be canceled: it is terminal, so a false cancel would
+    // also stop any later Stripe event from ever putting it back.
+    const [after] = await rowsFor(t, s.donorUserId);
+    expect(after.status).not.toBe("canceled");
+    expect(after.canceledAt).toBeUndefined();
+  });
+});
+
+describe("an event from the wrong connected account never mutates a row", () => {
+  async function liveGift() {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_acct" });
+    await completeCheckout(t, "cs_acct", "sub_acct");
+    return { t, s };
+  }
+
+  async function mismatchAudits(
+    t: ReturnType<typeof convexTest>,
+    fundId: Id<"funds">,
+  ) {
+    const audits = await t.run((ctx) =>
+      ctx.db
+        .query("financeAuditEvents")
+        .withIndex("by_fund", (q) => q.eq("fundId", fundId))
+        .collect(),
+    );
+    return audits.filter((e) => e.action === "webhook.rejected_account_mismatch");
+  }
+
+  test("customer.subscription.updated from another account changes nothing", async () => {
+    const { t, s } = await liveGift();
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "customer.subscription.updated",
+      account: "acct_attacker",
+      data: { object: { id: "sub_acct", status: "canceled" } },
+    });
+    expect((await rowsFor(t, s.donorUserId))[0].status).toBe("pending");
+    expect(await mismatchAudits(t, s.fundId)).toHaveLength(1);
+  });
+
+  test("customer.subscription.deleted from another account cannot cancel the gift", async () => {
+    const { t, s } = await liveGift();
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "customer.subscription.deleted",
+      account: "acct_attacker",
+      data: { object: { id: "sub_acct" } },
+    });
+    const [row] = await rowsFor(t, s.donorUserId);
+    expect(row.status).not.toBe("canceled");
+    expect(await mismatchAudits(t, s.fundId)).toHaveLength(1);
+  });
+
+  test("invoice.payment_failed from another account cannot mark the gift past due", async () => {
+    const { t, s } = await liveGift();
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.payment_failed",
+      account: "acct_attacker",
+      data: {
+        object: {
+          id: "in_spoof",
+          parent: { subscription_details: { subscription: "sub_acct" } },
+        },
+      },
+    });
+    expect((await rowsFor(t, s.donorUserId))[0].status).toBe("pending");
+    expect(await mismatchAudits(t, s.fundId)).toHaveLength(1);
+  });
+
+  test("an event with NO account at all is rejected too", async () => {
+    const { t, s } = await liveGift();
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "customer.subscription.deleted",
+      account: undefined,
+      data: { object: { id: "sub_acct" } },
+    });
+    expect((await rowsFor(t, s.donorUserId))[0].status).not.toBe("canceled");
+    expect(await mismatchAudits(t, s.fundId)).toHaveLength(1);
+  });
+});
+
+describe("subscription metadata is never the authority on money", () => {
+  test("an amount split that disagrees with the billed price leaves the row alone", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_meta" });
+    await completeCheckout(t, "cs_meta", "sub_meta");
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "customer.subscription.updated",
+      account: CONNECTED_ACCOUNT,
+      data: {
+        object: {
+          id: "sub_meta",
+          status: "active",
+          // Metadata claims $99 + $3 while the price actually bills $50.
+          metadata: { amountCents: "9900", feeCoverCents: "300" },
+          items: { data: [{ price: { unit_amount: 5000 } }] },
+        },
+      },
+    });
+
+    const [row] = await rowsFor(t, s.donorUserId);
+    expect(row.amountCents).toBe(GIFT_CENTS);
+    expect(row.feeCoverCents).toBe(FEE_CENTS);
+  });
+
+  test("credits what Stripe collected, not what the metadata claims", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_auth" });
+    await completeCheckout(t, "cs_auth", "sub_auth");
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.paid",
+      account: CONNECTED_ACCOUNT,
+      data: {
+        object: {
+          ...paidInvoiceWithMetadata({
+            invoiceId: "in_auth",
+            subscriptionId: "sub_auth",
+            paymentIntentId: "pi_auth",
+            amountPaid: 100, // Stripe collected $1…
+            recurringDonationId: (await rowsFor(t, s.donorUserId))[0]._id,
+          }),
+          // …while the snapshot metadata brags about $999.
+          parent: {
+            subscription_details: {
+              subscription: "sub_auth",
+              metadata: { amountCents: "99900", feeCoverCents: "0" },
+            },
+          },
+        },
+      },
+    });
+
+    const donations = await donationsFor(t, s.fundId);
+    expect(donations).toHaveLength(1);
+    expect(donations[0].amountCents + donations[0].feeCoverCents).toBe(100);
+    expect((await t.run((ctx) => ctx.db.get(s.fundId)))?.balanceCents).toBe(
+      10_000 + 100,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
   });
 });

--- a/apps/convex/__tests__/finance-recurring-giving.test.ts
+++ b/apps/convex/__tests__/finance-recurring-giving.test.ts
@@ -1,0 +1,1486 @@
+/**
+ * Recurring (monthly) giving — ADR-032 §3 "standing gifts".
+ *
+ * Covers functions/finance/giving.ts's recurring surface (create, the donor
+ * management actions, the webhook-facing mutations) and the recurring cases
+ * in functions/finance/webhooks.ts.
+ *
+ * TWO deliberate departures from finance-giving.test.ts's conventions, both
+ * because the thing under test here IS the Stripe-shaped plumbing:
+ *
+ *  1. The `stripe` SDK is mocked (as finance-payout-nets.test.ts does, and
+ *     for the same reason) — a subscription-mode Checkout Session, an inline
+ *     recurring price, and a subscription-item update are exactly the details
+ *     that break, so they're asserted on rather than skipped.
+ *  2. `handleFinanceStripeEvent` is driven DIRECTLY through a small ActionCtx
+ *     shim. finance-giving.test.ts drives its constituent pieces instead,
+ *     noting convex-test doesn't synthesize an ActionCtx for a plain exported
+ *     function — but the shim below is a faithful one (the dispatcher only
+ *     ever uses runQuery/runMutation/runAction, which `t` provides with the
+ *     same signatures), and for recurring giving the dispatcher's own routing
+ *     and cross-API-version field reading are half of what can go wrong.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/finance-recurring-giving.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, vi, beforeEach, afterEach } from "vitest";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { ActionCtx } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import { generateTokens } from "../lib/auth";
+import { buildGiveReturnUrls } from "../functions/finance/giving";
+import { computeCoverFeesCents } from "../lib/finance/fees";
+import {
+  handleFinanceStripeEvent,
+  mapStripeSubscriptionStatus,
+  resolveInvoicePaymentIntentId,
+  resolveInvoicePeriodEndMs,
+  resolveInvoiceSubscriptionId,
+  resolveSubscriptionAmounts,
+  resolveSubscriptionPeriodEndMs,
+} from "../functions/finance/webhooks";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+process.env.STRIPE_SECRET_KEY = "sk_test_recurring_giving";
+
+const CONNECTED_ACCOUNT = "acct_test123";
+
+/**
+ * The gift these tests give, and the fee the SERVER would quote for it
+ * (lib/finance/fees.ts). Derived rather than hardcoded: `validateDonationAmount`
+ * ceilings a submitted fee at this number, so a fixture that drifted from it
+ * would start failing for a reason with nothing to do with recurring giving.
+ */
+const GIFT_CENTS = 2500;
+const FEE_CENTS = computeCoverFeesCents(GIFT_CENTS);
+const TOTAL_CENTS = GIFT_CENTS + FEE_CENTS;
+
+// ============================================================================
+// Stripe SDK fake
+// ============================================================================
+
+const stripeStub = vi.hoisted(() => ({
+  calls: [] as Array<{ method: string; params: unknown; options: unknown }>,
+  sessionIds: [] as string[],
+  customerIds: [] as string[],
+  portalConfigs: [] as Array<{ id: string }>,
+  sessionCreateError: null as Error | null,
+  subscriptionCancelError: null as Error | null,
+  // Returned by subscriptions.retrieve — one item, whose price carries the
+  // product id updateRecurringAmount must reuse.
+  subscription: {
+    id: "sub_test_1",
+    items: {
+      data: [{ id: "si_test_1", price: { id: "price_1", product: "prod_1" } }],
+    },
+  } as Record<string, unknown>,
+}));
+
+vi.mock("stripe", () => {
+  const record = (method: string, params: unknown, options: unknown) => {
+    stripeStub.calls.push({ method, params, options });
+  };
+  class FakeStripe {
+    checkout = {
+      sessions: {
+        create: async (params: unknown, options: unknown) => {
+          record("checkout.sessions.create", params, options);
+          if (stripeStub.sessionCreateError) throw stripeStub.sessionCreateError;
+          const id = stripeStub.sessionIds.shift() ?? "cs_test_default";
+          return { id, url: `https://checkout.stripe.test/${id}` };
+        },
+        expire: async (id: string, options: unknown) => {
+          record("checkout.sessions.expire", id, options);
+          return { id };
+        },
+      },
+    };
+    customers = {
+      create: async (params: unknown, options: unknown) => {
+        record("customers.create", params, options);
+        return { id: stripeStub.customerIds.shift() ?? "cus_test_default" };
+      },
+    };
+    subscriptions = {
+      retrieve: async (id: string, params: unknown, options: unknown) => {
+        record("subscriptions.retrieve", { id, params }, options);
+        return stripeStub.subscription;
+      },
+      update: async (id: string, params: unknown, options: unknown) => {
+        record("subscriptions.update", { id, params }, options);
+        return stripeStub.subscription;
+      },
+      cancel: async (id: string, params: unknown, options: unknown) => {
+        record("subscriptions.cancel", { id, params }, options);
+        if (stripeStub.subscriptionCancelError) {
+          throw stripeStub.subscriptionCancelError;
+        }
+        return { id, status: "canceled" };
+      },
+    };
+    billingPortal = {
+      configurations: {
+        list: async (params: unknown, options: unknown) => {
+          record("billingPortal.configurations.list", params, options);
+          return { data: stripeStub.portalConfigs };
+        },
+        create: async (params: unknown, options: unknown) => {
+          record("billingPortal.configurations.create", params, options);
+          return { id: "bpc_created" };
+        },
+      },
+      sessions: {
+        create: async (params: unknown, options: unknown) => {
+          record("billingPortal.sessions.create", params, options);
+          return { url: "https://billing.stripe.test/session" };
+        },
+      },
+    };
+  }
+  return { default: FakeStripe };
+});
+
+function callsTo(method: string) {
+  return stripeStub.calls.filter((c) => c.method === method);
+}
+
+beforeEach(() => {
+  stripeStub.calls.length = 0;
+  stripeStub.sessionIds.length = 0;
+  stripeStub.customerIds.length = 0;
+  stripeStub.portalConfigs.length = 0;
+  stripeStub.sessionCreateError = null;
+  stripeStub.subscriptionCancelError = null;
+  stripeStub.subscription = {
+    id: "sub_test_1",
+    items: {
+      data: [{ id: "si_test_1", price: { id: "price_1", product: "prod_1" } }],
+    },
+  };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ============================================================================
+// Fixture
+// ============================================================================
+
+interface RecurringFixture {
+  communityId: Id<"communities">;
+  groupId: Id<"groups">;
+  fundId: Id<"funds">;
+  /** A SECOND fund in the same community — the Customer-reuse case. */
+  otherGroupId: Id<"groups">;
+  otherFundId: Id<"funds">;
+  donorUserId: Id<"users">;
+  otherDonorUserId: Id<"users">;
+}
+
+async function seedRecurringFixture(
+  t: ReturnType<typeof convexTest>,
+): Promise<RecurringFixture> {
+  return await t.run(async (ctx) => {
+    await ctx.db.insert("featureFlags", {
+      key: "group-giving",
+      enabled: true,
+      updatedAt: Date.now(),
+    });
+    const timestamp = Date.now();
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Test Church",
+      slug: "test-church",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Group",
+      slug: "small-group",
+      isActive: true,
+      createdAt: timestamp,
+      displayOrder: 1,
+    });
+
+    const mkGroup = async (name: string) =>
+      ctx.db.insert("groups", {
+        communityId,
+        groupTypeId,
+        name,
+        isArchived: false,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+    const groupId = await mkGroup("Young Adults");
+    const otherGroupId = await mkGroup("Youth");
+
+    const mkUser = async (firstName: string) =>
+      ctx.db.insert("users", {
+        firstName,
+        lastName: "Giver",
+        email: `${firstName.toLowerCase()}@example.com`,
+        phone: `+1555000${Math.floor(Math.random() * 9000 + 1000)}`,
+        isActive: true,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+    const donorUserId = await mkUser("Donor");
+    const otherDonorUserId = await mkUser("Other");
+
+    for (const userId of [donorUserId, otherDonorUserId]) {
+      for (const g of [groupId, otherGroupId]) {
+        await ctx.db.insert("groupMembers", {
+          groupId: g,
+          userId,
+          role: "member",
+          joinedAt: timestamp,
+          notificationsEnabled: true,
+        });
+      }
+    }
+
+    const mkFund = async (gid: Id<"groups">, name: string) =>
+      ctx.db.insert("funds", {
+        communityId,
+        groupId: gid,
+        name,
+        type: "group",
+        status: "active",
+        balanceCents: 10_000,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+    const fundId = await mkFund(groupId, "Young Adults Fund");
+    const otherFundId = await mkFund(otherGroupId, "Youth Fund");
+
+    await ctx.db.insert("communityFinance", {
+      communityId,
+      stripeConnectedAccountId: CONNECTED_ACCOUNT,
+      onboardingStatus: "live",
+      legalName: "Test Church Inc.",
+      ein: "12-3456789",
+      address: {
+        addressLine1: "123 Main St",
+        city: "Anytown",
+        state: "CA",
+        zipCode: "90210",
+      },
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    return {
+      communityId,
+      groupId,
+      fundId,
+      otherGroupId,
+      otherFundId,
+      donorUserId,
+      otherDonorUserId,
+    };
+  });
+}
+
+async function tokenFor(userId: Id<"users">): Promise<string> {
+  const { accessToken } = await generateTokens(userId);
+  return accessToken;
+}
+
+/**
+ * A faithful ActionCtx for `handleFinanceStripeEvent`: it only ever calls
+ * runQuery/runMutation/runAction, and convex-test's `t` implements all three
+ * with the same signatures against the same in-memory database.
+ */
+function webhookCtx(t: ReturnType<typeof convexTest>): ActionCtx {
+  return {
+    runQuery: (ref: never, args: never) => t.query(ref, args),
+    runMutation: (ref: never, args: never) => t.mutation(ref, args),
+    runAction: (ref: never, args: never) => t.action(ref, args),
+  } as unknown as ActionCtx;
+}
+
+/** Creates a monthly gift end-to-end through the real action. */
+async function createRecurring(
+  t: ReturnType<typeof convexTest>,
+  s: RecurringFixture,
+  overrides: {
+    fundId?: Id<"funds">;
+    donorUserId?: Id<"users">;
+    amountCents?: number;
+    coverFeesCents?: number;
+    sessionId?: string;
+    customerId?: string;
+  } = {},
+) {
+  stripeStub.sessionIds.push(overrides.sessionId ?? "cs_recurring_1");
+  stripeStub.customerIds.push(overrides.customerId ?? "cus_donor_1");
+  return await t.action(
+    api.functions.finance.giving.createRecurringDonationCheckoutSession,
+    {
+      token: await tokenFor(overrides.donorUserId ?? s.donorUserId),
+      fundId: overrides.fundId ?? s.fundId,
+      amountCents: overrides.amountCents ?? GIFT_CENTS,
+      coverFeesCents: overrides.coverFeesCents ?? FEE_CENTS,
+    },
+  );
+}
+
+/** Binds a subscription to the row the way checkout.session.completed does. */
+async function completeCheckout(
+  t: ReturnType<typeof convexTest>,
+  sessionId: string,
+  subscriptionId: string,
+  customerId = "cus_donor_1",
+) {
+  await handleFinanceStripeEvent(webhookCtx(t), {
+    type: "checkout.session.completed",
+    account: CONNECTED_ACCOUNT,
+    data: {
+      object: {
+        id: sessionId,
+        mode: "subscription",
+        subscription: subscriptionId,
+        customer: customerId,
+      },
+    },
+  });
+}
+
+/** An `invoice.paid` payload in the CURRENT (2025-03-31+) API shape. */
+function paidInvoice(params: {
+  invoiceId: string;
+  subscriptionId: string;
+  paymentIntentId: string;
+  amountPaid: number;
+  periodEndSeconds?: number;
+}) {
+  return {
+    id: params.invoiceId,
+    amount_paid: params.amountPaid,
+    parent: { subscription_details: { subscription: params.subscriptionId } },
+    payments: {
+      data: [{ payment: { payment_intent: params.paymentIntentId } }],
+    },
+    lines: {
+      data: [{ period: { end: params.periodEndSeconds ?? 1_800_000_000 } }],
+    },
+  };
+}
+
+async function rowsFor(
+  t: ReturnType<typeof convexTest>,
+  donorUserId: Id<"users">,
+) {
+  return await t.run((ctx) =>
+    ctx.db
+      .query("recurringDonations")
+      .withIndex("by_donor", (q) => q.eq("donorUserId", donorUserId))
+      .collect(),
+  );
+}
+
+async function donationsFor(
+  t: ReturnType<typeof convexTest>,
+  fundId: Id<"funds">,
+) {
+  return await t.run((ctx) =>
+    ctx.db
+      .query("donations")
+      .withIndex("by_fund", (q) => q.eq("fundId", fundId))
+      .collect(),
+  );
+}
+
+// ============================================================================
+// Pure webhook-payload readers
+// ============================================================================
+
+describe("Stripe payload readers (cross-API-version)", () => {
+  test("resolves an invoice's subscription from both the legacy and current shapes", () => {
+    expect(resolveInvoiceSubscriptionId({ subscription: "sub_legacy" })).toBe(
+      "sub_legacy",
+    );
+    expect(
+      resolveInvoiceSubscriptionId({
+        parent: { subscription_details: { subscription: "sub_new" } },
+      }),
+    ).toBe("sub_new");
+    // Expanded object form, and the "this invoice has no subscription" case.
+    expect(
+      resolveInvoiceSubscriptionId({ subscription: { id: "sub_expanded" } }),
+    ).toBe("sub_expanded");
+    expect(resolveInvoiceSubscriptionId({})).toBeNull();
+  });
+
+  test("resolves an invoice's PaymentIntent from both shapes — the idempotency key for a recurring gift", () => {
+    expect(resolveInvoicePaymentIntentId({ payment_intent: "pi_legacy" })).toBe(
+      "pi_legacy",
+    );
+    expect(
+      resolveInvoicePaymentIntentId({
+        payments: { data: [{ payment: { payment_intent: "pi_new" } }] },
+      }),
+    ).toBe("pi_new");
+    expect(resolveInvoicePaymentIntentId({ payments: { data: [] } })).toBeNull();
+  });
+
+  test("converts period ends from Stripe seconds to our milliseconds", () => {
+    expect(
+      resolveInvoicePeriodEndMs({ lines: { data: [{ period: { end: 1700 } }] } }),
+    ).toBe(1_700_000);
+    expect(resolveInvoicePeriodEndMs({})).toBeUndefined();
+    expect(resolveSubscriptionPeriodEndMs({ id: "s", current_period_end: 1700 })).toBe(
+      1_700_000,
+    );
+    expect(
+      resolveSubscriptionPeriodEndMs({
+        id: "s",
+        items: { data: [{ current_period_end: 1800 }] },
+      }),
+    ).toBe(1_800_000);
+  });
+
+  test("maps Stripe's subscription statuses onto the four states the row models", () => {
+    expect(mapStripeSubscriptionStatus("active")).toBe("active");
+    expect(mapStripeSubscriptionStatus("trialing")).toBe("active");
+    expect(mapStripeSubscriptionStatus("past_due")).toBe("past_due");
+    expect(mapStripeSubscriptionStatus("unpaid")).toBe("past_due");
+    expect(mapStripeSubscriptionStatus("canceled")).toBe("canceled");
+    expect(mapStripeSubscriptionStatus("incomplete_expired")).toBe("canceled");
+    // "incomplete" IS our "pending" — no transition to make.
+    expect(mapStripeSubscriptionStatus("incomplete")).toBeNull();
+    expect(mapStripeSubscriptionStatus(undefined)).toBeNull();
+  });
+
+  test("only trusts a metadata amount split that adds up to the price actually billed", () => {
+    const withPrice = (unitAmount: number, metadata: Record<string, string>) => ({
+      id: "sub_1",
+      metadata,
+      items: { data: [{ price: { unit_amount: unitAmount } }] },
+    });
+
+    expect(
+      resolveSubscriptionAmounts(
+        withPrice(2603, { amountCents: "2500", feeCoverCents: "103" }),
+      ),
+    ).toEqual({ amountCents: 2500, feeCoverCents: 103 });
+
+    // Stale metadata (says $25 + $1.03 while Stripe bills $50) is ignored —
+    // better to leave the row alone than record a split the donor isn't billed.
+    expect(
+      resolveSubscriptionAmounts(
+        withPrice(5000, { amountCents: "2500", feeCoverCents: "103" }),
+      ),
+    ).toBeNull();
+    expect(resolveSubscriptionAmounts(withPrice(2500, {}))).toBeNull();
+    expect(
+      resolveSubscriptionAmounts({ id: "sub_1", metadata: {}, items: { data: [] } }),
+    ).toBeNull();
+  });
+
+  test("buildGiveReturnUrls flags a monthly gift so the success screen can say so", () => {
+    const oneOff = buildGiveReturnUrls({
+      groupId: "g1",
+      totalCents: 2603,
+      fundName: "F",
+      communityName: "C",
+    });
+    expect(oneOff.successUrl).not.toContain("recurring=1");
+
+    const monthly = buildGiveReturnUrls({
+      groupId: "g1",
+      totalCents: 2603,
+      fundName: "F",
+      communityName: "C",
+      recurring: true,
+    });
+    expect(monthly.successUrl.endsWith("&recurring=1")).toBe(true);
+    expect(monthly.successUrl).toContain("&amount=2603");
+  });
+});
+
+// ============================================================================
+// createRecurringDonationCheckoutSession
+// ============================================================================
+
+describe("createRecurringDonationCheckoutSession", () => {
+  test("creates a monthly Checkout Session and a pending row bound to it", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+
+    const result = await createRecurring(t, s, { sessionId: "cs_abc" });
+    expect(result.url).toBe("https://checkout.stripe.test/cs_abc");
+    expect(result.sessionId).toBe("cs_abc");
+
+    const rows = await rowsFor(t, s.donorUserId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      fundId: s.fundId,
+      communityId: s.communityId,
+      donorUserId: s.donorUserId,
+      amountCents: GIFT_CENTS,
+      feeCoverCents: FEE_CENTS,
+      stripeCustomerId: "cus_donor_1",
+      stripeConnectedAccountId: CONNECTED_ACCOUNT,
+      checkoutSessionId: "cs_abc",
+      status: "pending",
+    });
+    expect(rows[0].stripeSubscriptionId).toBeUndefined();
+
+    const [session] = callsTo("checkout.sessions.create");
+    const params = session.params as any;
+    expect(params.mode).toBe("subscription");
+    expect(params.customer).toBe("cus_donor_1");
+    expect(params.line_items[0].quantity).toBe(1);
+    expect(params.line_items[0].price_data).toMatchObject({
+      currency: "usd",
+      unit_amount: TOTAL_CENTS, // gift + fee cover
+      recurring: { interval: "month" },
+    });
+    // payment_intent_data is illegal in subscription mode — the metadata that
+    // attributes a charge has to live on the subscription instead.
+    expect(params.payment_intent_data).toBeUndefined();
+    expect(params.subscription_data.metadata).toMatchObject({
+      recurringDonationId: rows[0]._id,
+      fundId: s.fundId,
+      donorUserId: s.donorUserId,
+      communityId: s.communityId,
+      amountCents: String(GIFT_CENTS),
+      feeCoverCents: String(FEE_CENTS),
+    });
+    expect(params.success_url).toContain("recurring=1");
+    // Direct charge on the community's own connected account.
+    expect((session.options as any).stripeAccount).toBe(CONNECTED_ACCOUNT);
+  });
+
+  test("the idempotency key includes the amount, so a changed amount is not collapsed into the first session", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+
+    stripeStub.sessionIds.push("cs_nonce");
+    stripeStub.customerIds.push("cus_donor_1");
+    await t.action(
+      api.functions.finance.giving.createRecurringDonationCheckoutSession,
+      {
+        token: await tokenFor(s.donorUserId),
+        fundId: s.fundId,
+        amountCents: GIFT_CENTS,
+        coverFeesCents: FEE_CENTS,
+        idempotencyNonce: "nonce-1",
+      },
+    );
+
+    const key = (callsTo("checkout.sessions.create")[0].options as any)
+      .idempotencyKey as string;
+    expect(key).toContain("nonce-1");
+    expect(key).toContain(`:${GIFT_CENTS}:${FEE_CENTS}`);
+  });
+
+  test("refuses a second monthly gift to the same fund while one is live", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+
+    await createRecurring(t, s, { sessionId: "cs_1" });
+    await completeCheckout(t, "cs_1", "sub_1");
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "customer.subscription.updated",
+      account: CONNECTED_ACCOUNT,
+      data: { object: { id: "sub_1", status: "active" } },
+    });
+
+    await expect(
+      createRecurring(t, s, { sessionId: "cs_2", customerId: "cus_x" }),
+    ).rejects.toThrow(/already have a monthly gift/i);
+
+    expect(await rowsFor(t, s.donorUserId)).toHaveLength(1);
+  });
+
+  test("refuses a second attempt while the first Checkout is still in its grace window", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+
+    await createRecurring(t, s, { sessionId: "cs_1" });
+    await expect(
+      createRecurring(t, s, { sessionId: "cs_2" }),
+    ).rejects.toThrow(/just started setting up/i);
+  });
+
+  test("supersedes an abandoned Checkout — expires it at Stripe rather than locking the donor out", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+
+    await createRecurring(t, s, { sessionId: "cs_stale" });
+    const [stale] = await rowsFor(t, s.donorUserId);
+    // Age it past PENDING_CHECKOUT_GRACE_MS (30 minutes).
+    await t.run((ctx) =>
+      ctx.db.patch(stale._id, { createdAt: Date.now() - 60 * 60 * 1000 }),
+    );
+
+    await createRecurring(t, s, { sessionId: "cs_fresh" });
+
+    expect(callsTo("checkout.sessions.expire").map((c) => c.params)).toEqual([
+      "cs_stale",
+    ]);
+    const rows = await rowsFor(t, s.donorUserId);
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.checkoutSessionId === "cs_stale")?.status).toBe(
+      "canceled",
+    );
+    expect(rows.find((r) => r.checkoutSessionId === "cs_fresh")?.status).toBe(
+      "pending",
+    );
+  });
+
+  test("reuses one Stripe Customer per donor per connected account across funds", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+
+    await createRecurring(t, s, { sessionId: "cs_1", customerId: "cus_donor_1" });
+    // A DIFFERENT fund in the same community — same person, same card on file.
+    await createRecurring(t, s, {
+      fundId: s.otherFundId,
+      sessionId: "cs_2",
+      customerId: "cus_should_not_be_used",
+    });
+
+    expect(callsTo("customers.create")).toHaveLength(1);
+    const rows = await rowsFor(t, s.donorUserId);
+    expect(rows.map((r) => r.stripeCustomerId)).toEqual([
+      "cus_donor_1",
+      "cus_donor_1",
+    ]);
+
+    // The second create never consumed a Customer id — that IS the reuse.
+    expect(stripeStub.customerIds).toEqual(["cus_should_not_be_used"]);
+    stripeStub.customerIds.length = 0;
+
+    // A different donor gets their own Customer.
+    await createRecurring(t, s, {
+      donorUserId: s.otherDonorUserId,
+      sessionId: "cs_3",
+      customerId: "cus_donor_2",
+    });
+    expect(callsTo("customers.create")).toHaveLength(2);
+    expect((await rowsFor(t, s.otherDonorUserId))[0].stripeCustomerId).toBe(
+      "cus_donor_2",
+    );
+  });
+
+  test("a failed Stripe call leaves no phantom row blocking the retry", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+
+    stripeStub.sessionCreateError = new Error("Stripe is down");
+    await expect(createRecurring(t, s)).rejects.toThrow("Stripe is down");
+
+    const rows = await rowsFor(t, s.donorUserId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("canceled");
+
+    // ...and the donor can immediately try again.
+    stripeStub.sessionCreateError = null;
+    await createRecurring(t, s, { sessionId: "cs_retry" });
+    expect(
+      (await rowsFor(t, s.donorUserId)).filter((r) => r.status === "pending"),
+    ).toHaveLength(1);
+  });
+
+  test("still enforces the shared donation validation seam (amount bounds, fund live)", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+
+    await expect(
+      createRecurring(t, s, { amountCents: 50 }),
+    ).rejects.toThrow(/Donation amount must be between/);
+    await expect(
+      createRecurring(t, s, { coverFeesCents: -1 }),
+    ).rejects.toThrow(/Invalid fee-cover amount/);
+
+    await t.run((ctx) => ctx.db.patch(s.fundId, { status: "frozen" as const }));
+    await expect(createRecurring(t, s)).rejects.toThrow(
+      /isn't currently accepting gifts/,
+    );
+  });
+
+  test("inherits the ONE-SIDED fee bound: an over-quote fee is refused, an under-quote one is charged as sent", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+
+    // Above the server's own gross-up (plus tolerance) — refused, because on a
+    // MONTHLY gift an inflated fee field would slip past MAX_DONATION_CENTS
+    // every month, not once.
+    await expect(
+      createRecurring(t, s, { coverFeesCents: FEE_CENTS + 50 }),
+    ).rejects.toThrow(/couldn't confirm the processing fee/);
+    expect(await rowsFor(t, s.donorUserId)).toHaveLength(0);
+    expect(callsTo("checkout.sessions.create")).toHaveLength(0);
+
+    // Below it — allowed (a donor on a pre-gross-up client under-covers with
+    // their own money), and the subscription is priced at what they sent.
+    await createRecurring(t, s, { coverFeesCents: 1, sessionId: "cs_under" });
+    const [row] = await rowsFor(t, s.donorUserId);
+    expect(row.feeCoverCents).toBe(1);
+    expect(
+      (callsTo("checkout.sessions.create")[0].params as any).line_items[0]
+        .price_data.unit_amount,
+    ).toBe(GIFT_CENTS + 1);
+  });
+});
+
+// ============================================================================
+// checkout.session.completed
+// ============================================================================
+
+describe("checkout.session.completed (Connect, subscription mode)", () => {
+  test("binds the subscription and customer onto the pending row, leaving it pending", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_bind" });
+
+    await completeCheckout(t, "cs_bind", "sub_bound", "cus_bound");
+
+    const [row] = await rowsFor(t, s.donorUserId);
+    expect(row.stripeSubscriptionId).toBe("sub_bound");
+    expect(row.stripeCustomerId).toBe("cus_bound");
+    // Money hasn't moved yet — invoice.paid is what activates it.
+    expect(row.status).toBe("pending");
+  });
+
+  test("ignores a payment-mode session (the one-off gift path owns those)", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_oneoff" });
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "checkout.session.completed",
+      account: CONNECTED_ACCOUNT,
+      data: {
+        object: { id: "cs_oneoff", mode: "payment", payment_intent: "pi_1" },
+      },
+    });
+
+    expect((await rowsFor(t, s.donorUserId))[0].stripeSubscriptionId).toBeUndefined();
+  });
+
+  test("rejects an event from a different connected account and audits it", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_spoof" });
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "checkout.session.completed",
+      account: "acct_attacker",
+      data: {
+        object: { id: "cs_spoof", mode: "subscription", subscription: "sub_x" },
+      },
+    });
+
+    expect((await rowsFor(t, s.donorUserId))[0].stripeSubscriptionId).toBeUndefined();
+    const audits = await t.run((ctx) =>
+      ctx.db
+        .query("financeAuditEvents")
+        .withIndex("by_fund", (q) => q.eq("fundId", s.fundId))
+        .collect(),
+    );
+    expect(
+      audits.filter((e) => e.action === "webhook.rejected_account_mismatch"),
+    ).toHaveLength(1);
+  });
+});
+
+// ============================================================================
+// invoice.paid — the money event
+// ============================================================================
+
+describe("invoice.paid", () => {
+  test("records the donation + ledger credit exactly once, and activates the row", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_pay" });
+    await completeCheckout(t, "cs_pay", "sub_pay");
+
+    const invoice = paidInvoice({
+      invoiceId: "in_1",
+      subscriptionId: "sub_pay",
+      paymentIntentId: "pi_recurring_1",
+      amountPaid: TOTAL_CENTS,
+      periodEndSeconds: 1_800_000,
+    });
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.paid",
+      account: CONNECTED_ACCOUNT,
+      data: { object: invoice },
+    });
+
+    const donations = await donationsFor(t, s.fundId);
+    expect(donations).toHaveLength(1);
+    expect(donations[0]).toMatchObject({
+      amountCents: GIFT_CENTS,
+      feeCoverCents: FEE_CENTS,
+      stripePaymentIntentId: "pi_recurring_1",
+      allocationStatus: "pending",
+    });
+    // Stamped with the recurring row it was billed under.
+    const [row] = await rowsFor(t, s.donorUserId);
+    expect(donations[0].recurringId).toBe(row._id);
+
+    const ledger = await t.run((ctx) =>
+      ctx.db
+        .query("ledgerEntries")
+        .withIndex("by_fund", (q) => q.eq("fundId", s.fundId))
+        .collect(),
+    );
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0].amountCents).toBe(TOTAL_CENTS);
+    expect(ledger[0].kind).toBe("donation");
+    expect((await t.run((ctx) => ctx.db.get(s.fundId)))?.balanceCents).toBe(
+      10_000 + TOTAL_CENTS,
+    );
+
+    expect(row.status).toBe("active");
+    expect(row.currentPeriodEnd).toBe(1_800_000_000);
+
+    // A redelivered invoice must not credit a second time.
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.paid",
+      account: CONNECTED_ACCOUNT,
+      data: { object: invoice },
+    });
+    expect(await donationsFor(t, s.fundId)).toHaveLength(1);
+    expect((await t.run((ctx) => ctx.db.get(s.fundId)))?.balanceCents).toBe(
+      10_000 + TOTAL_CENTS,
+    );
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("reads the LEGACY invoice shape too (subscription + payment_intent at the top level)", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_legacy" });
+    await completeCheckout(t, "cs_legacy", "sub_legacy");
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.paid",
+      account: CONNECTED_ACCOUNT,
+      data: {
+        object: {
+          id: "in_legacy",
+          amount_paid: TOTAL_CENTS,
+          subscription: "sub_legacy",
+          payment_intent: "pi_legacy",
+        },
+      },
+    });
+
+    expect(await donationsFor(t, s.fundId)).toHaveLength(1);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("credits what Stripe actually collected when it disagrees with the row", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_drift" });
+    await completeCheckout(t, "cs_drift", "sub_drift");
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.paid",
+      account: CONNECTED_ACCOUNT,
+      data: {
+        object: paidInvoice({
+          invoiceId: "in_drift",
+          subscriptionId: "sub_drift",
+          paymentIntentId: "pi_drift",
+          amountPaid: 5103, // donor is actually billed more than the row says
+        }),
+      },
+    });
+
+    const [donation] = await donationsFor(t, s.fundId);
+    expect(donation.amountCents + donation.feeCoverCents).toBe(5103);
+    expect(donation.feeCoverCents).toBe(FEE_CENTS);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("ignores an invoice with no subscription, and an unknown subscription", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.paid",
+      account: CONNECTED_ACCOUNT,
+      data: { object: { id: "in_x", amount_paid: 500 } },
+    });
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.paid",
+      account: CONNECTED_ACCOUNT,
+      data: {
+        object: paidInvoice({
+          invoiceId: "in_y",
+          subscriptionId: "sub_unknown",
+          paymentIntentId: "pi_y",
+          amountPaid: 500,
+        }),
+      },
+    });
+
+    expect(await donationsFor(t, s.fundId)).toHaveLength(0);
+  });
+
+  test("rejects an invoice delivered for a different connected account", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_mm" });
+    await completeCheckout(t, "cs_mm", "sub_mm");
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.paid",
+      account: "acct_attacker",
+      data: {
+        object: paidInvoice({
+          invoiceId: "in_mm",
+          subscriptionId: "sub_mm",
+          paymentIntentId: "pi_mm",
+          amountPaid: TOTAL_CENTS,
+        }),
+      },
+    });
+
+    expect(await donationsFor(t, s.fundId)).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// Non-interference with the one-off path
+// ============================================================================
+
+describe("payment_intent.succeeded non-interference", () => {
+  test("a subscription's PaymentIntent (no fundId metadata) records nothing", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_ni" });
+    await completeCheckout(t, "cs_ni", "sub_ni");
+
+    // This is exactly what Stripe sends for a subscription invoice's payment:
+    // subscription mode forbids `payment_intent_data`, so there is no metadata
+    // of ours on the intent at all. The one-off handler must ignore it —
+    // `invoice.paid` is the only thing that may record a monthly gift.
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "payment_intent.succeeded",
+      account: CONNECTED_ACCOUNT,
+      data: {
+        object: {
+          id: "pi_recurring_no_metadata",
+          amount: TOTAL_CENTS,
+          invoice: "in_ni",
+          metadata: {},
+        },
+      },
+    });
+
+    expect(await donationsFor(t, s.fundId)).toHaveLength(0);
+    expect((await t.run((ctx) => ctx.db.get(s.fundId)))?.balanceCents).toBe(10_000);
+    expect((await rowsFor(t, s.donorUserId))[0].status).toBe("pending");
+  });
+});
+
+// ============================================================================
+// Subscription lifecycle
+// ============================================================================
+
+describe("subscription lifecycle", () => {
+  test("updated syncs status, period end, and an amount change from subscription metadata", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_life" });
+    await completeCheckout(t, "cs_life", "sub_life");
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "customer.subscription.updated",
+      account: CONNECTED_ACCOUNT,
+      data: {
+        object: {
+          id: "sub_life",
+          status: "active",
+          metadata: { amountCents: "5000", feeCoverCents: "175" },
+          items: {
+            data: [
+              { current_period_end: 1_900_000, price: { unit_amount: 5175 } },
+            ],
+          },
+        },
+      },
+    });
+
+    let [row] = await rowsFor(t, s.donorUserId);
+    expect(row).toMatchObject({
+      status: "active",
+      amountCents: 5000,
+      feeCoverCents: 175,
+      currentPeriodEnd: 1_900_000_000,
+    });
+
+    // A failed payment moves it to past_due...
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "customer.subscription.updated",
+      account: CONNECTED_ACCOUNT,
+      data: { object: { id: "sub_life", status: "past_due" } },
+    });
+    [row] = await rowsFor(t, s.donorUserId);
+    expect(row.status).toBe("past_due");
+
+    // ...and recovery brings it back.
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "customer.subscription.updated",
+      account: CONNECTED_ACCOUNT,
+      data: { object: { id: "sub_life", status: "active" } },
+    });
+    [row] = await rowsFor(t, s.donorUserId);
+    expect(row.status).toBe("active");
+    // The amount survived a status-only event.
+    expect(row.amountCents).toBe(5000);
+  });
+
+  test("invoice.payment_failed marks the gift past_due", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_fail" });
+    await completeCheckout(t, "cs_fail", "sub_fail");
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "invoice.payment_failed",
+      account: CONNECTED_ACCOUNT,
+      data: { object: { id: "in_fail", subscription: "sub_fail" } },
+    });
+
+    expect((await rowsFor(t, s.donorUserId))[0].status).toBe("past_due");
+  });
+
+  test("deleted is terminal — a late 'active' update cannot resurrect it", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_del" });
+    await completeCheckout(t, "cs_del", "sub_del");
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "customer.subscription.deleted",
+      account: CONNECTED_ACCOUNT,
+      data: { object: { id: "sub_del", status: "canceled" } },
+    });
+
+    let [row] = await rowsFor(t, s.donorUserId);
+    expect(row.status).toBe("canceled");
+    expect(row.canceledAt).toEqual(expect.any(Number));
+
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "customer.subscription.updated",
+      account: CONNECTED_ACCOUNT,
+      data: { object: { id: "sub_del", status: "active" } },
+    });
+    [row] = await rowsFor(t, s.donorUserId);
+    expect(row.status).toBe("canceled");
+  });
+});
+
+// ============================================================================
+// Donor management
+// ============================================================================
+
+describe("updateRecurringAmount", () => {
+  test("updates the Stripe item with a new inline price and no proration, then the row", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_upd" });
+    await completeCheckout(t, "cs_upd", "sub_upd");
+    stripeStub.subscription = {
+      id: "sub_upd",
+      items: {
+        data: [{ id: "si_upd", price: { id: "price_1", product: "prod_upd" } }],
+      },
+    };
+
+    const [before] = await rowsFor(t, s.donorUserId);
+    const result = await t.action(
+      api.functions.finance.giving.updateRecurringAmount,
+      {
+        token: await tokenFor(s.donorUserId),
+        recurringDonationId: before._id,
+        amountCents: 5000,
+        coverFeesCents: computeCoverFeesCents(5000),
+      },
+    );
+    expect(result).toEqual({
+      amountCents: 5000,
+      feeCoverCents: computeCoverFeesCents(5000),
+    });
+
+    const [update] = callsTo("subscriptions.update");
+    const params = (update.params as any).params;
+    expect(params.proration_behavior).toBe("none");
+    expect(params.items[0]).toMatchObject({
+      id: "si_upd",
+      price_data: {
+        currency: "usd",
+        product: "prod_upd", // reuses the product Checkout created
+        unit_amount: 5000 + computeCoverFeesCents(5000),
+        recurring: { interval: "month" },
+      },
+    });
+    expect(params.metadata).toMatchObject({
+      amountCents: "5000",
+      feeCoverCents: String(computeCoverFeesCents(5000)),
+    });
+    expect((update.options as any).stripeAccount).toBe(CONNECTED_ACCOUNT);
+
+    const [after] = await rowsFor(t, s.donorUserId);
+    expect(after).toMatchObject({
+      amountCents: 5000,
+      feeCoverCents: computeCoverFeesCents(5000),
+    });
+
+    const audits = await t.run((ctx) =>
+      ctx.db
+        .query("financeAuditEvents")
+        .withIndex("by_fund", (q) => q.eq("fundId", s.fundId))
+        .collect(),
+    );
+    expect(
+      audits.filter((e) => e.action === "recurring.amount_updated"),
+    ).toHaveLength(1);
+  });
+
+  test("applies the same amount/fee validation as creating a gift, and never calls Stripe on a bad one", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_val" });
+    await completeCheckout(t, "cs_val", "sub_val");
+    const [row] = await rowsFor(t, s.donorUserId);
+    const token = await tokenFor(s.donorUserId);
+
+    await expect(
+      t.action(api.functions.finance.giving.updateRecurringAmount, {
+        token,
+        recurringDonationId: row._id,
+        amountCents: 50,
+      }),
+    ).rejects.toThrow(/Donation amount must be between/);
+    await expect(
+      t.action(api.functions.finance.giving.updateRecurringAmount, {
+        token,
+        recurringDonationId: row._id,
+        amountCents: GIFT_CENTS,
+        coverFeesCents: -1,
+      }),
+    ).rejects.toThrow(/Invalid fee-cover amount/);
+    // The one-sided ceiling applies to a CHANGE too — otherwise the create
+    // path's cap could be walked past afterwards, one edit at a time.
+    await expect(
+      t.action(api.functions.finance.giving.updateRecurringAmount, {
+        token,
+        recurringDonationId: row._id,
+        amountCents: GIFT_CENTS,
+        coverFeesCents: FEE_CENTS + 50,
+      }),
+    ).rejects.toThrow(/couldn't confirm the processing fee/);
+
+    expect(callsTo("subscriptions.update")).toHaveLength(0);
+    expect((await rowsFor(t, s.donorUserId))[0].amountCents).toBe(GIFT_CENTS);
+  });
+
+  test("refuses another donor's monthly gift", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_other" });
+    const [row] = await rowsFor(t, s.donorUserId);
+
+    await expect(
+      t.action(api.functions.finance.giving.updateRecurringAmount, {
+        token: await tokenFor(s.otherDonorUserId),
+        recurringDonationId: row._id,
+        amountCents: 100,
+      }),
+    ).rejects.toThrow(/Monthly gift not found/);
+  });
+});
+
+describe("cancelRecurringDonation", () => {
+  test("cancels at Stripe immediately and marks the row canceled", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_cancel" });
+    await completeCheckout(t, "cs_cancel", "sub_cancel");
+    const [row] = await rowsFor(t, s.donorUserId);
+
+    expect(
+      await t.action(api.functions.finance.giving.cancelRecurringDonation, {
+        token: await tokenFor(s.donorUserId),
+        recurringDonationId: row._id,
+      }),
+    ).toEqual({ canceled: true });
+
+    const [cancelCall] = callsTo("subscriptions.cancel");
+    expect((cancelCall.params as any).id).toBe("sub_cancel");
+    // Plain cancel — NOT cancel_at_period_end. The donor already paid for
+    // this period at its start, so there is nothing to run out.
+    expect((cancelCall.params as any).params).toBeUndefined();
+
+    const [after] = await rowsFor(t, s.donorUserId);
+    expect(after.status).toBe("canceled");
+    expect(after.canceledAt).toEqual(expect.any(Number));
+  });
+
+  test("is idempotent, and still marks the row when Stripe says it is already gone", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_c2" });
+    await completeCheckout(t, "cs_c2", "sub_c2");
+    const [row] = await rowsFor(t, s.donorUserId);
+    stripeStub.subscriptionCancelError = new Error("No such subscription");
+
+    await t.action(api.functions.finance.giving.cancelRecurringDonation, {
+      token: await tokenFor(s.donorUserId),
+      recurringDonationId: row._id,
+    });
+    expect((await rowsFor(t, s.donorUserId))[0].status).toBe("canceled");
+
+    // Second call short-circuits without touching Stripe again.
+    await t.action(api.functions.finance.giving.cancelRecurringDonation, {
+      token: await tokenFor(s.donorUserId),
+      recurringDonationId: row._id,
+    });
+    expect(callsTo("subscriptions.cancel")).toHaveLength(1);
+  });
+
+  test("expires the Checkout Session when the donor backs out before a subscription exists", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_pending_cancel" });
+    const [row] = await rowsFor(t, s.donorUserId);
+
+    await t.action(api.functions.finance.giving.cancelRecurringDonation, {
+      token: await tokenFor(s.donorUserId),
+      recurringDonationId: row._id,
+    });
+
+    expect(callsTo("checkout.sessions.expire").map((c) => c.params)).toEqual([
+      "cs_pending_cancel",
+    ]);
+    expect(callsTo("subscriptions.cancel")).toHaveLength(0);
+    expect((await rowsFor(t, s.donorUserId))[0].status).toBe("canceled");
+  });
+});
+
+describe("createCardUpdateSession", () => {
+  test("creates a portal configuration on first use and returns a portal session for this donor's Customer", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_card" });
+    await completeCheckout(t, "cs_card", "sub_card");
+    const [row] = await rowsFor(t, s.donorUserId);
+
+    const result = await t.action(
+      api.functions.finance.giving.createCardUpdateSession,
+      { token: await tokenFor(s.donorUserId), recurringDonationId: row._id },
+    );
+    expect(result.url).toBe("https://billing.stripe.test/session");
+
+    const [created] = callsTo("billingPortal.configurations.create");
+    const features = (created.params as any).features;
+    expect(features.payment_method_update.enabled).toBe(true);
+    // Cancels/amount changes go through OUR actions so the row stays truth.
+    expect(features.subscription_cancel).toBeUndefined();
+    expect(features.subscription_update).toBeUndefined();
+
+    const [portal] = callsTo("billingPortal.sessions.create");
+    expect(portal.params).toMatchObject({
+      customer: "cus_donor_1",
+      configuration: "bpc_created",
+    });
+    expect((portal.options as any).stripeAccount).toBe(CONNECTED_ACCOUNT);
+    // The group id is percent-encoded into the path, as it is for the
+    // Checkout return URLs — a Convex id contains a ";".
+    expect((portal.params as any).return_url).toContain(
+      `/groups/${encodeURIComponent(s.groupId)}/give`,
+    );
+  });
+
+  test("reuses an existing portal configuration", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_card2" });
+    const [row] = await rowsFor(t, s.donorUserId);
+    stripeStub.portalConfigs.push({ id: "bpc_existing" });
+
+    await t.action(api.functions.finance.giving.createCardUpdateSession, {
+      token: await tokenFor(s.donorUserId),
+      recurringDonationId: row._id,
+    });
+
+    expect(callsTo("billingPortal.configurations.create")).toHaveLength(0);
+    expect(
+      (callsTo("billingPortal.sessions.create")[0].params as any).configuration,
+    ).toBe("bpc_existing");
+  });
+});
+
+// ============================================================================
+// Donor-facing reads
+// ============================================================================
+
+describe("listMyRecurringDonations / getRecurringForFund", () => {
+  test("returns only the caller's own gifts, with fund names, excluding canceled ones", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_l1" });
+    await createRecurring(t, s, { fundId: s.otherFundId, sessionId: "cs_l2" });
+    await createRecurring(t, s, {
+      donorUserId: s.otherDonorUserId,
+      sessionId: "cs_l3",
+      customerId: "cus_other",
+    });
+
+    const mine = await t.query(
+      api.functions.finance.giving.listMyRecurringDonations,
+      { token: await tokenFor(s.donorUserId) },
+    );
+    expect(mine).toHaveLength(2);
+    expect(mine.map((r) => r.fundName).sort()).toEqual([
+      "Young Adults Fund",
+      "Youth Fund",
+    ]);
+    expect(mine.every((r) => r.fundId !== undefined)).toBe(true);
+
+    const theirs = await t.query(
+      api.functions.finance.giving.listMyRecurringDonations,
+      { token: await tokenFor(s.otherDonorUserId) },
+    );
+    expect(theirs).toHaveLength(1);
+
+    // Cancel one — it drops out of the manage list.
+    await t.action(api.functions.finance.giving.cancelRecurringDonation, {
+      token: await tokenFor(s.donorUserId),
+      recurringDonationId: mine[0].id,
+    });
+    expect(
+      await t.query(api.functions.finance.giving.listMyRecurringDonations, {
+        token: await tokenFor(s.donorUserId),
+      }),
+    ).toHaveLength(1);
+  });
+
+  test("getRecurringForFund returns only a LIVE gift, and only the caller's", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_g1" });
+
+    const token = await tokenFor(s.donorUserId);
+    // Still pending (donor in Checkout) — not a monthly gift yet.
+    expect(
+      await t.query(api.functions.finance.giving.getRecurringForFund, {
+        token,
+        fundId: s.fundId,
+      }),
+    ).toBeNull();
+
+    await completeCheckout(t, "cs_g1", "sub_g1");
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "customer.subscription.updated",
+      account: CONNECTED_ACCOUNT,
+      data: { object: { id: "sub_g1", status: "active" } },
+    });
+
+    expect(
+      await t.query(api.functions.finance.giving.getRecurringForFund, {
+        token,
+        fundId: s.fundId,
+      }),
+    ).toMatchObject({
+      fundId: s.fundId,
+      fundName: "Young Adults Fund",
+      amountCents: GIFT_CENTS,
+      feeCoverCents: FEE_CENTS,
+      status: "active",
+    });
+
+    // Another donor sees nothing of theirs on the same fund.
+    expect(
+      await t.query(api.functions.finance.giving.getRecurringForFund, {
+        token: await tokenFor(s.otherDonorUserId),
+        fundId: s.fundId,
+      }),
+    ).toBeNull();
+  });
+
+  test("both reads go dark when the group-giving flag is off", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    await createRecurring(t, s, { sessionId: "cs_flag" });
+    await completeCheckout(t, "cs_flag", "sub_flag");
+    await t.run(async (ctx) => {
+      const flag = await ctx.db
+        .query("featureFlags")
+        .withIndex("by_key", (q) => q.eq("key", "group-giving"))
+        .first();
+      await ctx.db.patch(flag!._id, { enabled: false });
+    });
+
+    const token = await tokenFor(s.donorUserId);
+    expect(
+      await t.query(api.functions.finance.giving.listMyRecurringDonations, {
+        token,
+      }),
+    ).toEqual([]);
+    expect(
+      await t.query(api.functions.finance.giving.getRecurringForFund, {
+        token,
+        fundId: s.fundId,
+      }),
+    ).toBeNull();
+  });
+});
+
+// ============================================================================
+// getGivingContext
+// ============================================================================
+
+describe("getGivingContext.existingRecurring", () => {
+  test("is null until a monthly gift is actually collecting, then reports its amounts", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seedRecurringFixture(t);
+    const token = await tokenFor(s.donorUserId);
+
+    expect(
+      (
+        await t.query(api.functions.finance.giving.getGivingContext, {
+          token,
+          groupId: s.groupId,
+        })
+      )?.existingRecurring,
+    ).toBeNull();
+
+    await createRecurring(t, s, { sessionId: "cs_ctx" });
+    await completeCheckout(t, "cs_ctx", "sub_ctx");
+    await handleFinanceStripeEvent(webhookCtx(t), {
+      type: "customer.subscription.updated",
+      account: CONNECTED_ACCOUNT,
+      data: { object: { id: "sub_ctx", status: "active" } },
+    });
+
+    expect(
+      (
+        await t.query(api.functions.finance.giving.getGivingContext, {
+          token,
+          groupId: s.groupId,
+        })
+      )?.existingRecurring,
+    ).toEqual({ amountCents: GIFT_CENTS, feeCoverCents: FEE_CENTS });
+  });
+});

--- a/apps/convex/__tests__/finance-webhook-routing.test.ts
+++ b/apps/convex/__tests__/finance-webhook-routing.test.ts
@@ -1,14 +1,15 @@
 /**
  * /stripe-webhook routing between SaaS billing and group giving.
  *
- * Three Stripe event types are ambiguous between the two systems, because a
+ * Four Stripe event types are ambiguous between the two systems, because a
  * recurring donation is a Stripe Subscription just like a community's
- * Togather subscription: `customer.subscription.updated`,
- * `customer.subscription.deleted`, `invoice.payment_failed`. A recurring
- * donation lives on the community's CONNECTED account, so its events arrive
- * with `event.account` set — those must NOT reach the billing handlers,
- * which would otherwise match a donor's subscription id against a
- * community's own row.
+ * Togather subscription — set up through a Checkout Session and then living
+ * the same lifecycle: `checkout.session.completed`,
+ * `customer.subscription.updated`, `customer.subscription.deleted`,
+ * `invoice.payment_failed`. A recurring donation lives on the community's
+ * CONNECTED account, so its events arrive with `event.account` set — those
+ * must NOT reach the billing handlers, which would otherwise match a donor's
+ * subscription id against a community's own row.
  *
  * These tests drive the real HTTP route (signature and all) and assert the
  * only externally-observable thing billing does: patching
@@ -238,21 +239,16 @@ describe("/stripe-webhook routes shared event types by event.account", () => {
     expect(await subscriptionStatusOf(t, communityId)).toBe("past_due");
   });
 
-  test("checkout.session.completed is untouched by the routing change", async () => {
-    // Guard against over-broad routing: only the three ambiguous cases check
-    // event.account. A Connect-flagged checkout.session.completed must still
-    // reach billing exactly as before.
-    //
-    // This asserts TODAY's behavior, and today it is safe: nothing creates a
-    // Checkout Session on a connected account (one-off giving uses
-    // PaymentIntents), and the Connect event destination does not subscribe
-    // to checkout.session.completed at all. It stops being safe the moment
-    // recurring giving opens Checkout on the connected account — that session
-    // completes with `event.account` set and donor metadata, and billing's
-    // handleCheckoutCompleted requires `communityId: v.string()`, so it would
-    // throw -> 500 -> Stripe retries forever. The PR that adds the
-    // subscription Checkout action MUST gate this case on isConnectEvent too
-    // and flip this assertion.
+  test("checkout.session.completed WITH event.account never activates a community subscription", async () => {
+    // This assertion is the FLIP that PR #736's version of this test told the
+    // recurring-giving PR to make. Its reasoning was exactly right: a monthly
+    // donation opens a subscription-mode Checkout Session on the CONNECTED
+    // account, so this type became ambiguous the moment that action shipped.
+    // Left unrouted, the completed session arrives with `event.account` set
+    // and donor metadata, and billing's handleCheckoutCompleted requires
+    // `communityId: v.string()` — it would either mark the wrong community
+    // paid or throw, 500, and have Stripe retry forever.
+
     const t = convexTest(schema, modules);
     const communityId = await seedSubscribedCommunity(t);
     await t.run(async (ctx) => {
@@ -265,6 +261,33 @@ describe("/stripe-webhook routes shared event types by event.account", () => {
     const response = await postEvent(t, {
       type: "checkout.session.completed",
       account: "acct_connected_123",
+      data: {
+        object: {
+          id: "cs_donor_monthly",
+          mode: "subscription",
+          customer: "cus_donor_123",
+          subscription: "sub_donor_123",
+          metadata: { communityId },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await subscriptionStatusOf(t, communityId)).toBeNull();
+  });
+
+  test("checkout.session.completed WITHOUT event.account still activates the community subscription (unchanged)", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await seedSubscribedCommunity(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(communityId, {
+        subscriptionStatus: undefined,
+        stripeSubscriptionId: undefined,
+      });
+    });
+
+    const response = await postEvent(t, {
+      type: "checkout.session.completed",
       data: {
         object: {
           customer: "cus_platform_123",

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -228,6 +228,37 @@ async function findLiveRecurring(
   );
 }
 
+/**
+ * Does this row stop the donor starting ANOTHER monthly gift to the same fund?
+ *
+ * Deliberately wider than `findLiveRecurring`: that one answers "is a gift
+ * collecting?" (what the give screen renders), this one answers "would a
+ * second Checkout risk double-charging them?" (what the create path must
+ * refuse). A `pending` row blocks when either
+ *
+ *  - it already has a subscription — Checkout completed and `invoice.paid`
+ *    simply hasn't landed yet, so the donor IS being billed however the row
+ *    reads; or
+ *  - it is younger than `PENDING_CHECKOUT_GRACE_MS` — a Checkout page that may
+ *    still be open in another tab.
+ *
+ * Anything older with no subscription is an abandoned Checkout, which the
+ * create path supersedes rather than letting it lock the donor out forever.
+ */
+function blocksNewRecurring(
+  row: Doc<"recurringDonations">,
+  nowMs: number,
+): boolean {
+  if ((LIVE_RECURRING_STATUSES as readonly string[]).includes(row.status)) {
+    return true;
+  }
+  return (
+    row.status === "pending" &&
+    (!!row.stripeSubscriptionId ||
+      nowMs - row.createdAt < PENDING_CHECKOUT_GRACE_MS)
+  );
+}
+
 /** "Friend of the ministry" covers anonymous/guest gifts (no donorUserId) — getDisplayName's own "Anonymous" fallback is for a real user with no name set, a different case. */
 function donorDisplayName(donor: Doc<"users"> | null): string {
   if (!donor) return "Friend of the ministry";
@@ -1559,17 +1590,16 @@ export const prepareRecurringDonation = internalQuery({
       .collect();
 
     const nowMs = now();
-    const blocking = rowsForFund.find(
-      (r) =>
-        (LIVE_RECURRING_STATUSES as readonly string[]).includes(r.status) ||
-        (r.status === "pending" &&
-          nowMs - r.createdAt < PENDING_CHECKOUT_GRACE_MS),
-    );
-    // Older `pending` rows are abandoned Checkouts — see
+    const blockingRows = rowsForFund.filter((r) => blocksNewRecurring(r, nowMs));
+    const blocking = blockingRows[0];
+    // Every OTHER `pending` row is an abandoned Checkout — see
     // PENDING_CHECKOUT_GRACE_MS. They're superseded (session expired at
     // Stripe, row canceled) rather than left to lock the donor out forever.
+    // Filtered against the whole blocking SET, not just the first one: with
+    // two blocking rows, `r !== blocking` would have handed the second to the
+    // supersede loop and canceled a row that is actively billing.
     const stalePending = rowsForFund.filter(
-      (r) => r.status === "pending" && r !== blocking,
+      (r) => r.status === "pending" && !blockingRows.includes(r),
     );
 
     // CUSTOMER REUSE RULE: one Stripe Customer per (donor, connected
@@ -1667,12 +1697,29 @@ export const beginRecurringDonation = internalMutation({
       throw new Error("Fund not found");
     }
 
-    const existing = await findLiveRecurring(ctx, args.fundId, userId);
-    if (existing) {
-      throw new ConvexError(ALREADY_RECURRING_MESSAGE);
+    // `blocksNewRecurring`, NOT `findLiveRecurring`: this check has to include
+    // non-stale `pending` rows or it doesn't serialize anything. Two taps from
+    // two tabs both pass the read-only check in `prepareRecurringDonation`,
+    // and a live-only check here lets BOTH inserts land — two Checkouts, two
+    // subscriptions, a donor billed twice a month for one gift. Reading the
+    // same `by_donor_fund` range the insert writes to is what makes Convex's
+    // OCC retry the loser, so the invariant actually holds under a race.
+    const timestamp = now();
+    const rowsForFund = await ctx.db
+      .query("recurringDonations")
+      .withIndex("by_donor_fund", (q) =>
+        q.eq("donorUserId", userId).eq("fundId", args.fundId),
+      )
+      .collect();
+    const blocking = rowsForFund.find((r) => blocksNewRecurring(r, timestamp));
+    if (blocking) {
+      throw new ConvexError(
+        blocking.status === "pending"
+          ? RECURRING_CHECKOUT_IN_PROGRESS_MESSAGE
+          : ALREADY_RECURRING_MESSAGE,
+      );
     }
 
-    const timestamp = now();
     const recurringDonationId = await ctx.db.insert("recurringDonations", {
       fundId: args.fundId,
       communityId: fund.communityId,
@@ -1806,11 +1853,51 @@ export const createRecurringDonationCheckoutSession = action({
     // Expire abandoned Checkout Sessions BEFORE starting a new one. Without
     // this, a donor who left one open in another tab could complete it after
     // the new one and end up with two subscriptions to the same fund — the
-    // exact thing the one-per-fund rule exists to prevent. Best-effort:
-    // Stripe errors on a session that already completed or expired, which is
-    // the outcome we wanted anyway.
+    // exact thing the one-per-fund rule exists to prevent.
+    //
+    // A row is only superseded once Stripe has CONFIRMED its session can never
+    // complete. Superseding on an unverified guess is worse than refusing the
+    // new attempt: a session that already completed has a live subscription
+    // behind it, and canceling the row orphans that subscription — it goes on
+    // billing the donor every month with no row for `invoice.paid` to find and
+    // nothing in the app to stop it. So "expire failed" is never treated as
+    // "expired".
     for (const stale of recurring.stalePending) {
-      if (stale.checkoutSessionId) {
+      if (!stale.checkoutSessionId) {
+        // Never reached Stripe at all — nothing to expire, safe to supersede.
+        await ctx.runMutation(
+          internal.functions.finance.giving.supersedePendingRecurringDonation,
+          { recurringDonationId: stale.id },
+        );
+        continue;
+      }
+
+      let sessionStatus: string | null = null;
+      try {
+        const staleSession = await stripe.checkout.sessions.retrieve(
+          stale.checkoutSessionId,
+          { stripeAccount: recurring.stripeConnectedAccountId },
+        );
+        sessionStatus = staleSession.status ?? null;
+      } catch (error) {
+        console.warn(
+          `[finance] createRecurringDonationCheckoutSession: could not read stale session ${stale.checkoutSessionId}`,
+          error,
+        );
+      }
+
+      if (sessionStatus === "complete") {
+        // The donor DID finish this Checkout; the subscription exists at
+        // Stripe even though `checkout.session.completed` hasn't bound it to
+        // the row yet. They already give monthly to this fund.
+        throw new ConvexError(ALREADY_RECURRING_MESSAGE);
+      }
+      if (sessionStatus === null) {
+        // Stripe wouldn't tell us. Ask the donor to retry rather than gamble a
+        // supersede that might orphan a live subscription.
+        throw new ConvexError(RECURRING_CHECKOUT_IN_PROGRESS_MESSAGE);
+      }
+      if (sessionStatus === "open") {
         try {
           await stripe.checkout.sessions.expire(stale.checkoutSessionId, {
             stripeAccount: recurring.stripeConnectedAccountId,
@@ -1820,8 +1907,11 @@ export const createRecurringDonationCheckoutSession = action({
             `[finance] createRecurringDonationCheckoutSession: could not expire stale session ${stale.checkoutSessionId}`,
             error,
           );
+          // Still open and we failed to close it — it can still complete.
+          throw new ConvexError(RECURRING_CHECKOUT_IN_PROGRESS_MESSAGE);
         }
       }
+      // Confirmed expired (or just expired by us): it can never complete.
       await ctx.runMutation(
         internal.functions.finance.giving.supersedePendingRecurringDonation,
         { recurringDonationId: stale.id },
@@ -2045,14 +2135,40 @@ export const recordRecurringDonationPaid = internalMutation({
     amountPaidCents: v.optional(v.number()),
     currentPeriodEnd: v.optional(v.number()),
     eventAccount: v.optional(v.string()),
+    /**
+     * The row id the subscription's metadata claims, used ONLY when the
+     * subscription id isn't bound to a row yet — see
+     * `resolveInvoiceRecurringDonationId` in webhooks.ts.
+     */
+    recurringDonationIdHint: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const row = await ctx.db
+    let row = await ctx.db
       .query("recurringDonations")
       .withIndex("by_stripeSubscriptionId", (q) =>
         q.eq("stripeSubscriptionId", args.stripeSubscriptionId),
       )
       .first();
+
+    // Webhook order is not guaranteed: the first month's `invoice.paid` can
+    // beat `checkout.session.completed`, so the subscription id may not be on
+    // any row yet. Falling back to the id we put in the subscription metadata
+    // is what stops that race silently swallowing a real payment. The row is
+    // only adopted when it is genuinely unbound — a row already pointing at a
+    // DIFFERENT subscription is never re-pointed by an invoice.
+    let boundHere = false;
+    if (!row && args.recurringDonationIdHint) {
+      const hintedId = ctx.db.normalizeId(
+        "recurringDonations",
+        args.recurringDonationIdHint,
+      );
+      const hinted = hintedId ? await ctx.db.get(hintedId) : null;
+      if (hinted && !hinted.stripeSubscriptionId) {
+        row = hinted;
+        boundHere = true;
+      }
+    }
+
     if (!row) {
       return; // Not a Togather monthly gift.
     }
@@ -2075,6 +2191,16 @@ export const recordRecurringDonationPaid = internalMutation({
 
     const rowTotalCents = row.amountCents + row.feeCoverCents;
     const totalCents = args.amountPaidCents ?? rowTotalCents;
+    if (totalCents <= 0) {
+      // A $0 invoice (a full discount, or a $0 proration) collected nothing,
+      // so there is nothing to credit. Returning beats falling through:
+      // `recordDonationCore` THROWS on a non-positive amount, which would fail
+      // the webhook and put Stripe into a permanent redelivery loop.
+      console.warn(
+        `[finance] invoice.paid: subscription ${args.stripeSubscriptionId} collected ${totalCents} — nothing to record`,
+      );
+      return;
+    }
     if (totalCents !== rowTotalCents) {
       console.warn(
         `[finance] invoice.paid: subscription ${args.stripeSubscriptionId} collected ${totalCents} but recurring donation ${row._id} expects ${rowTotalCents} — crediting what Stripe collected`,
@@ -2101,6 +2227,7 @@ export const recordRecurringDonationPaid = internalMutation({
     const patch: {
       status?: "active";
       currentPeriodEnd?: number;
+      stripeSubscriptionId?: string;
       updatedAt: number;
     } = { updatedAt: now() };
     if (row.status !== "canceled") {
@@ -2108,6 +2235,12 @@ export const recordRecurringDonationPaid = internalMutation({
     }
     if (args.currentPeriodEnd !== undefined) {
       patch.currentPeriodEnd = args.currentPeriodEnd;
+    }
+    if (boundHere) {
+      // We got here before `checkout.session.completed` did. Stamping the
+      // subscription now means every LATER event for it resolves by the
+      // ordinary index, and the metadata fallback is only ever used once.
+      patch.stripeSubscriptionId = args.stripeSubscriptionId;
     }
     await ctx.db.patch(row._id, patch);
 
@@ -2515,6 +2648,44 @@ export const markRecurringCanceled = internalMutation({
  * A gift still in Checkout (`pending`, no subscription yet) has its Checkout
  * Session expired instead, so it can't complete after the donor backed out.
  */
+/**
+ * Has this subscription genuinely stopped billing at Stripe?
+ *
+ * Asked only after a `subscriptions.cancel` threw, to tell "already canceled,
+ * nothing to do" apart from "still live, the cancel really failed". Defaults
+ * to FALSE whenever Stripe can't answer: claiming a gift is stopped when we
+ * don't know is the one wrong answer here — it hides a card that keeps getting
+ * charged. A 404 (`resource_missing`) is the exception, and only because a
+ * subscription that doesn't exist cannot bill anyone.
+ */
+async function isSubscriptionGoneAtStripe(
+  stripe: {
+    subscriptions: {
+      retrieve: (
+        id: string,
+        params?: Record<string, never>,
+        options?: { stripeAccount: string },
+      ) => Promise<{ status?: string }>;
+    };
+  },
+  subscriptionId: string,
+  stripeAccount: string,
+): Promise<boolean> {
+  try {
+    const subscription = await stripe.subscriptions.retrieve(
+      subscriptionId,
+      {},
+      { stripeAccount },
+    );
+    return (
+      subscription.status === "canceled" ||
+      subscription.status === "incomplete_expired"
+    );
+  } catch (error) {
+    return (error as { code?: string })?.code === "resource_missing";
+  }
+}
+
 export const cancelRecurringDonation = action({
   args: {
     token: v.string(),
@@ -2540,14 +2711,27 @@ export const cancelRecurringDonation = action({
           stripeAccount: row.stripeConnectedAccountId,
         });
       } catch (error) {
-        // Already canceled at Stripe (e.g. `customer.subscription.deleted`
-        // landed first, or the donor cancelled twice) — the desired end state
-        // is reached either way, so fall through to marking the row rather
-        // than failing a cancel the donor asked for.
+        // A cancel that failed is only safe to ignore once Stripe CONFIRMS
+        // the subscription is already gone (`customer.subscription.deleted`
+        // landed first, or the donor cancelled twice) — then the end state the
+        // donor asked for is already true. A transient network, rate-limit or
+        // 5xx failure is a different thing entirely: the subscription is still
+        // live and still charging, and marking the row canceled would both lie
+        // to the donor and make the row terminal, so no later Stripe event can
+        // ever put it back. Re-throw those and let them tap Stop again.
         console.warn(
           `[finance] cancelRecurringDonation: Stripe cancel failed for ${row.stripeSubscriptionId}`,
           error,
         );
+        if (
+          !(await isSubscriptionGoneAtStripe(
+            stripe,
+            row.stripeSubscriptionId,
+            row.stripeConnectedAccountId,
+          ))
+        ) {
+          throw error;
+        }
       }
     } else if (row.checkoutSessionId) {
       try {

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -20,6 +20,14 @@
  *      `donations` row, posts the ledger credit, and schedules the receipt
  *      email.
  *   3. `getFundOverview` powers the member-facing transparency screen.
+ *   4. MONTHLY gifts are a Stripe Subscription on the same connected
+ *      account (`createRecurringDonationCheckoutSession` and the donor
+ *      management actions at the bottom of this file). Each charge is
+ *      recorded as an ordinary `donations` row from `invoice.paid` — NOT
+ *      `payment_intent.succeeded`, because subscription-mode Checkout
+ *      forbids `payment_intent_data` and so the PaymentIntent carries none
+ *      of our metadata. Both paths write through `recordDonationCore`, so a
+ *      monthly gift and a one-off gift credit, audit and receipt identically.
  *
  * Every query here first authorizes the caller, then (for `getFundOverview`)
  * separately decides how MUCH detail they see — active members get
@@ -38,6 +46,7 @@ import {
   internalMutation,
   internalAction,
 } from "../../_generated/server";
+import type { MutationCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { getOptionalAuth, requireAuth } from "../../lib/auth";
@@ -47,6 +56,9 @@ import { postLedgerEntry } from "../../lib/finance/ledger";
 import { logFinanceAudit } from "../../lib/finance/audit";
 import { buildDonationReceiptEmail } from "../../lib/finance/receipts";
 import { computeCoverFeesCents, COVER_FEE_TOLERANCE_CENTS } from "../../lib/finance/fees";
+// Pure helper, no cycle: webhooks.ts reaches giving.ts through the generated
+// `internal` API, never by importing this module.
+import { splitDonationAmounts } from "./webhooks";
 import { getResendClient } from "../../lib/resend";
 import { now, getDisplayName } from "../../lib/utils";
 import {
@@ -69,6 +81,23 @@ const MAX_DONATION_CENTS = 2_000_000;
 
 /** How many recent ledger entries the transparency screen shows. */
 const RECENT_ACTIVITY_LIMIT = 20;
+
+/**
+ * How long a `pending` recurringDonations row (row created, donor still on
+ * Stripe's hosted Checkout page) keeps blocking a second attempt.
+ *
+ * "One monthly gift per donor per fund" has to hold, but a donor who opens
+ * Checkout and closes the tab must not be locked out of ever setting one up.
+ * Past this window the abandoned row is SUPERSEDED — its Stripe Checkout
+ * Session is expired so it can never complete behind our back, and the row is
+ * marked canceled — before the new attempt starts. 30 minutes is comfortably
+ * longer than anyone spends entering a card and far shorter than Stripe's own
+ * 24h session expiry, which would otherwise be the lockout.
+ */
+const PENDING_CHECKOUT_GRACE_MS = 30 * 60 * 1000;
+
+/** Statuses that mean "this donor already gives monthly to this fund". */
+const LIVE_RECURRING_STATUSES = ["active", "past_due"] as const;
 
 // ============================================================================
 // Access helpers (local — not exported from lib/helpers.ts, which this task
@@ -170,6 +199,33 @@ function startOfMonthUTC(ms: number): number {
 function startOfYearUTC(ms: number): number {
   const d = new Date(ms);
   return Date.UTC(d.getUTCFullYear(), 0, 1);
+}
+
+/**
+ * The donor's currently-collecting monthly gift to `fundId`, or null.
+ *
+ * "Collecting" deliberately excludes `pending` (row created, donor still on
+ * Stripe's Checkout page — no subscription exists yet) and `canceled`
+ * (terminal). `past_due` counts: Stripe is still retrying it, the donor still
+ * has a monthly gift, and offering to start a second one would double-charge
+ * them the moment the first recovers.
+ */
+async function findLiveRecurring(
+  ctx: { db: any },
+  fundId: Id<"funds">,
+  donorUserId: Id<"users">,
+): Promise<Doc<"recurringDonations"> | null> {
+  const rows = await ctx.db
+    .query("recurringDonations")
+    .withIndex("by_donor_fund", (q: any) =>
+      q.eq("donorUserId", donorUserId).eq("fundId", fundId),
+    )
+    .collect();
+  return (
+    rows.find((r: Doc<"recurringDonations">) =>
+      (LIVE_RECURRING_STATUSES as readonly string[]).includes(r.status),
+    ) ?? null
+  );
 }
 
 /** "Friend of the ministry" covers anonymous/guest gifts (no donorUserId) — getDisplayName's own "Anonymous" fallback is for a real user with no name set, a different case. */
@@ -346,12 +402,24 @@ export const getGivingContext = query({
     const givingLive =
       fund.status === "active" && communityFinance?.onboardingStatus === "live";
 
+    // The give screen switches its monthly toggle between "start a monthly
+    // gift" and "you already give $X/month" from this one field, so it must
+    // reflect only gifts that are actually collecting — a `pending` row (donor
+    // still in Checkout) or a canceled one is not a monthly gift yet/anymore.
+    const liveRecurring = await findLiveRecurring(ctx, fund._id, userId);
+
     return {
       fundId: fund._id,
       fundName: fund.name,
       communityLegalName: communityFinance?.legalName ?? community?.name ?? "",
       suggestedAmountsCents: SUGGESTED_AMOUNTS_CENTS,
       givingLive,
+      existingRecurring: liveRecurring
+        ? {
+            amountCents: liveRecurring.amountCents,
+            feeCoverCents: liveRecurring.feeCoverCents,
+          }
+        : null,
     };
   },
 });
@@ -654,6 +722,13 @@ export function buildGiveReturnUrls(params: {
   totalCents: number;
   fundName: string;
   communityName: string;
+  /**
+   * Monthly gift rather than a one-off. Adds `recurring=1` so the success
+   * screen — which renders from these params alone, with no session of its
+   * own — can say "$25 a month" instead of "$25". A flag rather than a
+   * separate route because everything else on that screen is identical.
+   */
+  recurring?: boolean;
 }): { successUrl: string; cancelUrl: string } {
   // groupId is a system-generated Convex id today, so encoding it is belt-and-
   // braces — but it is the one value here interpolated into the PATH, where an
@@ -664,7 +739,8 @@ export function buildGiveReturnUrls(params: {
       `${groupUrl}/give-success?session_id={CHECKOUT_SESSION_ID}` +
       `&amount=${params.totalCents}` +
       `&fund=${urlSafeName(params.fundName)}` +
-      `&community=${urlSafeName(params.communityName)}`,
+      `&community=${urlSafeName(params.communityName)}` +
+      (params.recurring ? "&recurring=1" : ""),
     cancelUrl: `${groupUrl}/give?giving=cancelled`,
   };
 }
@@ -916,16 +992,32 @@ export const getCheckoutSessionStatus = query({
 // total Stripe charged. The ledger credit below adds `feeCoverCents` on top,
 // so callers passing the charged total would double-count the cover — the
 // webhook layer splits the intent amount via splitDonationAmounts() first.
-export const recordDonationSucceeded = internalMutation({
+/**
+ * The one place a succeeded gift becomes a `donations` row + ledger credit +
+ * audit row + scheduled receipt, shared by BOTH collection paths: a one-off
+ * PaymentIntent (`recordDonationSucceeded`, from `payment_intent.succeeded`)
+ * and a monthly subscription's invoice (`recordRecurringDonationPaid`, from
+ * `invoice.paid`). Extracted rather than copied so a monthly gift can never
+ * drift from a one-off one in what it credits, audits, or receipts — the two
+ * webhook events differ only in how they FIND the fund/amounts.
+ *
+ * Idempotent on `paymentIntentId`: a redelivered webhook returns the existing
+ * donation id without touching the ledger or the balance a second time.
+ */
+async function recordDonationCore(
+  ctx: MutationCtx,
   args: {
-    paymentIntentId: v.string(),
-    fundId: v.id("funds"),
-    donorUserId: v.optional(v.id("users")),
-    amountCents: v.number(),
-    feeCoverCents: v.number(),
-    communityId: v.id("communities"),
+    paymentIntentId: string;
+    fundId: Id<"funds">;
+    donorUserId?: Id<"users">;
+    amountCents: number;
+    feeCoverCents: number;
+    communityId: Id<"communities">;
+    /** Set for a monthly gift — the `recurringDonations` row it was billed under. */
+    recurringId?: string;
   },
-  handler: async (ctx, args) => {
+): Promise<Id<"donations">> {
+  {
     const existing = await ctx.db
       .query("donations")
       .withIndex("by_stripePaymentIntentId", (q) =>
@@ -953,6 +1045,7 @@ export const recordDonationSucceeded = internalMutation({
       amountCents: args.amountCents,
       feeCoverCents: args.feeCoverCents,
       stripePaymentIntentId: args.paymentIntentId,
+      recurringId: args.recurringId,
       allocationStatus: "pending",
       receiptEmailStatus: "pending",
       createdAt: now(),
@@ -983,6 +1076,7 @@ export const recordDonationSucceeded = internalMutation({
         paymentIntentId: args.paymentIntentId,
         amountCents: args.amountCents,
         feeCoverCents: args.feeCoverCents,
+        recurringId: args.recurringId ?? null,
       },
     });
 
@@ -993,6 +1087,20 @@ export const recordDonationSucceeded = internalMutation({
     );
 
     return donationId;
+  }
+}
+
+export const recordDonationSucceeded = internalMutation({
+  args: {
+    paymentIntentId: v.string(),
+    fundId: v.id("funds"),
+    donorUserId: v.optional(v.id("users")),
+    amountCents: v.number(),
+    feeCoverCents: v.number(),
+    communityId: v.id("communities"),
+  },
+  handler: async (ctx, args) => {
+    return await recordDonationCore(ctx, args);
   },
 });
 
@@ -1372,5 +1480,1168 @@ export const sendDonationReceipt = internalAction({
         { donationId: args.donationId, status: "failed" },
       );
     }
+  },
+});
+
+// ============================================================================
+// Recurring (monthly) giving — ADR-032 §3 "standing gifts".
+//
+// A monthly gift is a Stripe SUBSCRIPTION on the community's connected
+// account, and every charge it makes is recorded as an ordinary `donations`
+// row so the ledger, receipts, allocation and transparency screens keep
+// working unchanged (see the `recurringDonations` doc comment in schema.ts).
+//
+// Three things make this materially different from the one-off path, and
+// each is the reason for a piece of machinery below:
+//
+//  1. Subscription-mode Checkout REQUIRES a Stripe Customer, and donors have
+//     none — communities have a platform Customer for SaaS billing, donors
+//     have nothing anywhere. So one is created (and thereafter reused) on the
+//     CONNECTED account, and its id is stored on the row.
+//  2. `payment_intent_data` is not allowed in subscription mode, so the
+//     metadata that attributes a charge to a fund cannot ride on the
+//     PaymentIntent. It goes on `subscription_data.metadata` instead — which
+//     means a monthly charge is recorded from `invoice.paid`, NOT from
+//     `payment_intent.succeeded`. That handler sees a PaymentIntent with no
+//     `fundId` metadata and returns early, exactly as it does for billing's
+//     own intents; there is a test asserting that non-interference.
+//  3. The subscription does not exist while the donor is still on Stripe's
+//     hosted page, so the row is inserted `pending` and bound to its
+//     subscription later, by `checkout.session.completed`.
+// ============================================================================
+
+/** The give screen's own route, which doubles as the manage screen today.
+ * When a dedicated "manage my monthly gift" screen ships, this is the one
+ * line that changes. */
+function buildRecurringManageUrl(groupId: string): string {
+  return `${DOMAIN_CONFIG.appUrl}/groups/${encodeURIComponent(groupId)}/give`;
+}
+
+/** Copy the donor actually reads when they already give monthly to this fund. */
+const ALREADY_RECURRING_MESSAGE =
+  "You already have a monthly gift to this fund. You can change the amount or stop it from your giving settings.";
+
+/** Copy for the narrower case of a Checkout page still open in another tab. */
+const RECURRING_CHECKOUT_IN_PROGRESS_MESSAGE =
+  "You just started setting up a monthly gift to this fund. Finish that checkout, or try again in a few minutes.";
+
+/**
+ * Everything the recurring Checkout path needs that `prepareDonationIntent`
+ * (the shared auth/amount/fund/live seam, which this path calls FIRST and
+ * does not duplicate) doesn't already answer: is there already a monthly gift
+ * here, is there a stale Checkout to supersede, and is there a Stripe
+ * Customer for this donor we should reuse.
+ */
+export const prepareRecurringDonation = internalQuery({
+  args: { token: v.string(), fundId: v.id("funds") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireGroupGivingEnabled(ctx);
+
+    const fund = await ctx.db.get(args.fundId);
+    if (!fund) {
+      throw new Error("Fund not found");
+    }
+    const communityFinance = await ctx.db
+      .query("communityFinance")
+      .withIndex("by_community", (q) => q.eq("communityId", fund.communityId))
+      .first();
+    const stripeConnectedAccountId = communityFinance?.stripeConnectedAccountId;
+    if (!stripeConnectedAccountId) {
+      throw new Error("Giving isn't set up for this community yet");
+    }
+
+    const rowsForFund = await ctx.db
+      .query("recurringDonations")
+      .withIndex("by_donor_fund", (q) =>
+        q.eq("donorUserId", userId).eq("fundId", args.fundId),
+      )
+      .collect();
+
+    const nowMs = now();
+    const blocking = rowsForFund.find(
+      (r) =>
+        (LIVE_RECURRING_STATUSES as readonly string[]).includes(r.status) ||
+        (r.status === "pending" &&
+          nowMs - r.createdAt < PENDING_CHECKOUT_GRACE_MS),
+    );
+    // Older `pending` rows are abandoned Checkouts — see
+    // PENDING_CHECKOUT_GRACE_MS. They're superseded (session expired at
+    // Stripe, row canceled) rather than left to lock the donor out forever.
+    const stalePending = rowsForFund.filter(
+      (r) => r.status === "pending" && r !== blocking,
+    );
+
+    // CUSTOMER REUSE RULE: one Stripe Customer per (donor, connected
+    // account) — NOT per fund and NOT per subscription. A donor giving
+    // monthly to two funds in the same community is one person with one card
+    // on file at that community, so a second Customer would split their
+    // payment methods across two billing-portal identities and make "update
+    // my card" fix only half their gifts. Scanning the donor's OWN rows is
+    // the whole search space (nothing else ever creates a donor Customer),
+    // and the connected-account match is what keeps community A's Customer
+    // out of community B's account, where the id would simply not exist.
+    const donorRows = await ctx.db
+      .query("recurringDonations")
+      .withIndex("by_donor", (q) => q.eq("donorUserId", userId))
+      .collect();
+    const reusableCustomerId =
+      donorRows.find(
+        (r) =>
+          r.stripeConnectedAccountId === stripeConnectedAccountId &&
+          !!r.stripeCustomerId,
+      )?.stripeCustomerId ?? null;
+
+    const donor = await ctx.db.get(userId);
+
+    return {
+      donorUserId: userId,
+      donorName: donorDisplayName(donor),
+      donorEmail: donor?.email,
+      stripeConnectedAccountId,
+      blockingStatus: blocking?.status ?? null,
+      stalePending: stalePending.map((r) => ({
+        id: r._id,
+        checkoutSessionId: r.checkoutSessionId,
+      })),
+      reusableCustomerId,
+    };
+  },
+});
+
+/**
+ * Marks an abandoned Checkout's row canceled so it stops blocking a fresh
+ * attempt. Never touches a row that has a subscription — by then it isn't a
+ * stale Checkout, it's a real monthly gift.
+ */
+export const supersedePendingRecurringDonation = internalMutation({
+  args: { recurringDonationId: v.id("recurringDonations") },
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.recurringDonationId);
+    if (!row || row.status !== "pending" || row.stripeSubscriptionId) {
+      return;
+    }
+    const timestamp = now();
+    await ctx.db.patch(row._id, {
+      status: "canceled",
+      canceledAt: timestamp,
+      updatedAt: timestamp,
+    });
+    await logFinanceAudit(ctx, {
+      communityId: row.communityId,
+      fundId: row.fundId,
+      actorUserId: row.donorUserId,
+      action: "recurring.checkout_abandoned",
+      details: { recurringDonationId: row._id, reason: "superseded" },
+    });
+  },
+});
+
+/**
+ * Inserts the `pending` row, re-checking the one-per-donor-per-fund rule
+ * INSIDE the transaction. The check in `prepareRecurringDonation` is for the
+ * error message; this one is the actual guarantee — two taps racing through
+ * the action would both pass a read-only check and only this write can
+ * serialize them.
+ *
+ * `checkoutSessionId` starts empty because the Stripe session doesn't exist
+ * yet: the row id has to exist FIRST so it can go into the subscription
+ * metadata (which is what every later invoice carries), and Convex ids are
+ * only minted by the insert. `bindRecurringCheckoutSession` fills it in a
+ * moment later; `abandonRecurringDonation` cancels the row if Stripe fails in
+ * between, so a failed create can't leave a phantom blocking the retry.
+ */
+export const beginRecurringDonation = internalMutation({
+  args: {
+    token: v.string(),
+    fundId: v.id("funds"),
+    amountCents: v.number(),
+    feeCoverCents: v.number(),
+    stripeConnectedAccountId: v.string(),
+    stripeCustomerId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const fund = await ctx.db.get(args.fundId);
+    if (!fund) {
+      throw new Error("Fund not found");
+    }
+
+    const existing = await findLiveRecurring(ctx, args.fundId, userId);
+    if (existing) {
+      throw new ConvexError(ALREADY_RECURRING_MESSAGE);
+    }
+
+    const timestamp = now();
+    const recurringDonationId = await ctx.db.insert("recurringDonations", {
+      fundId: args.fundId,
+      communityId: fund.communityId,
+      donorUserId: userId,
+      amountCents: args.amountCents,
+      feeCoverCents: args.feeCoverCents,
+      stripeCustomerId: args.stripeCustomerId,
+      stripeConnectedAccountId: args.stripeConnectedAccountId,
+      checkoutSessionId: "",
+      status: "pending",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    await logFinanceAudit(ctx, {
+      communityId: fund.communityId,
+      fundId: args.fundId,
+      actorUserId: userId,
+      action: "recurring.created",
+      details: {
+        recurringDonationId,
+        amountCents: args.amountCents,
+        feeCoverCents: args.feeCoverCents,
+      },
+    });
+
+    return recurringDonationId;
+  },
+});
+
+/** Stamps the real Checkout Session id (and Customer) onto a row created by
+ * `beginRecurringDonation` — the handle `checkout.session.completed` resolves. */
+export const bindRecurringCheckoutSession = internalMutation({
+  args: {
+    recurringDonationId: v.id("recurringDonations"),
+    checkoutSessionId: v.string(),
+    stripeCustomerId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.recurringDonationId, {
+      checkoutSessionId: args.checkoutSessionId,
+      ...(args.stripeCustomerId
+        ? { stripeCustomerId: args.stripeCustomerId }
+        : {}),
+      updatedAt: now(),
+    });
+  },
+});
+
+/** Cancels a row whose Stripe Checkout Session never got created, so the
+ * failed attempt doesn't block the donor's retry. */
+export const abandonRecurringDonation = internalMutation({
+  args: { recurringDonationId: v.id("recurringDonations") },
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.recurringDonationId);
+    if (!row || row.status !== "pending" || row.stripeSubscriptionId) {
+      return;
+    }
+    const timestamp = now();
+    await ctx.db.patch(row._id, {
+      status: "canceled",
+      canceledAt: timestamp,
+      updatedAt: timestamp,
+    });
+    await logFinanceAudit(ctx, {
+      communityId: row.communityId,
+      fundId: row.fundId,
+      actorUserId: row.donorUserId,
+      action: "recurring.checkout_abandoned",
+      details: { recurringDonationId: row._id, reason: "stripe_error" },
+    });
+  },
+});
+
+/**
+ * Creates a subscription-mode Stripe Checkout Session on the community's
+ * connected account for a MONTHLY gift to `fundId`.
+ *
+ * Everything the one-off path validates is validated here too, by calling the
+ * same `prepareDonationIntent` seam rather than re-deriving any of it.
+ */
+export const createRecurringDonationCheckoutSession = action({
+  args: {
+    token: v.string(),
+    fundId: v.id("funds"),
+    amountCents: v.number(),
+    coverFeesCents: v.optional(v.number()),
+    /** Same contract as createDonationCheckoutSession's — see that action. */
+    idempotencyNonce: v.optional(v.string()),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    url: string;
+    sessionId: string;
+    recurringDonationId: Id<"recurringDonations">;
+  }> => {
+    const context = await ctx.runQuery(
+      internal.functions.finance.giving.prepareDonationIntent,
+      {
+        token: args.token,
+        fundId: args.fundId,
+        amountCents: args.amountCents,
+        coverFeesCents: args.coverFeesCents,
+      },
+    );
+    if (!context.groupId) {
+      // Same limitation as one-off hosted Checkout: the success/cancel links
+      // are group-scoped routes a community-wide general fund has no screen for.
+      throw new Error("Checkout isn't available for this fund yet");
+    }
+
+    const recurring = await ctx.runQuery(
+      internal.functions.finance.giving.prepareRecurringDonation,
+      { token: args.token, fundId: args.fundId },
+    );
+    if (recurring.blockingStatus) {
+      throw new ConvexError(
+        recurring.blockingStatus === "pending"
+          ? RECURRING_CHECKOUT_IN_PROGRESS_MESSAGE
+          : ALREADY_RECURRING_MESSAGE,
+      );
+    }
+
+    const Stripe = (await import("stripe")).default;
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: "2026-02-25.clover",
+    });
+
+    // Expire abandoned Checkout Sessions BEFORE starting a new one. Without
+    // this, a donor who left one open in another tab could complete it after
+    // the new one and end up with two subscriptions to the same fund — the
+    // exact thing the one-per-fund rule exists to prevent. Best-effort:
+    // Stripe errors on a session that already completed or expired, which is
+    // the outcome we wanted anyway.
+    for (const stale of recurring.stalePending) {
+      if (stale.checkoutSessionId) {
+        try {
+          await stripe.checkout.sessions.expire(stale.checkoutSessionId, {
+            stripeAccount: recurring.stripeConnectedAccountId,
+          });
+        } catch (error) {
+          console.warn(
+            `[finance] createRecurringDonationCheckoutSession: could not expire stale session ${stale.checkoutSessionId}`,
+            error,
+          );
+        }
+      }
+      await ctx.runMutation(
+        internal.functions.finance.giving.supersedePendingRecurringDonation,
+        { recurringDonationId: stale.id },
+      );
+    }
+
+    // See the CUSTOMER REUSE RULE in prepareRecurringDonation: one Customer
+    // per (donor, connected account), created here the first time only.
+    const stripeCustomerId =
+      recurring.reusableCustomerId ??
+      (
+        await stripe.customers.create(
+          {
+            name: recurring.donorName,
+            email: recurring.donorEmail,
+            metadata: { donorUserId: recurring.donorUserId },
+          },
+          { stripeAccount: recurring.stripeConnectedAccountId },
+        )
+      ).id;
+
+    const recurringDonationId = await ctx.runMutation(
+      internal.functions.finance.giving.beginRecurringDonation,
+      {
+        token: args.token,
+        fundId: args.fundId,
+        // From the PREPARED context, not `args` — see prepareDonationIntent's
+        // return comment. The row is what every future invoice is checked
+        // against, so it has to hold the validated pair, not the submitted one.
+        amountCents: context.amountCents,
+        feeCoverCents: context.feeCoverCents,
+        stripeConnectedAccountId: recurring.stripeConnectedAccountId,
+        stripeCustomerId,
+      },
+    );
+
+    const totalCents = context.amountCents + context.feeCoverCents;
+    const { successUrl, cancelUrl } = buildGiveReturnUrls({
+      groupId: context.groupId,
+      totalCents,
+      fundName: context.fundName,
+      communityName: context.communityName,
+      recurring: true,
+    });
+
+    let session;
+    try {
+      session = await stripe.checkout.sessions.create(
+        {
+          mode: "subscription",
+          customer: stripeCustomerId,
+          line_items: [
+            {
+              price_data: {
+                currency: "usd",
+                unit_amount: totalCents,
+                recurring: { interval: "month" },
+                product_data: { name: `Monthly gift to ${context.fundName}` },
+              },
+              quantity: 1,
+            },
+          ],
+          success_url: successUrl,
+          cancel_url: cancelUrl,
+          // NOT payment_intent_data — Stripe rejects it in subscription mode.
+          // These land on the Subscription, and every invoice this
+          // subscription ever raises carries them, which is how `invoice.paid`
+          // attributes a monthly charge back to this fund and donor.
+          subscription_data: {
+            description: `Monthly gift — ${context.fundName}`,
+            metadata: {
+              recurringDonationId,
+              fundId: args.fundId,
+              donorUserId: context.userId,
+              communityId: context.communityId,
+              amountCents: String(context.amountCents),
+              feeCoverCents: String(context.feeCoverCents),
+            },
+          },
+        },
+        {
+          stripeAccount: recurring.stripeConnectedAccountId,
+          // The AMOUNT is in the key, unlike the one-off path's: a donor who
+          // backs out, changes $25 to $50, and re-submits reuses the same
+          // client nonce, and a key without the amount would hand them back
+          // the $25 session — silently ignoring the change they just made.
+          ...(args.idempotencyNonce
+            ? {
+                idempotencyKey: `recurring-checkout:${args.fundId}:${args.idempotencyNonce}:${context.amountCents}:${context.feeCoverCents}`,
+              }
+            : {}),
+        },
+      );
+    } catch (error) {
+      await ctx.runMutation(
+        internal.functions.finance.giving.abandonRecurringDonation,
+        { recurringDonationId },
+      );
+      throw error;
+    }
+
+    if (!session.url) {
+      await ctx.runMutation(
+        internal.functions.finance.giving.abandonRecurringDonation,
+        { recurringDonationId },
+      );
+      throw new Error("Stripe did not return a Checkout URL");
+    }
+
+    await ctx.runMutation(
+      internal.functions.finance.giving.bindRecurringCheckoutSession,
+      {
+        recurringDonationId,
+        checkoutSessionId: session.id,
+        stripeCustomerId,
+      },
+    );
+
+    return { url: session.url, sessionId: session.id, recurringDonationId };
+  },
+});
+
+// ============================================================================
+// Recurring webhook mutations — called by functions/finance/webhooks.ts.
+// ============================================================================
+
+/**
+ * Binds a completed subscription-mode Checkout to its pending row
+ * (`checkout.session.completed`). Status deliberately STAYS "pending": the
+ * subscription existing is not the same as it having collected anything, and
+ * `invoice.paid` — the event that actually records the money — is what flips
+ * it to "active".
+ *
+ * Cross-checks `eventAccount` against the row's own connected account for the
+ * same reason `payment_intent.succeeded` does (ADR-032 §6): nothing about the
+ * event itself proves it came from the community this row belongs to.
+ */
+export const bindRecurringSubscription = internalMutation({
+  args: {
+    checkoutSessionId: v.string(),
+    stripeSubscriptionId: v.string(),
+    stripeCustomerId: v.optional(v.string()),
+    eventAccount: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("recurringDonations")
+      .withIndex("by_checkoutSessionId", (q) =>
+        q.eq("checkoutSessionId", args.checkoutSessionId),
+      )
+      .first();
+    if (!row) {
+      // Not one of ours (a one-off donation Checkout, or another integration
+      // on the same connected account) — nothing to do.
+      return;
+    }
+    if (!args.eventAccount || args.eventAccount !== row.stripeConnectedAccountId) {
+      console.error(
+        `[finance] checkout.session.completed: account mismatch on recurring donation ${row._id} — event.account=${args.eventAccount ?? "missing"} expected=${row.stripeConnectedAccountId}`,
+      );
+      await logFinanceAudit(ctx, {
+        communityId: row.communityId,
+        fundId: row.fundId,
+        action: "webhook.rejected_account_mismatch",
+        details: {
+          eventAccount: args.eventAccount ?? null,
+          expectedAccount: row.stripeConnectedAccountId,
+          recurringDonationId: row._id,
+        },
+      });
+      return;
+    }
+    if (row.status === "canceled") {
+      // Superseded/abandoned between creating the session and completing it.
+      // Do NOT resurrect it — the subscription is real at Stripe, so log
+      // loudly; the donor's live row (if any) is a different subscription.
+      console.error(
+        `[finance] checkout.session.completed: subscription ${args.stripeSubscriptionId} completed for canceled recurring donation ${row._id}`,
+      );
+      return;
+    }
+
+    await ctx.db.patch(row._id, {
+      stripeSubscriptionId: args.stripeSubscriptionId,
+      ...(args.stripeCustomerId
+        ? { stripeCustomerId: args.stripeCustomerId }
+        : {}),
+      updatedAt: now(),
+    });
+    await logFinanceAudit(ctx, {
+      communityId: row.communityId,
+      fundId: row.fundId,
+      actorUserId: row.donorUserId,
+      action: "recurring.subscription_bound",
+      details: {
+        recurringDonationId: row._id,
+        stripeSubscriptionId: args.stripeSubscriptionId,
+      },
+    });
+  },
+});
+
+/**
+ * Records a monthly charge (`invoice.paid`) as an ordinary donation and marks
+ * the subscription active.
+ *
+ * The invoice's PaymentIntent id is the idempotency key, exactly as for a
+ * one-off gift — `recordDonationCore` bails before any write if a donation
+ * already exists for it, so a redelivered `invoice.paid` credits the ledger
+ * exactly once.
+ *
+ * `amountPaidCents` (what Stripe actually collected) is the authority on the
+ * TOTAL, with the row supplying the fee-cover split — a stale row can then
+ * only ever mis-split a correct total, never credit money that wasn't
+ * collected. `splitDonationAmounts` normalizes a cover that no longer fits.
+ */
+export const recordRecurringDonationPaid = internalMutation({
+  args: {
+    stripeSubscriptionId: v.string(),
+    paymentIntentId: v.string(),
+    amountPaidCents: v.optional(v.number()),
+    currentPeriodEnd: v.optional(v.number()),
+    eventAccount: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("recurringDonations")
+      .withIndex("by_stripeSubscriptionId", (q) =>
+        q.eq("stripeSubscriptionId", args.stripeSubscriptionId),
+      )
+      .first();
+    if (!row) {
+      return; // Not a Togather monthly gift.
+    }
+    if (!args.eventAccount || args.eventAccount !== row.stripeConnectedAccountId) {
+      console.error(
+        `[finance] invoice.paid: account mismatch on recurring donation ${row._id} — event.account=${args.eventAccount ?? "missing"} expected=${row.stripeConnectedAccountId}`,
+      );
+      await logFinanceAudit(ctx, {
+        communityId: row.communityId,
+        fundId: row.fundId,
+        action: "webhook.rejected_account_mismatch",
+        details: {
+          eventAccount: args.eventAccount ?? null,
+          expectedAccount: row.stripeConnectedAccountId,
+          recurringDonationId: row._id,
+        },
+      });
+      return;
+    }
+
+    const rowTotalCents = row.amountCents + row.feeCoverCents;
+    const totalCents = args.amountPaidCents ?? rowTotalCents;
+    if (totalCents !== rowTotalCents) {
+      console.warn(
+        `[finance] invoice.paid: subscription ${args.stripeSubscriptionId} collected ${totalCents} but recurring donation ${row._id} expects ${rowTotalCents} — crediting what Stripe collected`,
+      );
+    }
+    const { baseCents, feeCoverCents } = splitDonationAmounts(
+      totalCents,
+      row.feeCoverCents,
+    );
+
+    const donationId = await recordDonationCore(ctx, {
+      paymentIntentId: args.paymentIntentId,
+      fundId: row.fundId,
+      donorUserId: row.donorUserId,
+      amountCents: baseCents,
+      feeCoverCents,
+      communityId: row.communityId,
+      recurringId: row._id,
+    });
+
+    // A canceled row is terminal: Stripe can still settle an invoice raised
+    // before the cancel landed (the money is real, and is recorded above),
+    // but it must not come back to life.
+    const patch: {
+      status?: "active";
+      currentPeriodEnd?: number;
+      updatedAt: number;
+    } = { updatedAt: now() };
+    if (row.status !== "canceled") {
+      patch.status = "active";
+    }
+    if (args.currentPeriodEnd !== undefined) {
+      patch.currentPeriodEnd = args.currentPeriodEnd;
+    }
+    await ctx.db.patch(row._id, patch);
+
+    return donationId;
+  },
+});
+
+/**
+ * Syncs a subscription's lifecycle onto its row —
+ * `customer.subscription.updated` / `.deleted` and `invoice.payment_failed`
+ * all land here.
+ *
+ * `amountCents`/`feeCoverCents` are only applied when the caller resolved
+ * BOTH from the subscription's own metadata AND they add up to the price the
+ * subscription now charges. Anything else (metadata missing, stale, or
+ * inconsistent with the price) is ignored in favour of leaving the row alone
+ * rather than writing a split that doesn't match what the donor is billed.
+ */
+export const applyRecurringSubscriptionState = internalMutation({
+  args: {
+    stripeSubscriptionId: v.string(),
+    status: v.optional(
+      v.union(
+        v.literal("active"),
+        v.literal("past_due"),
+        v.literal("canceled"),
+      ),
+    ),
+    currentPeriodEnd: v.optional(v.number()),
+    amountCents: v.optional(v.number()),
+    feeCoverCents: v.optional(v.number()),
+    eventAccount: v.optional(v.string()),
+    /** For the audit row — which Stripe event drove this. */
+    reason: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("recurringDonations")
+      .withIndex("by_stripeSubscriptionId", (q) =>
+        q.eq("stripeSubscriptionId", args.stripeSubscriptionId),
+      )
+      .first();
+    if (!row) {
+      return;
+    }
+    if (!args.eventAccount || args.eventAccount !== row.stripeConnectedAccountId) {
+      console.error(
+        `[finance] ${args.reason}: account mismatch on recurring donation ${row._id} — event.account=${args.eventAccount ?? "missing"} expected=${row.stripeConnectedAccountId}`,
+      );
+      await logFinanceAudit(ctx, {
+        communityId: row.communityId,
+        fundId: row.fundId,
+        action: "webhook.rejected_account_mismatch",
+        details: {
+          eventAccount: args.eventAccount ?? null,
+          expectedAccount: row.stripeConnectedAccountId,
+          recurringDonationId: row._id,
+        },
+      });
+      return;
+    }
+
+    const timestamp = now();
+    const patch: Partial<Doc<"recurringDonations">> = { updatedAt: timestamp };
+
+    // "canceled" is terminal — a late/reordered update event must never
+    // reactivate a gift the donor already stopped.
+    if (args.status && row.status !== "canceled" && args.status !== row.status) {
+      patch.status = args.status;
+      if (args.status === "canceled") {
+        patch.canceledAt = timestamp;
+      }
+    }
+    if (args.currentPeriodEnd !== undefined) {
+      patch.currentPeriodEnd = args.currentPeriodEnd;
+    }
+    if (
+      args.amountCents !== undefined &&
+      args.feeCoverCents !== undefined &&
+      (args.amountCents !== row.amountCents ||
+        args.feeCoverCents !== row.feeCoverCents)
+    ) {
+      patch.amountCents = args.amountCents;
+      patch.feeCoverCents = args.feeCoverCents;
+    }
+
+    await ctx.db.patch(row._id, patch);
+
+    // No status/amount change means a redelivered or incidental event — keep
+    // it out of the audit trail (same rule as applyIncreaseEntityStatus).
+    if (patch.status === undefined && patch.amountCents === undefined) {
+      return;
+    }
+    await logFinanceAudit(ctx, {
+      communityId: row.communityId,
+      fundId: row.fundId,
+      actorUserId: row.donorUserId,
+      action: "recurring.status_synced",
+      details: {
+        recurringDonationId: row._id,
+        from: row.status,
+        to: patch.status ?? row.status,
+        amountCents: patch.amountCents ?? row.amountCents,
+        feeCoverCents: patch.feeCoverCents ?? row.feeCoverCents,
+        reason: args.reason,
+      },
+    });
+  },
+});
+
+// ============================================================================
+// Donor-facing management: list, read, change amount, cancel, update card.
+// ============================================================================
+
+/** Shape both donor-facing reads return. */
+interface RecurringSummary {
+  id: Id<"recurringDonations">;
+  fundId: Id<"funds">;
+  groupId: Id<"groups"> | null;
+  fundName: string;
+  amountCents: number;
+  feeCoverCents: number;
+  status: "pending" | "active" | "past_due" | "canceled";
+  currentPeriodEnd: number | null;
+  createdAt: number;
+}
+
+async function toRecurringSummary(
+  ctx: { db: any },
+  row: Doc<"recurringDonations">,
+): Promise<RecurringSummary> {
+  const fund = await ctx.db.get(row.fundId);
+  return {
+    id: row._id,
+    fundId: row.fundId,
+    groupId: fund?.groupId ?? null,
+    fundName: fund?.name ?? "",
+    amountCents: row.amountCents,
+    feeCoverCents: row.feeCoverCents,
+    status: row.status,
+    currentPeriodEnd: row.currentPeriodEnd ?? null,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * The signed-in donor's own monthly gifts, newest first.
+ *
+ * Scoped to the caller by construction — the `by_donor` index is keyed on the
+ * authenticated user id and no argument can widen it, so there is no fund or
+ * community a donor could ask about to see someone else's giving.
+ *
+ * Canceled gifts are excluded: this is the list you MANAGE, and a stopped
+ * gift has nothing left to manage. The charges it made remain visible as
+ * ordinary donations in giving history.
+ */
+export const listMyRecurringDonations = query({
+  args: { token: v.string() },
+  handler: async (ctx, args): Promise<RecurringSummary[]> => {
+    const userId = await requireAuth(ctx, args.token);
+    if (!(await isGroupGivingEnabled(ctx))) {
+      return [];
+    }
+    const rows = await ctx.db
+      .query("recurringDonations")
+      .withIndex("by_donor", (q) => q.eq("donorUserId", userId))
+      .order("desc")
+      .collect();
+    return await Promise.all(
+      rows
+        .filter((r) => r.status !== "canceled")
+        .map((r) => toRecurringSummary(ctx, r)),
+    );
+  },
+});
+
+/**
+ * The caller's own monthly gift to one fund (the give screen's monthly toggle
+ * and the fund dashboard's "you give $X/month" box), or null.
+ *
+ * Same donor scoping as `listMyRecurringDonations`: `fundId` narrows, it
+ * never widens — the donor half of the index is always the caller.
+ */
+export const getRecurringForFund = query({
+  args: { token: v.string(), fundId: v.id("funds") },
+  handler: async (ctx, args): Promise<RecurringSummary | null> => {
+    const userId = await requireAuth(ctx, args.token);
+    if (!(await isGroupGivingEnabled(ctx))) {
+      return null;
+    }
+    const row = await findLiveRecurring(ctx, args.fundId, userId);
+    return row ? await toRecurringSummary(ctx, row) : null;
+  },
+});
+
+/** Loads a recurring row the caller OWNS, for the management actions. */
+export const getMyRecurringDonation = internalQuery({
+  args: { token: v.string(), recurringDonationId: v.id("recurringDonations") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireGroupGivingEnabled(ctx);
+    const row = await ctx.db.get(args.recurringDonationId);
+    if (!row || row.donorUserId !== userId) {
+      // Same answer for "doesn't exist" and "isn't yours" — a donor must not
+      // be able to probe for other people's giving by id.
+      throw new Error("Monthly gift not found");
+    }
+    const fund = await ctx.db.get(row.fundId);
+    return { row, groupId: fund?.groupId ?? null, fundName: fund?.name ?? "" };
+  },
+});
+
+/** Applies a donor-initiated amount change once Stripe has accepted it. */
+export const applyRecurringAmountUpdate = internalMutation({
+  args: {
+    recurringDonationId: v.id("recurringDonations"),
+    amountCents: v.number(),
+    feeCoverCents: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.recurringDonationId);
+    if (!row) return;
+    await ctx.db.patch(row._id, {
+      amountCents: args.amountCents,
+      feeCoverCents: args.feeCoverCents,
+      updatedAt: now(),
+    });
+    await logFinanceAudit(ctx, {
+      communityId: row.communityId,
+      fundId: row.fundId,
+      actorUserId: row.donorUserId,
+      action: "recurring.amount_updated",
+      details: {
+        recurringDonationId: row._id,
+        fromAmountCents: row.amountCents,
+        fromFeeCoverCents: row.feeCoverCents,
+        toAmountCents: args.amountCents,
+        toFeeCoverCents: args.feeCoverCents,
+      },
+    });
+  },
+});
+
+/**
+ * Changes what a monthly gift charges from the NEXT invoice onward.
+ *
+ * Validation runs through `prepareDonationIntent` — the same seam the create
+ * paths use — so the amount bounds, the one-sided fee-cover bound (a CEILING
+ * at `computeCoverFeesCents` + tolerance, with no floor, since only an
+ * over-large fee can move money past `MAX_DONATION_CENTS`), the fund-active
+ * check and the community-live check are literally the same code, not a
+ * re-implementation. There is no fee math in this action at all.
+ *
+ * `proration_behavior: "none"`: the donor already paid for the current period
+ * at its start, and this is a gift, not a service they are getting more or
+ * less of. Prorating would either bill them again mid-month or hand back part
+ * of a gift they meant to give — both wrong. The new amount simply applies at
+ * the next renewal.
+ */
+export const updateRecurringAmount = action({
+  args: {
+    token: v.string(),
+    recurringDonationId: v.id("recurringDonations"),
+    amountCents: v.number(),
+    coverFeesCents: v.optional(v.number()),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ amountCents: number; feeCoverCents: number }> => {
+    const { row } = await ctx.runQuery(
+      internal.functions.finance.giving.getMyRecurringDonation,
+      { token: args.token, recurringDonationId: args.recurringDonationId },
+    );
+    if (row.status === "canceled") {
+      throw new ConvexError(
+        "This monthly gift has been stopped. Start a new one to give monthly again.",
+      );
+    }
+    if (!row.stripeSubscriptionId) {
+      throw new ConvexError(
+        "This monthly gift is still being set up. Try again in a moment.",
+      );
+    }
+
+    // The shared seam: auth, flag, amount bounds, fee bound, fund active,
+    // community live — all of it, for the fund this gift actually belongs to.
+    const context = await ctx.runQuery(
+      internal.functions.finance.giving.prepareDonationIntent,
+      {
+        token: args.token,
+        fundId: row.fundId,
+        amountCents: args.amountCents,
+        coverFeesCents: args.coverFeesCents,
+      },
+    );
+
+    const Stripe = (await import("stripe")).default;
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: "2026-02-25.clover",
+    });
+
+    const subscription = await stripe.subscriptions.retrieve(
+      row.stripeSubscriptionId,
+      {},
+      { stripeAccount: row.stripeConnectedAccountId },
+    );
+    const item = subscription.items.data[0];
+    if (!item) {
+      throw new Error(
+        `updateRecurringAmount: subscription ${row.stripeSubscriptionId} has no items`,
+      );
+    }
+    // A SubscriptionItem's inline `price_data` takes a product ID (unlike
+    // Checkout's, which accepts `product_data`), so reuse the product the
+    // Checkout session already created for this gift.
+    const productId =
+      typeof item.price.product === "string"
+        ? item.price.product
+        : item.price.product.id;
+
+    const totalCents = context.amountCents + context.feeCoverCents;
+    await stripe.subscriptions.update(
+      row.stripeSubscriptionId,
+      {
+        items: [
+          {
+            id: item.id,
+            price_data: {
+              currency: "usd",
+              product: productId,
+              unit_amount: totalCents,
+              recurring: { interval: "month" },
+            },
+          },
+        ],
+        proration_behavior: "none",
+        // Kept in lockstep with the row: `customer.subscription.updated` reads
+        // the split back out of here when the price changes, and an invoice
+        // that arrives before our own patch commits must still describe the
+        // gift correctly.
+        metadata: {
+          recurringDonationId: row._id,
+          fundId: row.fundId,
+          donorUserId: row.donorUserId,
+          communityId: row.communityId,
+          amountCents: String(context.amountCents),
+          feeCoverCents: String(context.feeCoverCents),
+        },
+      },
+      { stripeAccount: row.stripeConnectedAccountId },
+    );
+
+    await ctx.runMutation(
+      internal.functions.finance.giving.applyRecurringAmountUpdate,
+      {
+        recurringDonationId: row._id,
+        amountCents: context.amountCents,
+        feeCoverCents: context.feeCoverCents,
+      },
+    );
+
+    return {
+      amountCents: context.amountCents,
+      feeCoverCents: context.feeCoverCents,
+    };
+  },
+});
+
+/** Marks a monthly gift stopped. Separate from
+ * `applyRecurringSubscriptionState` because this one is donor-initiated and
+ * should say so in the audit trail. */
+export const markRecurringCanceled = internalMutation({
+  args: { recurringDonationId: v.id("recurringDonations") },
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.recurringDonationId);
+    if (!row || row.status === "canceled") return;
+    const timestamp = now();
+    await ctx.db.patch(row._id, {
+      status: "canceled",
+      canceledAt: timestamp,
+      updatedAt: timestamp,
+    });
+    await logFinanceAudit(ctx, {
+      communityId: row.communityId,
+      fundId: row.fundId,
+      actorUserId: row.donorUserId,
+      action: "recurring.canceled",
+      details: { recurringDonationId: row._id, from: row.status },
+    });
+  },
+});
+
+/**
+ * Stops a monthly gift.
+ *
+ * Cancels IMMEDIATELY (`subscriptions.cancel`, not `cancel_at_period_end`).
+ * Stripe subscriptions charge in ADVANCE: the donor paid for the current
+ * period at its START, so there is nothing left in it for them to "use up" —
+ * `cancel_at_period_end` would only mean the gift keeps showing as active for
+ * up to a month while collecting nothing. Cancelling now ends future invoices
+ * and claws nothing back, which is exactly the approved promise: "Ends future
+ * gifts. Past gifts stay."
+ *
+ * A gift still in Checkout (`pending`, no subscription yet) has its Checkout
+ * Session expired instead, so it can't complete after the donor backed out.
+ */
+export const cancelRecurringDonation = action({
+  args: {
+    token: v.string(),
+    recurringDonationId: v.id("recurringDonations"),
+  },
+  handler: async (ctx, args): Promise<{ canceled: true }> => {
+    const { row } = await ctx.runQuery(
+      internal.functions.finance.giving.getMyRecurringDonation,
+      { token: args.token, recurringDonationId: args.recurringDonationId },
+    );
+    if (row.status === "canceled") {
+      return { canceled: true }; // Idempotent — a double tap is not an error.
+    }
+
+    const Stripe = (await import("stripe")).default;
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: "2026-02-25.clover",
+    });
+
+    if (row.stripeSubscriptionId) {
+      try {
+        await stripe.subscriptions.cancel(row.stripeSubscriptionId, undefined, {
+          stripeAccount: row.stripeConnectedAccountId,
+        });
+      } catch (error) {
+        // Already canceled at Stripe (e.g. `customer.subscription.deleted`
+        // landed first, or the donor cancelled twice) — the desired end state
+        // is reached either way, so fall through to marking the row rather
+        // than failing a cancel the donor asked for.
+        console.warn(
+          `[finance] cancelRecurringDonation: Stripe cancel failed for ${row.stripeSubscriptionId}`,
+          error,
+        );
+      }
+    } else if (row.checkoutSessionId) {
+      try {
+        await stripe.checkout.sessions.expire(row.checkoutSessionId, {
+          stripeAccount: row.stripeConnectedAccountId,
+        });
+      } catch (error) {
+        console.warn(
+          `[finance] cancelRecurringDonation: could not expire session ${row.checkoutSessionId}`,
+          error,
+        );
+      }
+    }
+
+    await ctx.runMutation(
+      internal.functions.finance.giving.markRecurringCanceled,
+      { recurringDonationId: row._id },
+    );
+    return { canceled: true };
+  },
+});
+
+/**
+ * A hosted page where the donor can replace the card behind their monthly
+ * gift.
+ *
+ * SHIPPED: Stripe's Billing Portal, on the connected account, scoped to this
+ * donor's Customer. The portal is what actually re-attaches a new payment
+ * method to the live subscription — a Checkout `mode: "setup"` session would
+ * only vault a PaymentMethod and leave us to attach it ourselves from another
+ * webhook branch, which is more moving parts for a worse result.
+ *
+ * A connected account has no portal configuration by default and community
+ * admins will never create one, so one is created on first use, with exactly
+ * two features enabled: updating the payment method and viewing invoices.
+ * `subscription_cancel`/`subscription_update` stay OFF deliberately — cancels
+ * and amount changes go through this file so the `recurringDonations` row and
+ * the audit trail stay the source of truth rather than drifting behind a
+ * Stripe-hosted UI.
+ */
+export const createCardUpdateSession = action({
+  args: {
+    token: v.string(),
+    recurringDonationId: v.id("recurringDonations"),
+  },
+  handler: async (ctx, args): Promise<{ url: string }> => {
+    const { row, groupId } = await ctx.runQuery(
+      internal.functions.finance.giving.getMyRecurringDonation,
+      { token: args.token, recurringDonationId: args.recurringDonationId },
+    );
+    if (!row.stripeCustomerId) {
+      throw new ConvexError(
+        "This monthly gift is still being set up. Try again in a moment.",
+      );
+    }
+    if (!groupId) {
+      throw new Error("Card updates aren't available for this fund yet");
+    }
+    const returnUrl = buildRecurringManageUrl(groupId);
+
+    const Stripe = (await import("stripe")).default;
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: "2026-02-25.clover",
+    });
+
+    const existing = await stripe.billingPortal.configurations.list(
+      { limit: 1, active: true },
+      { stripeAccount: row.stripeConnectedAccountId },
+    );
+    const configurationId =
+      existing.data[0]?.id ??
+      (
+        await stripe.billingPortal.configurations.create(
+          {
+            business_profile: { headline: "Manage your monthly gift" },
+            features: {
+              payment_method_update: { enabled: true },
+              invoice_history: { enabled: true },
+            },
+            default_return_url: returnUrl,
+          },
+          { stripeAccount: row.stripeConnectedAccountId },
+        )
+      ).id;
+
+    const session = await stripe.billingPortal.sessions.create(
+      {
+        customer: row.stripeCustomerId,
+        return_url: returnUrl,
+        configuration: configurationId,
+      },
+      { stripeAccount: row.stripeConnectedAccountId },
+    );
+
+    return { url: session.url };
   },
 });

--- a/apps/convex/functions/finance/webhooks.ts
+++ b/apps/convex/functions/finance/webhooks.ts
@@ -9,7 +9,11 @@
  * - `handleFinanceStripeEvent` — called from the EXISTING `/stripe-webhook`
  *   route's switch (functions/ee/billing.ts's billing events already live
  *   there) for whatever billing's switch doesn't handle itself, i.e.
- *   `account.updated`.
+ *   `account.updated`, plus the four types that are AMBIGUOUS between SaaS
+ *   billing and recurring giving (`checkout.session.completed`,
+ *   `customer.subscription.updated`/`.deleted`, `invoice.payment_failed`),
+ *   which http.ts routes here on `event.account` — see
+ *   lib/finance/webhookRouting.ts.
  *
  * Replay safety: Increase (and Stripe) can redeliver the same event more
  * than once. We don't keep a table of handled event ids (schema.ts is out of
@@ -600,6 +604,170 @@ export function splitDonationAmounts(
   };
 }
 
+// ============================================================================
+// Recurring-giving event shapes.
+//
+// Stripe moved several fields between API versions and the connected account
+// decides which version its events are serialized with, so each of these is
+// read from BOTH the pre-2025-03-31 location and the current one. Getting
+// this wrong doesn't fail loudly — it silently drops a donor's monthly gift —
+// so the readers are tolerant by design and each returns null rather than
+// guessing.
+// ============================================================================
+
+/** `data.object` of a `checkout.session.completed` we might own. */
+interface StripeCheckoutSessionObject {
+  id: string;
+  mode?: string;
+  subscription?: string | { id: string } | null;
+  customer?: string | { id: string } | null;
+}
+
+/** `data.object` of an `invoice.*` event. */
+interface StripeInvoiceObject {
+  id?: string;
+  amount_paid?: number;
+  /** Pre-2025-03-31 API versions put the subscription here. */
+  subscription?: string | { id: string } | null;
+  /** 2025-03-31+ moved it under `parent.subscription_details`. */
+  parent?: {
+    subscription_details?: { subscription?: string | { id: string } | null } | null;
+  } | null;
+  /** Pre-2025-03-31 API versions put the PaymentIntent here. */
+  payment_intent?: string | { id: string } | null;
+  /** 2025-03-31+ moved it into the `payments` sub-list. */
+  payments?: {
+    data?: Array<{
+      payment?: { payment_intent?: string | { id: string } | null } | null;
+    }>;
+  } | null;
+  lines?: { data?: Array<{ period?: { end?: number } | null }> } | null;
+}
+
+/** `data.object` of a `customer.subscription.*` event. */
+interface StripeSubscriptionObject {
+  id: string;
+  status?: string;
+  /** Pre-2025-03-31; newer versions put it on each item instead. */
+  current_period_end?: number;
+  cancel_at_period_end?: boolean;
+  metadata?: Record<string, string> | null;
+  items?: {
+    data?: Array<{
+      current_period_end?: number;
+      price?: { unit_amount?: number | null } | null;
+    }>;
+  } | null;
+}
+
+/** Unwraps Stripe's "id string OR expanded object" union. */
+function stripeId(value: string | { id: string } | null | undefined): string | null {
+  if (typeof value === "string") return value || null;
+  return value?.id ?? null;
+}
+
+/** The subscription an invoice belongs to, across API versions. */
+export function resolveInvoiceSubscriptionId(
+  invoice: StripeInvoiceObject,
+): string | null {
+  return (
+    stripeId(invoice.subscription) ??
+    stripeId(invoice.parent?.subscription_details?.subscription)
+  );
+}
+
+/**
+ * The PaymentIntent that paid an invoice, across API versions. This is the
+ * idempotency key a recurring donation is recorded under — the same key a
+ * one-off gift uses — so a redelivered `invoice.paid` can't double-credit.
+ */
+export function resolveInvoicePaymentIntentId(
+  invoice: StripeInvoiceObject,
+): string | null {
+  const legacy = stripeId(invoice.payment_intent);
+  if (legacy) return legacy;
+  for (const entry of invoice.payments?.data ?? []) {
+    const id = stripeId(entry.payment?.payment_intent);
+    if (id) return id;
+  }
+  return null;
+}
+
+/** When the paid-for period ends, in ms — the donor-facing "next bill" date. */
+export function resolveInvoicePeriodEndMs(
+  invoice: StripeInvoiceObject,
+): number | undefined {
+  const end = invoice.lines?.data?.[0]?.period?.end;
+  return typeof end === "number" ? end * 1000 : undefined;
+}
+
+/**
+ * Stripe's subscription status vocabulary mapped onto the four states
+ * `recurringDonations.status` models.
+ *
+ * `incomplete` means the very first payment hasn't succeeded yet, which is
+ * exactly what our "pending" already means — returning null leaves the row
+ * where it is rather than inventing a transition. Everything that means "we
+ * are not collecting from this card right now" collapses to `past_due`,
+ * because that is the only state the donor-facing copy distinguishes.
+ */
+export function mapStripeSubscriptionStatus(
+  status: string | undefined,
+): "active" | "past_due" | "canceled" | null {
+  switch (status) {
+    case "active":
+    case "trialing":
+      return "active";
+    case "past_due":
+    case "unpaid":
+    case "paused":
+      return "past_due";
+    case "canceled":
+    case "incomplete_expired":
+      return "canceled";
+    default:
+      return null; // "incomplete" and anything Stripe adds later.
+  }
+}
+
+/** The period end a subscription object reports, in ms, across API versions. */
+export function resolveSubscriptionPeriodEndMs(
+  subscription: StripeSubscriptionObject,
+): number | undefined {
+  const end =
+    subscription.current_period_end ??
+    subscription.items?.data?.[0]?.current_period_end;
+  return typeof end === "number" ? end * 1000 : undefined;
+}
+
+/**
+ * The gift/fee-cover split a subscription now charges, or null.
+ *
+ * Only trusted when the metadata WE set adds up to the price the subscription
+ * actually bills. A donor changing their amount updates both in one Stripe
+ * call (`updateRecurringAmount`), so a disagreement means the metadata is
+ * stale or was written by something else — in which case leaving the row
+ * alone beats recording a split the donor isn't being billed.
+ */
+export function resolveSubscriptionAmounts(
+  subscription: StripeSubscriptionObject,
+): { amountCents: number; feeCoverCents: number } | null {
+  const unitAmount = subscription.items?.data?.[0]?.price?.unit_amount;
+  if (typeof unitAmount !== "number") return null;
+  const amountCents = Number(subscription.metadata?.amountCents);
+  const feeCoverCents = Number(subscription.metadata?.feeCoverCents);
+  if (
+    !Number.isInteger(amountCents) ||
+    !Number.isInteger(feeCoverCents) ||
+    amountCents <= 0 ||
+    feeCoverCents < 0 ||
+    amountCents + feeCoverCents !== unitAmount
+  ) {
+    return null;
+  }
+  return { amountCents, feeCoverCents };
+}
+
 export async function handleFinanceStripeEvent(
   ctx: ActionCtx,
   event: StripeFinanceEvent,
@@ -681,6 +849,123 @@ export async function handleFinanceStripeEvent(
           amountCents: baseCents,
           feeCoverCents,
           communityId: metadata.communityId,
+        },
+      );
+      return;
+    }
+
+    // ------------------------------------------------------------------
+    // Recurring giving. http.ts routes these here only when
+    // `isConnectEvent(event)` — the platform-account versions belong to SaaS
+    // billing (see lib/finance/webhookRouting.ts).
+    // ------------------------------------------------------------------
+
+    case "checkout.session.completed": {
+      const session = event.data.object as StripeCheckoutSessionObject;
+      // A one-off donation Checkout needs nothing here: its money is
+      // recorded from `payment_intent.succeeded`, and it has no row to bind.
+      if (session.mode !== "subscription") {
+        return;
+      }
+      const subscriptionId = stripeId(session.subscription);
+      if (!subscriptionId) {
+        console.error(
+          `[finance] checkout.session.completed: subscription-mode session ${session.id} has no subscription`,
+        );
+        return;
+      }
+      await ctx.runMutation(
+        internal.functions.finance.giving.bindRecurringSubscription,
+        {
+          checkoutSessionId: session.id,
+          stripeSubscriptionId: subscriptionId,
+          stripeCustomerId: stripeId(session.customer) ?? undefined,
+          eventAccount: event.account,
+        },
+      );
+      return;
+    }
+
+    case "invoice.paid": {
+      // THE money event for monthly giving. A subscription's PaymentIntent
+      // carries no metadata of ours (subscription mode forbids
+      // `payment_intent_data`), so `payment_intent.succeeded` ignores it and
+      // this is where a recurring charge becomes a `donations` row.
+      const invoice = event.data.object as StripeInvoiceObject;
+      const subscriptionId = resolveInvoiceSubscriptionId(invoice);
+      if (!subscriptionId) {
+        return; // A one-off invoice — not a monthly gift.
+      }
+      const paymentIntentId = resolveInvoicePaymentIntentId(invoice);
+      if (!paymentIntentId) {
+        // Without it there is no idempotency key, and recording anyway would
+        // risk double-crediting on redelivery. Loud, because a real monthly
+        // gift landing here means money collected but not credited.
+        console.error(
+          `[finance] invoice.paid: invoice ${invoice.id ?? "?"} for subscription ${subscriptionId} has no payment_intent — not recording`,
+        );
+        return;
+      }
+      await ctx.runMutation(
+        internal.functions.finance.giving.recordRecurringDonationPaid,
+        {
+          stripeSubscriptionId: subscriptionId,
+          paymentIntentId,
+          amountPaidCents: invoice.amount_paid,
+          currentPeriodEnd: resolveInvoicePeriodEndMs(invoice),
+          eventAccount: event.account,
+        },
+      );
+      return;
+    }
+
+    case "invoice.payment_failed": {
+      const invoice = event.data.object as StripeInvoiceObject;
+      const subscriptionId = resolveInvoiceSubscriptionId(invoice);
+      if (!subscriptionId) {
+        return;
+      }
+      // No dunning email in this pass — the row going `past_due` is what the
+      // donor-facing management screen renders from.
+      await ctx.runMutation(
+        internal.functions.finance.giving.applyRecurringSubscriptionState,
+        {
+          stripeSubscriptionId: subscriptionId,
+          status: "past_due",
+          eventAccount: event.account,
+          reason: "invoice.payment_failed",
+        },
+      );
+      return;
+    }
+
+    case "customer.subscription.updated": {
+      const subscription = event.data.object as StripeSubscriptionObject;
+      const amounts = resolveSubscriptionAmounts(subscription);
+      await ctx.runMutation(
+        internal.functions.finance.giving.applyRecurringSubscriptionState,
+        {
+          stripeSubscriptionId: subscription.id,
+          status: mapStripeSubscriptionStatus(subscription.status) ?? undefined,
+          currentPeriodEnd: resolveSubscriptionPeriodEndMs(subscription),
+          amountCents: amounts?.amountCents,
+          feeCoverCents: amounts?.feeCoverCents,
+          eventAccount: event.account,
+          reason: "customer.subscription.updated",
+        },
+      );
+      return;
+    }
+
+    case "customer.subscription.deleted": {
+      const subscription = event.data.object as StripeSubscriptionObject;
+      await ctx.runMutation(
+        internal.functions.finance.giving.applyRecurringSubscriptionState,
+        {
+          stripeSubscriptionId: subscription.id,
+          status: "canceled",
+          eventAccount: event.account,
+          reason: "customer.subscription.deleted",
         },
       );
       return;

--- a/apps/convex/functions/finance/webhooks.ts
+++ b/apps/convex/functions/finance/webhooks.ts
@@ -629,9 +629,17 @@ interface StripeInvoiceObject {
   amount_paid?: number;
   /** Pre-2025-03-31 API versions put the subscription here. */
   subscription?: string | { id: string } | null;
-  /** 2025-03-31+ moved it under `parent.subscription_details`. */
+  /**
+   * Pre-2025-03-31 sibling of `subscription`, carrying an immutable snapshot
+   * of the subscription's metadata taken when the invoice was finalized.
+   */
+  subscription_details?: { metadata?: Record<string, string> | null } | null;
+  /** 2025-03-31+ moved both under `parent.subscription_details`. */
   parent?: {
-    subscription_details?: { subscription?: string | { id: string } | null } | null;
+    subscription_details?: {
+      subscription?: string | { id: string } | null;
+      metadata?: Record<string, string> | null;
+    } | null;
   } | null;
   /** Pre-2025-03-31 API versions put the PaymentIntent here. */
   payment_intent?: string | { id: string } | null;
@@ -677,6 +685,27 @@ export function resolveInvoiceSubscriptionId(
 }
 
 /**
+ * The `recurringDonations` row id we stamped on the subscription, as echoed
+ * back on the invoice, across API versions.
+ *
+ * A LOCATOR ONLY — never an amount, a fund, or a donor. Stripe does not
+ * guarantee webhook ORDER, so `invoice.paid` for the very first month can
+ * arrive before `checkout.session.completed` has bound the subscription id to
+ * the row, and a subscription-id lookup would then find nothing and silently
+ * drop a real payment. This is the second way to find the same row; what that
+ * row SAYS is still the only thing trusted about the gift, and the caller
+ * re-checks `event.account` against it exactly as it does on the normal path.
+ */
+export function resolveInvoiceRecurringDonationId(
+  invoice: StripeInvoiceObject,
+): string | null {
+  const id =
+    invoice.subscription_details?.metadata?.recurringDonationId ??
+    invoice.parent?.subscription_details?.metadata?.recurringDonationId;
+  return typeof id === "string" && id.length > 0 ? id : null;
+}
+
+/**
  * The PaymentIntent that paid an invoice, across API versions. This is the
  * idempotency key a recurring donation is recorded under — the same key a
  * one-off gift uses — so a redelivered `invoice.paid` can't double-credit.
@@ -691,6 +720,46 @@ export function resolveInvoicePaymentIntentId(
     if (id) return id;
   }
   return null;
+}
+
+/**
+ * Last resort for an invoice's PaymentIntent: ask Stripe for the invoice
+ * again, with `payments` expanded.
+ *
+ * `Invoice.payments` is typed OPTIONAL by the SDK — unlike `lines`,
+ * `amount_paid` and `parent`, which are not — the convention for a field that
+ * may only arrive when expanded, and webhook payloads are never expanded. When
+ * the delivered payload does carry it, `resolveInvoicePaymentIntentId` already
+ * answered and this never runs. When it doesn't, the alternative is dropping a
+ * monthly gift Stripe really did collect, which is far worse than one extra
+ * API call on a path that fires once a month per donor.
+ *
+ * Returns null on any failure — the caller then logs loudly and declines to
+ * record, rather than inventing an idempotency key.
+ */
+async function fetchInvoicePaymentIntentId(
+  invoiceId: string | undefined,
+  eventAccount: string | undefined,
+): Promise<string | null> {
+  if (!invoiceId || !eventAccount) return null;
+  try {
+    const Stripe = (await import("stripe")).default;
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: "2026-02-25.clover",
+    });
+    const fresh = (await stripe.invoices.retrieve(
+      invoiceId,
+      { expand: ["payments"] },
+      { stripeAccount: eventAccount },
+    )) as StripeInvoiceObject;
+    return resolveInvoicePaymentIntentId(fresh);
+  } catch (error) {
+    console.error(
+      `[finance] invoice.paid: could not re-read invoice ${invoiceId} for its PaymentIntent`,
+      error,
+    );
+    return null;
+  }
 }
 
 /** When the paid-for period ends, in ms — the donor-facing "next bill" date. */
@@ -896,7 +965,9 @@ export async function handleFinanceStripeEvent(
       if (!subscriptionId) {
         return; // A one-off invoice — not a monthly gift.
       }
-      const paymentIntentId = resolveInvoicePaymentIntentId(invoice);
+      const paymentIntentId =
+        resolveInvoicePaymentIntentId(invoice) ??
+        (await fetchInvoicePaymentIntentId(invoice.id, event.account));
       if (!paymentIntentId) {
         // Without it there is no idempotency key, and recording anyway would
         // risk double-crediting on redelivery. Loud, because a real monthly
@@ -914,6 +985,10 @@ export async function handleFinanceStripeEvent(
           amountPaidCents: invoice.amount_paid,
           currentPeriodEnd: resolveInvoicePeriodEndMs(invoice),
           eventAccount: event.account,
+          // Only used if the subscription id hasn't been bound to a row yet —
+          // see resolveInvoiceRecurringDonationId.
+          recurringDonationIdHint:
+            resolveInvoiceRecurringDonationId(invoice) ?? undefined,
         },
       );
       return;

--- a/apps/convex/http.ts
+++ b/apps/convex/http.ts
@@ -410,10 +410,11 @@ http.route({
  * - customer.subscription.deleted -> marks subscription as canceled
  * - invoice.payment_failed -> marks subscription as past_due
  *
- * The last three are shared with recurring giving (a monthly donation is a
- * Stripe Subscription on the community's CONNECTED account): when
- * `event.account` is set the event is a Connect event and goes to the finance
- * handler instead of billing. See lib/finance/webhookRouting.ts.
+ * ALL FOUR are shared with recurring giving (a monthly donation is a Stripe
+ * Subscription on the community's CONNECTED account, set up through a
+ * subscription-mode Checkout Session): when `event.account` is set the event
+ * is a Connect event and goes to the finance handler instead of billing. See
+ * lib/finance/webhookRouting.ts.
  */
 http.route({
   path: "/stripe-webhook",
@@ -457,7 +458,18 @@ http.route({
 
     try {
       switch (event.type) {
+        // Ambiguous for the same reason as the three cases below: a monthly
+        // donation is set up through a subscription-mode Checkout Session on
+        // the community's CONNECTED account, and lands here alongside a
+        // community's own SaaS-billing checkout. `event.account` is the
+        // routing key (lib/finance/webhookRouting.ts) — without this, the
+        // billing handler would read a donor's session as a community
+        // subscription activation.
         case "checkout.session.completed": {
+          if (isConnectEvent(event)) {
+            await handleFinanceStripeEvent(ctx, event);
+            break;
+          }
           const session = event.data.object;
           await ctx.runMutation(
             internal.functions.ee.billing.handleCheckoutCompleted,


### PR DESCRIPTION
## Summary

The backend for monthly recurring giving (approved design, artifact v5 R1–R3). Stacks on #736's foundations; #734's fee contract fully integrated (all charge values flow from the validated `prepareDonationIntent` seam — create and edit are unforgeable the same way).

- **`createRecurringDonationCheckoutSession`**: Checkout `mode:"subscription"`, monthly inline price on the connected account, Customer created-or-reused per donor+account, one active monthly per donor per fund (transaction-checked), abandoned sessions expire at Stripe and are superseded after 30 min (no 24h lockout), idempotency key includes amount+fee.
- **Webhooks**: `checkout.session.completed` (Connect) binds the subscription; `invoice.paid` records a donations row + ledger credit + receipt exactly once (replay-safe), crediting what Stripe actually collected; `customer.subscription.updated/deleted` + `invoice.payment_failed` drive the status lifecycle. Readers handle both pre- and post-2025-03-31 Stripe invoice shapes — getting that wrong silently drops gifts. `http.ts`: `checkout.session.completed` now routes by `isConnectEvent` (closing the trap #736 documented — a donor's session would have 500'd the billing handler into endless Stripe retries).
- **Management**: list/get for the dashboard box and give screen, `updateRecurringAmount` (same one-sided fee ceiling as create), `cancelRecurringDonation` (immediate — Stripe bills in advance so nothing is clawed back; "Ends future gifts. Past gifts stay."), `createCardUpdateSession` (Billing Portal on the connected account, payment-method-update only so our row stays truth).

## Evidence
```
finance-recurring-giving.test.ts: 39 passed (webhook shim drives the real dispatcher;
  replay-safety, both Stripe API shapes, fee ceiling on create AND update)
finance-webhook-routing.test.ts: 14 passed · full convex suite: 169 files / 3004 tests
tsc --noEmit: clean
```

### Deploy note
Function logic only — no schema/crons/migrations (schema shipped in #736). Merge deploys staging immediately.

### Owner checklist before real recurring gifts flow (staging + prod Stripe dashboards)
Add to the **Connect** webhook destination: `invoice.paid`, `invoice.payment_failed`, `customer.subscription.updated`, `customer.subscription.deleted` (documented in docs/secrets.md by #736).

UI PR (the three approved screens) follows, stacked on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcamCRXMUU1DhocRpr59YD