### PR TITLE
feat(finance-ui): monthly recurring giving — the three approved screens

### DIFF
--- a/apps/convex/__tests__/finance-recurring-giving.test.ts
+++ b/apps/convex/__tests__/finance-recurring-giving.test.ts
@@ -1340,7 +1340,7 @@ describe("createCardUpdateSession", () => {
     // The group id is percent-encoded into the path, as it is for the
     // Checkout return URLs — a Convex id contains a ";".
     expect((portal.params as any).return_url).toContain(
-      `/groups/${encodeURIComponent(s.groupId)}/give`,
+      `/groups/${encodeURIComponent(s.groupId)}/monthly-giving`,
     );
   });
 

--- a/apps/convex/__tests__/finance-recurring-giving.test.ts
+++ b/apps/convex/__tests__/finance-recurring-giving.test.ts
@@ -1339,8 +1339,12 @@ describe("createCardUpdateSession", () => {
     expect((portal.options as any).stripeAccount).toBe(CONNECTED_ACCOUNT);
     // The group id is percent-encoded into the path, as it is for the
     // Checkout return URLs — a Convex id contains a ";".
+    // `portal_return=1` is load-bearing, not cosmetic: on native this URL
+    // opens in the portal's own auth-less in-app browser, and the flag is how
+    // the manage screen tells that dead end apart from "auth still restoring"
+    // and shows a close-this-window notice instead of an endless skeleton.
     expect((portal.params as any).return_url).toContain(
-      `/groups/${encodeURIComponent(s.groupId)}/monthly-giving`,
+      `/groups/${encodeURIComponent(s.groupId)}/monthly-giving?portal_return=1`,
     );
   });
 

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -1542,9 +1542,17 @@ export const sendDonationReceipt = internalAction({
 // ============================================================================
 
 /** The dedicated manage screen for a monthly gift — where the Stripe Billing
- * Portal returns the donor after a card update. */
+ * Portal returns the donor after a card update.
+ *
+ * `portal_return=1` is not decoration. On native the portal opens in an
+ * auth-less in-app browser, so this URL loads the WEB app with no session and
+ * every authenticated query on the manage screen skips — a skeleton that never
+ * fills. The flag is how that screen tells "came back from Stripe with no
+ * session" (show a terminal "you can close this window" notice) apart from
+ * "signed in, auth still restoring" (keep the skeleton). Same shape as
+ * `?giving=cancelled` on the give sheet. */
 function buildRecurringManageUrl(groupId: string): string {
-  return `${DOMAIN_CONFIG.appUrl}/groups/${encodeURIComponent(groupId)}/monthly-giving`;
+  return `${DOMAIN_CONFIG.appUrl}/groups/${encodeURIComponent(groupId)}/monthly-giving?portal_return=1`;
 }
 
 /** Copy the donor actually reads when they already give monthly to this fund. */

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -1541,11 +1541,10 @@ export const sendDonationReceipt = internalAction({
 //     subscription later, by `checkout.session.completed`.
 // ============================================================================
 
-/** The give screen's own route, which doubles as the manage screen today.
- * When a dedicated "manage my monthly gift" screen ships, this is the one
- * line that changes. */
+/** The dedicated manage screen for a monthly gift — where the Stripe Billing
+ * Portal returns the donor after a card update. */
 function buildRecurringManageUrl(groupId: string): string {
-  return `${DOMAIN_CONFIG.appUrl}/groups/${encodeURIComponent(groupId)}/give`;
+  return `${DOMAIN_CONFIG.appUrl}/groups/${encodeURIComponent(groupId)}/monthly-giving`;
 }
 
 /** Copy the donor actually reads when they already give monthly to this fund. */

--- a/apps/mobile/app/groups/[group_id]/give-success.tsx
+++ b/apps/mobile/app/groups/[group_id]/give-success.tsx
@@ -47,6 +47,8 @@ export default function GiveSuccessScreen() {
     fund?: string;
     community?: string;
     session_id?: string;
+    /** `"1"` for a monthly gift — see `parseGiveSuccessParams`. */
+    recurring?: string;
   }>();
 
   const reduceMotion = useReduceMotion();

--- a/apps/mobile/app/groups/[group_id]/monthly-giving.tsx
+++ b/apps/mobile/app/groups/[group_id]/monthly-giving.tsx
@@ -1,0 +1,3 @@
+import { MonthlyGivingScreen } from "@features/finance/member/MonthlyGivingScreen";
+
+export default MonthlyGivingScreen;

--- a/apps/mobile/components/wa/WaCell.tsx
+++ b/apps/mobile/components/wa/WaCell.tsx
@@ -71,6 +71,12 @@ export interface WaCellProps {
   title: string;
   /** Sub-line under the title (e.g. "Lock chat"'s explanatory text) — grows the cell to the tall variant. */
   description?: string;
+  /**
+   * Overrides the sub-line's default tertiary gray. For the rare row whose
+   * sub-line carries a state the reader must not skim past (a failing payment,
+   * an expired invite) — not for decoration: WA sub-lines are gray.
+   */
+  descriptionColor?: string;
   /** Right-aligned value before the chevron, e.g. "5.4 MB", "Off", "On" (`navigational` only). */
   value?: string;
   /** Replaces the default value+chevron block entirely (`navigational` only) — e.g. a copy-icon button. */
@@ -94,6 +100,7 @@ export function WaCell({
   iconColor,
   title,
   description,
+  descriptionColor,
   value,
   trailingAccessory,
   variant = 'navigational',
@@ -164,7 +171,9 @@ export function WaCell({
             {title}
           </Text>
           {description ? (
-            <Text style={[styles.description, { color: colors.textTertiary }]}>{description}</Text>
+            <Text style={[styles.description, { color: descriptionColor ?? colors.textTertiary }]}>
+              {description}
+            </Text>
           ) : null}
         </View>
 

--- a/apps/mobile/features/finance/member/FundScreen.tsx
+++ b/apps/mobile/features/finance/member/FundScreen.tsx
@@ -32,6 +32,15 @@ export function FundScreen() {
     fundId ? { fundId } : "skip",
   );
 
+  // The viewer's own monthly gift to this fund, if any. Donor-scoped by
+  // construction on the server (`by_donor_fund`), so this is never anyone
+  // else's giving — and it returns `null` for a `pending`/canceled row, which
+  // is exactly when the dashboard box should not exist.
+  const recurring = useAuthenticatedQuery(
+    api.functions.finance.giving.getRecurringForFund,
+    fundId ? { fundId } : "skip",
+  );
+
   // Manager+ (or leader/community admin) viewers get the "Fund settings" cell
   // linking to the leader giving hub (approvals + roles) — the only nav entry
   // point into it besides deep links, since the per-group toolbar config is
@@ -68,6 +77,12 @@ export function FundScreen() {
         onBack={handleBack}
         onGivePress={handleGivePress}
         onGetReimbursedPress={() => setShowReimbursement(true)}
+        recurring={recurring}
+        onManageRecurringPress={
+          groupId
+            ? () => router.push(`/groups/${groupId}/monthly-giving` as any)
+            : undefined
+        }
         onManagePress={
           canManage && groupId
             ? () =>

--- a/apps/mobile/features/finance/member/FundScreenView.tsx
+++ b/apps/mobile/features/finance/member/FundScreenView.tsx
@@ -45,12 +45,25 @@ import {
   expenseStatusNote,
 } from "./labels";
 import { GIVING_GOLD, GIVING_GOLD_TINT } from "./giveTheme";
+import {
+  isLiveRecurring,
+  formatMonthlyTitle,
+  formatMonthlySubtitle,
+  type RecurringSummary,
+} from "./recurring";
 import type { FundActivityEntry, FundOverview, MyExpense } from "./types";
 
 /** Hero balance type size — the one number this whole screen exists to show. */
 const BALANCE_SIZE = 46;
 /** Fund-glyph tile edge, sized to sit above the balance without competing. */
 const GLYPH_TILE = 44;
+/**
+ * Gold tile edge inside the monthly box's cell. A hair wider than
+ * `WA_CELL_ICON_COLUMN` (24) so the disc reads as a tile rather than a bare
+ * glyph; the 4pt it borrows comes out of the 16pt icon→label gap, which stays
+ * comfortably wider than the gap on a plain cell's 24pt glyph.
+ */
+const MONTHLY_TILE = 28;
 
 export interface FundScreenViewProps {
   /** `undefined` while loading, `null` when giving isn't set up for this group. */
@@ -60,6 +73,14 @@ export interface FundScreenViewProps {
   onBack: () => void;
   onGivePress: () => void;
   onGetReimbursedPress: () => void;
+  /**
+   * The viewer's own monthly gift to this fund. `undefined` while loading,
+   * `null` when they have none. A `pending` or `canceled` row renders nothing
+   * at all — see `isLiveRecurring`.
+   */
+  recurring?: RecurringSummary | null;
+  /** Opens the monthly-giving manage screen. */
+  onManageRecurringPress?: () => void;
   /**
    * Set for manager+ viewers — renders the leaders-only "Fund settings" cell
    * that opens the leader giving hub (approvals + roles). Its presence IS the
@@ -74,6 +95,8 @@ export function FundScreenView({
   onBack,
   onGivePress,
   onGetReimbursedPress,
+  recurring,
+  onManageRecurringPress,
   onManagePress,
 }: FundScreenViewProps) {
   const { colors, isDark } = useTheme();
@@ -181,6 +204,43 @@ export function FundScreenView({
               )}
             </WaInsetGroup>
           </View>
+
+          {/* YOUR MONTHLY GIVING — pinned between the group's activity and the
+              viewer's own errands, because that is exactly what it is: the
+              hinge from "here is what the fund did" to "here is your business
+              with it". Above Reimbursements on purpose — a live monthly gift
+              is standing money the donor should be able to see and stop
+              without scrolling past a rare errand to reach it.
+
+              Rendered only for a gift that is actually collecting: a `pending`
+              row (donor still in Checkout) or a canceled one gets no group at
+              all, header included, rather than an empty card. */}
+          {isLiveRecurring(recurring) && (
+            <View style={styles.group}>
+              <WaInsetGroup>
+                <WaCell
+                  testID="fund-monthly-box"
+                  iconNode={
+                    <View
+                      style={[styles.monthlyTile, { backgroundColor: GIVING_GOLD_TINT }]}
+                    >
+                      <Ionicons name="repeat" size={16} color={GIVING_GOLD} />
+                    </View>
+                  }
+                  title={formatMonthlyTitle(recurring.amountCents)}
+                  description={formatMonthlySubtitle(recurring)}
+                  // A failing card has to LOOK different, not just read
+                  // differently — the sub-line's default gray is the same ink
+                  // "Next gift Sep 1" wears, and a donor scanning the screen
+                  // would skim straight past the one row that needs them.
+                  descriptionColor={
+                    recurring.status === "past_due" ? colors.warning : undefined
+                  }
+                  onPress={onManageRecurringPress}
+                />
+              </WaInsetGroup>
+            </View>
+          )}
 
           {/* REIMBURSEMENTS — the ask sits first as a normal navigational cell,
               then the viewer's own requests below it, so "Get reimbursed" and
@@ -358,6 +418,13 @@ const styles = StyleSheet.create({
   group: { marginTop: WA_GROUP_SPACING },
 
   hero: { alignItems: "center", paddingHorizontal: WA_CELL_PADDING, paddingVertical: 24 },
+  monthlyTile: {
+    width: MONTHLY_TILE,
+    height: MONTHLY_TILE,
+    borderRadius: MONTHLY_TILE / 2,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   glyphTile: {
     width: GLYPH_TILE,
     height: GLYPH_TILE,

--- a/apps/mobile/features/finance/member/GiveScreen.tsx
+++ b/apps/mobile/features/finance/member/GiveScreen.tsx
@@ -24,8 +24,20 @@
  *     browser — where every `useAuthenticatedQuery` skips and the screen would
  *     sit on a skeleton forever. Unauthenticated + cancelled renders a static
  *     notice instead.
+ *
+ * MONTHLY gifts reuse all of it with one substitution. Subscription-mode
+ * Checkout has NO PaymentIntent, so there is nothing for
+ * `getCheckoutSessionStatus` to watch. Instead the waiting step subscribes to
+ * `getRecurringForFund` — a live (not polled) Convex query that returns only
+ * `active`/`past_due` rows — and advances when it hands back the very row this
+ * submission created. Stripe drives that flip in two beats:
+ * `checkout.session.completed` binds the subscription to the pending row, then
+ * `invoice.paid` activates it. Only `active` advances: `past_due` means the
+ * first invoice failed, and a thank-you screen for a declined card is a lie the
+ * donor's statement contradicts — they stay on the waiting step with Reopen and
+ * Cancel, exactly as a failed one-off does.
  */
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Platform } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
@@ -37,7 +49,12 @@ import {
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { formatError } from "@/utils/error-handling";
-import { GiveScreenView, GiveCancelledNotice, type GiveStep } from "./GiveScreenView";
+import {
+  GiveScreenView,
+  GiveCancelledNotice,
+  type GiveStep,
+  type GiveFrequency,
+} from "./GiveScreenView";
 import { estimateCoverFeesCents, resolveGiveAmountCents } from "./amount";
 import { urlSafeName } from "./giveSuccessParams";
 import type { CheckoutSession } from "./types";
@@ -66,8 +83,12 @@ export function GiveScreen() {
   const createDonationCheckoutSession = useAuthenticatedAction(
     api.functions.finance.giving.createDonationCheckoutSession,
   );
+  const createRecurringDonationCheckoutSession = useAuthenticatedAction(
+    api.functions.finance.giving.createRecurringDonationCheckoutSession,
+  );
 
   const [step, setStep] = useState<GiveStep>("amount");
+  const [frequency, setFrequency] = useState<GiveFrequency>("once");
   const [selectedPresetCents, setSelectedPresetCents] = useState<number | null>(null);
   const [customAmountText, setCustomAmountText] = useState("");
   const [coverFees, setCoverFees] = useState(false);
@@ -96,53 +117,120 @@ export function GiveScreen() {
     watchedPaymentIntentId ? { paymentIntentId: watchedPaymentIntentId } : "skip",
   );
 
+  // The monthly equivalent. `getRecurringForFund` is donor-scoped and returns
+  // only a LIVE row, so "it came back non-null with our id" is precisely
+  // "Stripe bound the subscription and the first invoice was paid".
+  const watchedRecurringDonationId =
+    step === "confirmation" ? (checkoutSession?.recurringDonationId ?? null) : null;
+  const recurringStatus = useAuthenticatedQuery(
+    api.functions.finance.giving.getRecurringForFund,
+    watchedRecurringDonationId && context?.fundId
+      ? { fundId: context.fundId as Id<"funds"> }
+      : "skip",
+  );
+
   // Guards the redirect against a re-render firing it twice (the query stays
-  // "complete" once it flips, and `router.replace` isn't idempotent).
+  // "complete" once it flips, and `router.replace` isn't idempotent). Shared
+  // by both watchers — only one is ever live, and a single latch means neither
+  // can double-navigate the other.
   const advancedRef = useRef(false);
+
+  /**
+   * Hands the donor to the thank-you screen. Shared by both watchers so the
+   * one-off and monthly paths can never drift on the query string the
+   * zero-auth success screen renders from.
+   */
+  const goToThankYou = useCallback(
+    (gift: {
+      amountCents: number;
+      fund: string;
+      community: string;
+      recurring: boolean;
+    }) => {
+      // The browser sheet is a native-only surface; on web the donor is already
+      // ON Stripe's page and its own `success_url` navigation does this job.
+      // Dismissing is a courtesy, never a precondition for the thank-you: when
+      // nothing is open this throws on some platforms and rejects on others, and
+      // the `.then` wrapper swallows both.
+      if (Platform.OS !== "web") {
+        Promise.resolve()
+          .then(() => WebBrowser.dismissBrowser())
+          .catch(() => {});
+      }
+
+      // `urlSafeName`, not bare `encodeURIComponent`: it throws on an unpaired
+      // surrogate, and throwing here — after `advancedRef` has latched — costs
+      // the donor the thank-you screen with no retry. Same helper shape the
+      // backend uses to build Stripe's success_url.
+      const query =
+        `?amount=${gift.amountCents}` +
+        `&fund=${urlSafeName(gift.fund)}` +
+        `&community=${urlSafeName(gift.community)}` +
+        // Matches `buildGiveReturnUrls`' own flag, so a monthly gift reads the
+        // same whether the donor came back through Stripe's redirect or
+        // through this watcher.
+        (gift.recurring ? "&recurring=1" : "");
+      router.replace(`/groups/${groupId}/give-success${query}` as any);
+    },
+    [groupId, router],
+  );
 
   useEffect(() => {
     if (checkoutStatus?.status !== "complete") return;
     if (advancedRef.current) return;
     advancedRef.current = true;
 
-    // The browser sheet is a native-only surface; on web the donor is already
-    // ON Stripe's page and its own `success_url` navigation does this job.
-    // Dismissing is a courtesy, never a precondition for the thank-you: when
-    // nothing is open this throws on some platforms and rejects on others, and
-    // the `.then` wrapper swallows both.
-    if (Platform.OS !== "web") {
-      Promise.resolve()
-        .then(() => WebBrowser.dismissBrowser())
-        .catch(() => {});
-    }
-
     // The query's own values win over local state: they're what was actually
     // charged and recorded, where the local total is only what was requested.
     const giftCents = resolveGiveAmountCents(selectedPresetCents, customAmountText) ?? 0;
     const localTotalCents =
       giftCents + (coverFees ? estimateCoverFeesCents(giftCents) : 0);
-    const amountCents = checkoutStatus.amountCents ?? localTotalCents;
-    const fund = checkoutStatus.fundName ?? context?.fundName ?? "";
-    const community = checkoutStatus.communityName ?? context?.communityLegalName ?? "";
-
-    // `urlSafeName`, not bare `encodeURIComponent`: it throws on an unpaired
-    // surrogate, and throwing here — after `advancedRef` has latched — costs
-    // the donor the thank-you screen with no retry. Same helper shape the
-    // backend uses to build Stripe's success_url.
-    const query =
-      `?amount=${amountCents}` +
-      `&fund=${urlSafeName(fund)}` +
-      `&community=${urlSafeName(community)}`;
-    router.replace(`/groups/${groupId}/give-success${query}` as any);
+    goToThankYou({
+      amountCents: checkoutStatus.amountCents ?? localTotalCents,
+      fund: checkoutStatus.fundName ?? context?.fundName ?? "",
+      community: checkoutStatus.communityName ?? context?.communityLegalName ?? "",
+      recurring: false,
+    });
   }, [
     checkoutStatus,
     context?.fundName,
     context?.communityLegalName,
     coverFees,
     customAmountText,
-    groupId,
-    router,
+    goToThankYou,
     selectedPresetCents,
+  ]);
+
+  // The monthly watcher. Two guards beyond "a row came back":
+  //
+  //  - the id must be THIS submission's, so a row created in another tab (or
+  //    an unrelated live gift the donor somehow has) can't fake a thank-you;
+  //  - the status must be `active`, not merely live. `past_due` means the very
+  //    first invoice failed, and thanking someone for a declined card is the
+  //    one screen that would stop them from fixing it.
+  useEffect(() => {
+    if (!watchedRecurringDonationId) return;
+    if (!recurringStatus || recurringStatus.id !== watchedRecurringDonationId) return;
+    if (recurringStatus.status !== "active") return;
+    if (advancedRef.current) return;
+    advancedRef.current = true;
+
+    // Server truth again: the row holds the validated gift/fee split, so the
+    // amount shown is what the subscription actually bills.
+    goToThankYou({
+      amountCents: recurringStatus.amountCents + recurringStatus.feeCoverCents,
+      fund: recurringStatus.fundName || (context?.fundName ?? ""),
+      // The recurring row carries no community name — the give context is the
+      // only place this screen has one, and it's the same community either way.
+      community: context?.communityLegalName ?? "",
+      recurring: true,
+    });
+  }, [
+    context?.communityLegalName,
+    context?.fundName,
+    goToThankYou,
+    recurringStatus,
+    watchedRecurringDonationId,
   ]);
 
   // Stripe's cancel_url inside the auth-less in-app browser. Placed after every
@@ -176,6 +264,18 @@ export function GiveScreen() {
     }
   };
 
+  const handleSelectFrequency = (next: GiveFrequency) => {
+    setFrequency(next);
+    // A rejected monthly submission left an error the donor can't act on once
+    // they've switched back to a one-off (and vice versa).
+    setError(null);
+  };
+
+  const handleManageRecurring = () => {
+    if (!groupId) return;
+    router.push(`/groups/${groupId}/monthly-giving` as any);
+  };
+
   const handleSelectPreset = (cents: number) => {
     setSelectedPresetCents((current) => (current === cents ? null : cents));
     setCustomAmountText("");
@@ -190,6 +290,10 @@ export function GiveScreen() {
 
   const handleContinue = async () => {
     if (!context) return;
+    // One active monthly per fund is enforced server-side; the view swaps the
+    // CTA for a "you already give $X/month" notice, and this is the matching
+    // guard for anything that reaches the handler anyway.
+    if (frequency === "monthly" && context.existingRecurring) return;
     const amountCents = resolveGiveAmountCents(selectedPresetCents, customAmountText);
     if (!amountCents) return;
 
@@ -197,12 +301,22 @@ export function GiveScreen() {
     setError(null);
     try {
       const coverFeesCents = coverFees ? estimateCoverFeesCents(amountCents) : 0;
-      const result = await createDonationCheckoutSession({
+      const args = {
         fundId: context.fundId as Id<"funds">,
         amountCents,
         coverFeesCents,
         idempotencyNonce: idempotencyNonceRef.current,
-      });
+      };
+      // Subscription-mode Checkout returns no PaymentIntent, so the monthly
+      // result is normalised into the same shape with the recurring row id in
+      // place of it — that id is what the waiting step watches.
+      const result: CheckoutSession =
+        frequency === "monthly"
+          ? {
+              ...(await createRecurringDonationCheckoutSession(args)),
+              paymentIntentId: null,
+            }
+          : await createDonationCheckoutSession(args);
       setCheckoutSession(result);
       // Rotate the nonce now that this submission has its session: a failed
       // call keeps the old nonce (retry = same idempotency key = no double
@@ -240,20 +354,29 @@ export function GiveScreen() {
     <GiveScreenView
       context={context}
       step={step}
+      frequency={frequency}
       selectedPresetCents={selectedPresetCents}
       customAmountText={customAmountText}
       coverFees={coverFees}
       submitting={submitting}
       error={error}
       checkoutSession={checkoutSession}
-      canAutoAdvance={checkoutSession?.paymentIntentId != null}
+      // Whichever join key this gift's path actually has. Monthly gets the
+      // recurring row id; a one-off gets its PaymentIntent. Neither present
+      // means nothing is watching, and the waiting step offers its way out.
+      canAutoAdvance={
+        checkoutSession?.paymentIntentId != null ||
+        checkoutSession?.recurringDonationId != null
+      }
       onBack={handleBack}
+      onSelectFrequency={handleSelectFrequency}
       onSelectPreset={handleSelectPreset}
       onCustomAmountChange={handleCustomAmountChange}
       onToggleCoverFees={setCoverFees}
       onContinue={handleContinue}
       onReopenCheckout={handleReopenCheckout}
       onFinishManually={handleFinishManually}
+      onManageRecurringPress={handleManageRecurring}
     />
   );
 }

--- a/apps/mobile/features/finance/member/GiveScreen.tsx
+++ b/apps/mobile/features/finance/member/GiveScreen.tsx
@@ -48,7 +48,7 @@ import {
   api,
 } from "@services/api/convex";
 import type { Id } from "@services/api/convex";
-import { formatError } from "@/utils/error-handling";
+import { errorMessage } from "@/utils/error-handling";
 import {
   GiveScreenView,
   GiveCancelledNotice,
@@ -327,7 +327,15 @@ export function GiveScreen() {
       setStep("confirmation");
       await openCheckoutUrl(result.url);
     } catch (err) {
-      setError(formatError(err, "Couldn't start this gift. Please try again."));
+      setError(
+        // `errorMessage`, not `formatError`: the rejections this call can return
+        // are the actionable ones ("Finish that checkout, or try again in a few
+        // minutes.", "You already give monthly to this fund."), and a ConvexError
+        // carries them on `.data`. In production `.message` is only
+        // "[CONVEX A(...)] [Request ID: ...] Server Error", so parsing the
+        // message would replace every one of them with the fallback below.
+        errorMessage(err, "Couldn't start this gift. Please try again."),
+      );
     } finally {
       setSubmitting(false);
     }

--- a/apps/mobile/features/finance/member/GiveScreen.tsx
+++ b/apps/mobile/features/finance/member/GiveScreen.tsx
@@ -86,11 +86,6 @@ export function GiveScreen() {
   const createRecurringDonationCheckoutSession = useAuthenticatedAction(
     api.functions.finance.giving.createRecurringDonationCheckoutSession,
   );
-  // Only ever called on the row THIS screen just created and the donor then
-  // walked away from — see `handleBack`.
-  const cancelRecurringDonation = useAuthenticatedAction(
-    api.functions.finance.giving.cancelRecurringDonation,
-  );
 
   const [step, setStep] = useState<GiveStep>("amount");
   const [frequency, setFrequency] = useState<GiveFrequency>("once");
@@ -251,43 +246,15 @@ export function GiveScreen() {
     return <GiveCancelledNotice />;
   }
 
-  const handleBack = async () => {
+  const handleBack = () => {
     if (step === "confirmation") {
       // Editing the gift after a session was created starts a NEW submission
       // — drop the stale session so "Reopen" can't relaunch the old amount.
       // (The nonce was already rotated when that session was created, so the
       // next Give gets a fresh idempotency key; reusing the old key with
       // different params would make Stripe reject the request.)
-      const abandonedRecurringId = checkoutSession?.recurringDonationId;
       setCheckoutSession(null);
       setStep("amount");
-
-      // A MONTHLY submission left a `pending` recurringDonations row on the
-      // server, and that row blocks a new monthly gift to this fund for the
-      // whole `PENDING_CHECKOUT_GRACE_MS` window (30 minutes) while its Stripe
-      // page stays live. Clearing local state alone would therefore turn
-      // "Cancel this gift" into "you may not give monthly for half an hour",
-      // with the reason ("a checkout is already in progress") describing a
-      // page the donor just walked away from. Release it: the action expires
-      // the Checkout Session and marks the row canceled.
-      //
-      // Awaited behind `submitting` rather than fired and forgotten, because
-      // the give CTA is disabled while submitting — that is what stops an
-      // immediate re-tap from racing its own release and hitting the block.
-      // Failures are swallowed: the donor lands exactly where an unreleased
-      // row would have left them, and the row's grace window still expires.
-      if (abandonedRecurringId) {
-        setSubmitting(true);
-        try {
-          await cancelRecurringDonation({
-            recurringDonationId: abandonedRecurringId as Id<"recurringDonations">,
-          });
-        } catch {
-          // Intentionally silent — nothing the donor can act on here.
-        } finally {
-          setSubmitting(false);
-        }
-      }
       return;
     }
     if (router.canGoBack()) {

--- a/apps/mobile/features/finance/member/GiveScreen.tsx
+++ b/apps/mobile/features/finance/member/GiveScreen.tsx
@@ -86,6 +86,11 @@ export function GiveScreen() {
   const createRecurringDonationCheckoutSession = useAuthenticatedAction(
     api.functions.finance.giving.createRecurringDonationCheckoutSession,
   );
+  // Only ever called on the row THIS screen just created and the donor then
+  // walked away from — see `handleBack`.
+  const cancelRecurringDonation = useAuthenticatedAction(
+    api.functions.finance.giving.cancelRecurringDonation,
+  );
 
   const [step, setStep] = useState<GiveStep>("amount");
   const [frequency, setFrequency] = useState<GiveFrequency>("once");
@@ -246,15 +251,43 @@ export function GiveScreen() {
     return <GiveCancelledNotice />;
   }
 
-  const handleBack = () => {
+  const handleBack = async () => {
     if (step === "confirmation") {
       // Editing the gift after a session was created starts a NEW submission
       // — drop the stale session so "Reopen" can't relaunch the old amount.
       // (The nonce was already rotated when that session was created, so the
       // next Give gets a fresh idempotency key; reusing the old key with
       // different params would make Stripe reject the request.)
+      const abandonedRecurringId = checkoutSession?.recurringDonationId;
       setCheckoutSession(null);
       setStep("amount");
+
+      // A MONTHLY submission left a `pending` recurringDonations row on the
+      // server, and that row blocks a new monthly gift to this fund for the
+      // whole `PENDING_CHECKOUT_GRACE_MS` window (30 minutes) while its Stripe
+      // page stays live. Clearing local state alone would therefore turn
+      // "Cancel this gift" into "you may not give monthly for half an hour",
+      // with the reason ("a checkout is already in progress") describing a
+      // page the donor just walked away from. Release it: the action expires
+      // the Checkout Session and marks the row canceled.
+      //
+      // Awaited behind `submitting` rather than fired and forgotten, because
+      // the give CTA is disabled while submitting — that is what stops an
+      // immediate re-tap from racing its own release and hitting the block.
+      // Failures are swallowed: the donor lands exactly where an unreleased
+      // row would have left them, and the row's grace window still expires.
+      if (abandonedRecurringId) {
+        setSubmitting(true);
+        try {
+          await cancelRecurringDonation({
+            recurringDonationId: abandonedRecurringId as Id<"recurringDonations">,
+          });
+        } catch {
+          // Intentionally silent — nothing the donor can act on here.
+        } finally {
+          setSubmitting(false);
+        }
+      }
       return;
     }
     if (router.canGoBack()) {

--- a/apps/mobile/features/finance/member/GiveScreenView.tsx
+++ b/apps/mobile/features/finance/member/GiveScreenView.tsx
@@ -12,7 +12,10 @@
  * the moment the money lands, so the waiting step's own buttons (Reopen /
  * Cancel) are the manual fallback, not the happy path. There is deliberately
  * no "Done": a donor tapping it mid-payment would leave with no idea whether
- * their gift went through. The one exception is `canAutoAdvance === false`
+ * their gift went through. A MONTHLY gift takes the same route with a
+ * different watcher (`GiveScreen` subscribes to the recurring row rather than
+ * a PaymentIntent — subscription-mode Checkout has none), so every state on
+ * this screen is shared. The one exception is `canAutoAdvance === false`
  * (Stripe returned no PaymentIntent, so nothing is watching) — there the
  * screen can never resolve itself, and an exit that doesn't cancel the gift
  * is the only thing standing between the donor and a duplicate donation.
@@ -38,6 +41,7 @@ import {
   WaInsetGroup,
   WaCell,
   WA_GROUP_MARGIN,
+  WA_GROUP_RADIUS,
   WA_GROUP_SPACING,
   WA_CELL_PADDING,
   WA_TYPE_FOOTNOTE,
@@ -49,9 +53,18 @@ import {
 import { formatCents } from "../format";
 import { estimateCoverFeesCents, resolveGiveAmountCents } from "./amount";
 import { GIVING_GOLD, GIVING_GOLD_TINT } from "./giveTheme";
+import { formatMonthlyRate } from "./recurring";
 import type { CheckoutSession, GivingContext } from "./types";
 
 export type GiveStep = "amount" | "confirmation";
+
+/**
+ * One time vs monthly. Chosen ABOVE the amount, not below it: the amount a
+ * donor picks depends on how often they're being asked for it, and a
+ * frequency control discovered after the fact makes the number they already
+ * typed wrong.
+ */
+export type GiveFrequency = "once" | "monthly";
 
 /** Typed-amount display size — the give sheet's one hero number. */
 const AMOUNT_SIZE = 56;
@@ -60,6 +73,7 @@ export interface GiveScreenViewProps {
   /** `undefined` while loading, `null` when giving isn't set up for this group. */
   context: GivingContext | null | undefined;
   step: GiveStep;
+  frequency: GiveFrequency;
   selectedPresetCents: number | null;
   customAmountText: string;
   coverFees: boolean;
@@ -73,6 +87,7 @@ export interface GiveScreenViewProps {
    */
   canAutoAdvance: boolean;
   onBack: () => void;
+  onSelectFrequency: (frequency: GiveFrequency) => void;
   onSelectPreset: (cents: number) => void;
   onCustomAmountChange: (text: string) => void;
   onToggleCoverFees: (value: boolean) => void;
@@ -80,11 +95,14 @@ export interface GiveScreenViewProps {
   onReopenCheckout: () => void;
   /** Leaves the give flow for the fund without touching the gift in flight. */
   onFinishManually: () => void;
+  /** Opens the monthly-giving manage screen for the gift they already have. */
+  onManageRecurringPress: () => void;
 }
 
 export function GiveScreenView({
   context,
   step,
+  frequency,
   selectedPresetCents,
   customAmountText,
   coverFees,
@@ -93,20 +111,32 @@ export function GiveScreenView({
   checkoutSession,
   canAutoAdvance,
   onBack,
+  onSelectFrequency,
   onSelectPreset,
   onCustomAmountChange,
   onToggleCoverFees,
   onContinue,
   onReopenCheckout,
   onFinishManually,
+  onManageRecurringPress,
 }: GiveScreenViewProps) {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
 
+  const monthly = frequency === "monthly";
   const amountCents = resolveGiveAmountCents(selectedPresetCents, customAmountText);
   const feeCents = coverFees && amountCents ? estimateCoverFeesCents(amountCents) : 0;
   const totalCents = (amountCents ?? 0) + feeCents;
-  const canContinue = !!amountCents && !submitting;
+  // One active monthly per fund is a BACKEND rule — the create action rejects a
+  // second one. The CTA steps aside rather than letting the donor find that out
+  // from an error after a tap; switching back to One time brings it straight
+  // back, so nothing here is a dead end.
+  const existingRecurring = context?.existingRecurring ?? null;
+  const blockedByExistingRecurring = monthly && !!existingRecurring;
+  const canContinue = !!amountCents && !submitting && !blockedByExistingRecurring;
+  const ctaLabel = amountCents
+    ? `Give ${formatCents(totalCents)}${monthly ? " monthly" : ""}`
+    : "Give";
 
   // The big display IS the input: a tapped preset writes its dollars into the
   // same field the donor types in, so there is one amount on screen and one
@@ -146,6 +176,7 @@ export function GiveScreenView({
         <WaitingStep
           fundName={context.fundName}
           totalCents={totalCents}
+          monthly={monthly}
           canReopen={!!checkoutSession}
           canAutoAdvance={canAutoAdvance}
           onReopenCheckout={onReopenCheckout}
@@ -166,6 +197,48 @@ export function GiveScreenView({
             <Text style={[styles.kicker, { color: colors.textSecondary }]}>
               Tax-deductible gift to {context.communityLegalName}
             </Text>
+
+            {/* Frequency first, then the amount — same chip vocabulary as the
+                presets below (fill = chosen), so the whole form reads as one
+                row of choices rather than two unrelated controls. */}
+            <View style={styles.frequencyRow}>
+              {(
+                [
+                  ["once", "One time"],
+                  ["monthly", "Monthly"],
+                ] as const
+              ).map(([value, label]) => {
+                const selected = frequency === value;
+                return (
+                  <Pressable
+                    key={value}
+                    onPress={() => onSelectFrequency(value)}
+                    accessibilityRole="button"
+                    accessibilityLabel={label}
+                    accessibilityState={{ selected }}
+                    testID={`give-frequency-${value}`}
+                    style={({ pressed }) => [
+                      styles.presetChip,
+                      {
+                        backgroundColor: selected
+                          ? colors.buttonPrimary
+                          : colors.surfaceGrouped,
+                      },
+                      pressed && styles.pressed,
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.presetChipText,
+                        { color: selected ? colors.buttonPrimaryText : colors.text },
+                      ]}
+                    >
+                      {label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
 
             <WaInsetGroup>
               <View style={styles.amountCard}>
@@ -249,29 +322,53 @@ export function GiveScreenView({
               doesn't have, and it fills with the community accent where the
               approved design calls for the neutral dark primary. */}
           <View style={[styles.ctaBar, { paddingBottom: insets.bottom + 12 }]}>
-            <Pressable
-              onPress={onContinue}
-              disabled={!canContinue}
-              accessibilityRole="button"
-              accessibilityLabel={amountCents ? `Give ${formatCents(totalCents)}` : "Give"}
-              accessibilityState={{ disabled: !canContinue }}
-              style={({ pressed }) => [
-                styles.ctaPill,
-                {
-                  backgroundColor: canContinue ? colors.buttonPrimary : colors.buttonDisabled,
-                },
-                pressed && styles.pressed,
-              ]}
-            >
-              <Text
-                style={[
-                  styles.ctaLabel,
-                  { color: canContinue ? colors.buttonPrimaryText : colors.textSecondary },
+            {blockedByExistingRecurring ? (
+              <View
+                testID="give-existing-recurring-notice"
+                style={[styles.noticeCard, { backgroundColor: colors.surfaceGrouped }]}
+              >
+                <Text style={[styles.noticeText, { color: colors.text }]}>
+                  You already give {formatMonthlyRate(existingRecurring.amountCents)}{" "}
+                  to this fund
+                </Text>
+                <Pressable
+                  onPress={onManageRecurringPress}
+                  accessibilityRole="button"
+                  accessibilityLabel="Manage your monthly gift"
+                  style={({ pressed }) => [styles.noticeLink, pressed && styles.pressed]}
+                >
+                  <Text style={[styles.noticeLinkText, { color: GIVING_GOLD }]}>
+                    Manage
+                  </Text>
+                </Pressable>
+              </View>
+            ) : (
+              <Pressable
+                onPress={onContinue}
+                disabled={!canContinue}
+                accessibilityRole="button"
+                accessibilityLabel={ctaLabel}
+                accessibilityState={{ disabled: !canContinue }}
+                style={({ pressed }) => [
+                  styles.ctaPill,
+                  {
+                    backgroundColor: canContinue
+                      ? colors.buttonPrimary
+                      : colors.buttonDisabled,
+                  },
+                  pressed && styles.pressed,
                 ]}
               >
-                {amountCents ? `Give ${formatCents(totalCents)}` : "Give"}
-              </Text>
-            </Pressable>
+                <Text
+                  style={[
+                    styles.ctaLabel,
+                    { color: canContinue ? colors.buttonPrimaryText : colors.textSecondary },
+                  ]}
+                >
+                  {ctaLabel}
+                </Text>
+              </Pressable>
+            )}
           </View>
         </>
       )}
@@ -290,6 +387,7 @@ export function GiveScreenView({
 function WaitingStep({
   fundName,
   totalCents,
+  monthly,
   canReopen,
   canAutoAdvance,
   onReopenCheckout,
@@ -299,6 +397,7 @@ function WaitingStep({
 }: {
   fundName: string;
   totalCents: number;
+  monthly: boolean;
   canReopen: boolean;
   canAutoAdvance: boolean;
   onReopenCheckout: () => void;
@@ -335,7 +434,10 @@ function WaitingStep({
 
       <View style={styles.group}>
         <WaInsetGroup separatorInset={0}>
-          <KeyValueRow label="Amount" value={formatCents(totalCents)} />
+          <KeyValueRow
+            label="Amount"
+            value={monthly ? formatMonthlyRate(totalCents) : formatCents(totalCents)}
+          />
           <KeyValueRow label="Fund" value={fundName} />
         </WaInsetGroup>
       </View>
@@ -531,6 +633,15 @@ const styles = StyleSheet.create({
     paddingHorizontal: WA_GROUP_MARGIN,
   },
 
+  // Same margin as a `WaInsetGroup` card so the chips line up with the amount
+  // card's edges rather than floating loose above it.
+  frequencyRow: {
+    flexDirection: "row",
+    gap: 10,
+    marginHorizontal: WA_GROUP_MARGIN,
+    marginBottom: 16,
+  },
+
   amountCard: { paddingHorizontal: WA_CELL_PADDING, paddingTop: 20, paddingBottom: 16 },
   amountRow: { flexDirection: "row", alignItems: "flex-start", justifyContent: "center" },
   amountPrefix: {
@@ -578,6 +689,22 @@ const styles = StyleSheet.create({
     fontWeight: WA_WEIGHT_SEMIBOLD,
     fontVariant: ["tabular-nums"],
   },
+
+  // Sits in the CTA's slot, at the CTA's height, so the bar doesn't jump when
+  // the donor toggles between One time and Monthly.
+  noticeCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    minHeight: 50,
+    borderRadius: WA_GROUP_RADIUS,
+    paddingHorizontal: WA_CELL_PADDING,
+    paddingVertical: 10,
+    gap: 12,
+  },
+  noticeText: { fontSize: WA_TYPE_SUBTITLE, flexShrink: 1 },
+  noticeLink: { paddingVertical: 4 },
+  noticeLinkText: { fontSize: WA_TYPE_SUBTITLE, fontWeight: WA_WEIGHT_SEMIBOLD },
 
   waitingCard: { alignItems: "center", paddingHorizontal: WA_CELL_PADDING, paddingVertical: 28 },
   lockTile: {

--- a/apps/mobile/features/finance/member/MonthlyGivingScreen.tsx
+++ b/apps/mobile/features/finance/member/MonthlyGivingScreen.tsx
@@ -121,7 +121,14 @@ export function MonthlyGivingScreen() {
     context === undefined ? undefined : context === null ? null : recurring;
 
   const goToFund = () => {
-    if (router.canGoBack()) {
+    // A `portal_return=1` arrival is a cold boot on this URL, and `canGoBack()`
+    // is NOT a reliable "there's something behind me" there: the root layout
+    // pins `(tabs)` as `initialRouteName`, so even a fresh deep link has a
+    // frame under it — popping would drop the donor on the tab bar instead of
+    // the fund they were managing. Same distinction give-success draws with
+    // `session_id`. Every other arrival really did come from the fund (or the
+    // give sheet), where popping is what avoids stacking a second copy.
+    if (params.portal_return !== "1" && router.canGoBack()) {
       router.back();
       return;
     }

--- a/apps/mobile/features/finance/member/MonthlyGivingScreen.tsx
+++ b/apps/mobile/features/finance/member/MonthlyGivingScreen.tsx
@@ -18,16 +18,37 @@
  *     pattern the give sheet uses for Checkout. Nothing here waits on it: the
  *     donor returns to a screen whose queries are live, so a replaced card
  *     shows up on its own when Stripe's webhook lands.
+ *  3. **Stripe's portal returns HERE, and on native that return lands in the
+ *     auth-less in-app browser** — the web app cold-boots with no session,
+ *     every `useAuthenticatedQuery` skips, and the skeleton would never fill.
+ *     `buildRecurringManageUrl` tags that return with `?portal_return=1`, which
+ *     is what lets this screen show a terminal "you can close this window"
+ *     notice there instead. Same trick as the give sheet's `?giving=cancelled`.
+ *
+ * Errors come through `errorMessage`, not `formatError`: a `ConvexError` carries
+ * its text on `.data`, and in PRODUCTION `.message` is only
+ * "[CONVEX A(…)] [Request ID: …] Server Error". Parsing the message would turn
+ * every real rejection this screen can hit — the fee ceiling, the amount
+ * bounds, "this gift is still being set up" — into one generic "please try
+ * again", which is the one thing a donor can't act on.
  */
 import React, { useState } from "react";
 import { Platform } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
-import { useAuthenticatedQuery, useAuthenticatedAction, api } from "@services/api/convex";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedAction,
+  useStoredAuthToken,
+  api,
+} from "@services/api/convex";
 import type { Id } from "@services/api/convex";
-import { formatError } from "@/utils/error-handling";
+import { errorMessage } from "@/utils/error-handling";
 import { confirmAsync } from "@/utils/platformAlert";
-import { MonthlyGivingScreenView } from "./MonthlyGivingScreenView";
+import {
+  MonthlyGivingScreenView,
+  MonthlyGivingPortalReturnNotice,
+} from "./MonthlyGivingScreenView";
 import { estimateCoverFeesCents, resolveGiveAmountCents } from "./amount";
 
 /** Opens a URL in the platform's browser sheet — same helper shape as
@@ -41,9 +62,10 @@ async function openHostedUrl(url: string): Promise<void> {
 }
 
 export function MonthlyGivingScreen() {
-  const params = useLocalSearchParams<{ group_id: string }>();
+  const params = useLocalSearchParams<{ group_id: string; portal_return?: string }>();
   const groupId = params.group_id;
   const router = useRouter();
+  const token = useStoredAuthToken();
 
   // The give context is only here for the fund id and the preset chips — this
   // screen never starts a gift, so nothing else on it is used.
@@ -76,6 +98,20 @@ export function MonthlyGivingScreen() {
   const [canceling, setCanceling] = useState(false);
   const [updatingCard, setUpdatingCard] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Stripe's Billing Portal return, landing in the auth-less in-app browser.
+  // Placed after every hook so the hook order never changes; the queries above
+  // already skip without a token, so nothing is in flight behind it.
+  //
+  // NOTE: `useStoredAuthToken` starts at `null` and resolves from storage a
+  // frame or two later, so a signed-in donor returning on WEB (where the app
+  // cold-boots on this URL) sees this notice briefly before the manage screen
+  // takes over. That's the same deliberate trade `GiveScreen` makes for
+  // `?giving=cancelled`: gating on `Platform.OS` instead would hand the native
+  // in-app browser the permanent skeleton this exists to kill.
+  if (params.portal_return === "1" && !token) {
+    return <MonthlyGivingPortalReturnNotice />;
+  }
 
   // `context === null` means giving isn't set up for this group at all, which
   // for this screen is the same answer as "you have no monthly gift here" —
@@ -130,7 +166,7 @@ export function MonthlyGivingScreen() {
       });
       setEditing(false);
     } catch (err) {
-      setError(formatError(err, "Couldn't change this amount. Please try again."));
+      setError(errorMessage(err, "Couldn't change this amount. Please try again."));
     } finally {
       setSaving(false);
     }
@@ -146,7 +182,7 @@ export function MonthlyGivingScreen() {
       });
       await openHostedUrl(url);
     } catch (err) {
-      setError(formatError(err, "Couldn't open the payment page. Please try again."));
+      setError(errorMessage(err, "Couldn't open the payment page. Please try again."));
     } finally {
       setUpdatingCard(false);
     }
@@ -173,7 +209,7 @@ export function MonthlyGivingScreen() {
       // behind it are live, so nothing here has to invalidate anything.
       goToFund();
     } catch (err) {
-      setError(formatError(err, "Couldn't stop this monthly gift. Please try again."));
+      setError(errorMessage(err, "Couldn't stop this monthly gift. Please try again."));
       setCanceling(false);
     }
   };

--- a/apps/mobile/features/finance/member/MonthlyGivingScreen.tsx
+++ b/apps/mobile/features/finance/member/MonthlyGivingScreen.tsx
@@ -1,0 +1,207 @@
+/**
+ * MonthlyGivingScreen — data wrapper for the donor-facing monthly-giving
+ * manage screen (ADR-032 recurring giving). Reached from the fund dashboard's
+ * "You give $X monthly" box and from the give sheet's already-giving notice
+ * (app/groups/[group_id]/monthly-giving.tsx).
+ *
+ * All Convex/router wiring lives here; the UI is `MonthlyGivingScreenView`,
+ * kept prop-only so a verification harness can render it with mock data.
+ *
+ * Two things worth knowing about the actions this screen calls:
+ *
+ *  1. **Cancelling is confirmed through `confirmAsync`, never `Alert.alert`.**
+ *     `Alert.alert` is a no-op on web in this codebase, so a confirm built on
+ *     it would silently do nothing there — and "nothing happened" on a Cancel
+ *     button is indistinguishable from "it worked" until the next invoice.
+ *  2. **Updating the card leaves the app.** `createCardUpdateSession` returns a
+ *     Stripe Billing Portal URL, opened with the same `openBrowserAsync`
+ *     pattern the give sheet uses for Checkout. Nothing here waits on it: the
+ *     donor returns to a screen whose queries are live, so a replaced card
+ *     shows up on its own when Stripe's webhook lands.
+ */
+import React, { useState } from "react";
+import { Platform } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import * as WebBrowser from "expo-web-browser";
+import { useAuthenticatedQuery, useAuthenticatedAction, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { formatError } from "@/utils/error-handling";
+import { confirmAsync } from "@/utils/platformAlert";
+import { MonthlyGivingScreenView } from "./MonthlyGivingScreenView";
+import { estimateCoverFeesCents, resolveGiveAmountCents } from "./amount";
+
+/** Opens a URL in the platform's browser sheet — same helper shape as
+ * `GiveScreen`'s `openCheckoutUrl`. */
+async function openHostedUrl(url: string): Promise<void> {
+  if (Platform.OS === "web") {
+    window.location.href = url;
+  } else {
+    await WebBrowser.openBrowserAsync(url);
+  }
+}
+
+export function MonthlyGivingScreen() {
+  const params = useLocalSearchParams<{ group_id: string }>();
+  const groupId = params.group_id;
+  const router = useRouter();
+
+  // The give context is only here for the fund id and the preset chips — this
+  // screen never starts a gift, so nothing else on it is used.
+  const context = useAuthenticatedQuery(
+    api.functions.finance.giving.getGivingContext,
+    groupId ? { groupId: groupId as Id<"groups"> } : "skip",
+  );
+  const fundId = context?.fundId as Id<"funds"> | undefined;
+
+  const recurring = useAuthenticatedQuery(
+    api.functions.finance.giving.getRecurringForFund,
+    fundId ? { fundId } : "skip",
+  );
+
+  const updateRecurringAmount = useAuthenticatedAction(
+    api.functions.finance.giving.updateRecurringAmount,
+  );
+  const cancelRecurringDonation = useAuthenticatedAction(
+    api.functions.finance.giving.cancelRecurringDonation,
+  );
+  const createCardUpdateSession = useAuthenticatedAction(
+    api.functions.finance.giving.createCardUpdateSession,
+  );
+
+  const [editing, setEditing] = useState(false);
+  const [selectedPresetCents, setSelectedPresetCents] = useState<number | null>(null);
+  const [amountText, setAmountText] = useState("");
+  const [coverFees, setCoverFees] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [canceling, setCanceling] = useState(false);
+  const [updatingCard, setUpdatingCard] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // `context === null` means giving isn't set up for this group at all, which
+  // for this screen is the same answer as "you have no monthly gift here" —
+  // there is nothing to manage either way, and `undefined` (still loading) has
+  // to stay distinct from both so the skeleton doesn't flash an empty state.
+  const recurringForView =
+    context === undefined ? undefined : context === null ? null : recurring;
+
+  const goToFund = () => {
+    if (router.canGoBack()) {
+      router.back();
+      return;
+    }
+    router.replace(`/groups/${groupId}/fund` as any);
+  };
+
+  const handleStartEdit = () => {
+    if (!recurring) return;
+    // Seeded from the live gift, so "change the amount" opens on what they
+    // actually give rather than an empty field they have to re-derive.
+    setSelectedPresetCents(null);
+    setAmountText(String(Math.round(recurring.amountCents / 100)));
+    setCoverFees(recurring.feeCoverCents > 0);
+    setError(null);
+    setEditing(true);
+  };
+
+  const handleSelectPreset = (cents: number) => {
+    setSelectedPresetCents((current) => (current === cents ? null : cents));
+    setAmountText("");
+    setError(null);
+  };
+
+  const handleAmountChange = (text: string) => {
+    setAmountText(text);
+    setSelectedPresetCents(null);
+    setError(null);
+  };
+
+  const handleSaveAmount = async () => {
+    if (!recurring) return;
+    const amountCents = resolveGiveAmountCents(selectedPresetCents, amountText);
+    if (!amountCents) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      await updateRecurringAmount({
+        recurringDonationId: recurring.id as Id<"recurringDonations">,
+        amountCents,
+        coverFeesCents: coverFees ? estimateCoverFeesCents(amountCents) : 0,
+      });
+      setEditing(false);
+    } catch (err) {
+      setError(formatError(err, "Couldn't change this amount. Please try again."));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleUpdateCard = async () => {
+    if (!recurring) return;
+    setUpdatingCard(true);
+    setError(null);
+    try {
+      const { url } = await createCardUpdateSession({
+        recurringDonationId: recurring.id as Id<"recurringDonations">,
+      });
+      await openHostedUrl(url);
+    } catch (err) {
+      setError(formatError(err, "Couldn't open the payment page. Please try again."));
+    } finally {
+      setUpdatingCard(false);
+    }
+  };
+
+  const handleCancelRecurring = async () => {
+    if (!recurring) return;
+    const confirmed = await confirmAsync({
+      title: "Cancel monthly giving?",
+      message: "Ends future gifts. Past gifts stay.",
+      confirmText: "Stop giving monthly",
+      cancelText: "Keep giving",
+      destructive: true,
+    });
+    if (!confirmed) return;
+
+    setCanceling(true);
+    setError(null);
+    try {
+      await cancelRecurringDonation({
+        recurringDonationId: recurring.id as Id<"recurringDonations">,
+      });
+      // Back to the fund, where the monthly box is now gone — the queries
+      // behind it are live, so nothing here has to invalidate anything.
+      goToFund();
+    } catch (err) {
+      setError(formatError(err, "Couldn't stop this monthly gift. Please try again."));
+      setCanceling(false);
+    }
+  };
+
+  return (
+    <MonthlyGivingScreenView
+      recurring={recurringForView}
+      suggestedAmountsCents={context?.suggestedAmountsCents ?? []}
+      editing={editing}
+      editSelectedPresetCents={selectedPresetCents}
+      editAmountText={amountText}
+      editCoverFees={coverFees}
+      saving={saving}
+      canceling={canceling}
+      updatingCard={updatingCard}
+      error={error}
+      onBack={goToFund}
+      onStartEdit={handleStartEdit}
+      onCancelEdit={() => {
+        setEditing(false);
+        setError(null);
+      }}
+      onSelectPreset={handleSelectPreset}
+      onAmountChange={handleAmountChange}
+      onToggleCoverFees={setCoverFees}
+      onSaveAmount={handleSaveAmount}
+      onUpdateCard={handleUpdateCard}
+      onCancelRecurring={handleCancelRecurring}
+    />
+  );
+}

--- a/apps/mobile/features/finance/member/MonthlyGivingScreenView.tsx
+++ b/apps/mobile/features/finance/member/MonthlyGivingScreenView.tsx
@@ -1,0 +1,490 @@
+/**
+ * MonthlyGivingScreenView — presentational manage screen for a donor's own
+ * monthly gift (ADR-032 recurring giving). Pure props in, no Convex/router
+ * imports, so a verification harness can render it standalone with mock data.
+ *
+ * Same WhatsApp shell as `FundScreenView`: grouped-gray canvas, floating
+ * `WaSubScreenHeader`, content as `WaInsetGroup` cards.
+ *
+ * The screen is ordered by how urgent each row is to the donor who opened it:
+ * a failing payment first (it is the only reason most people arrive here in a
+ * hurry), then what the gift IS, then the facts about it, then the two things
+ * they might change, then the one thing they might stop. The destructive cell
+ * is last and alone in its card — it is the only irreversible control on the
+ * screen and must never sit a thumb's width from "Change amount".
+ *
+ * Changing the CARD is the one action that leaves the app: Stripe's Billing
+ * Portal is what actually re-attaches a payment method to a live subscription,
+ * so the row says where it is going ("Opens Stripe's secure page") rather than
+ * looking like an in-app form that suddenly isn't one.
+ */
+import React from "react";
+import { View, Text, StyleSheet, ScrollView, Pressable, TextInput } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@hooks/useTheme";
+import { Skeleton, EmptyState } from "@components/ui";
+import {
+  WaSubScreenHeader,
+  WaInsetGroup,
+  WaCell,
+  WA_GROUP_MARGIN,
+  WA_GROUP_RADIUS,
+  WA_GROUP_SPACING,
+  WA_CELL_PADDING,
+  WA_TYPE_FOOTNOTE,
+  WA_TYPE_SUBTITLE,
+  WA_TYPE_ROW_TITLE,
+  WA_WEIGHT_BOLD,
+  WA_WEIGHT_SEMIBOLD,
+} from "@components/wa";
+import { formatCents } from "../format";
+import { estimateCoverFeesCents, resolveGiveAmountCents } from "./amount";
+import { GIVING_GOLD, GIVING_GOLD_TINT } from "./giveTheme";
+import {
+  formatFeeCoverValue,
+  formatRecurringDate,
+  type RecurringSummary,
+} from "./recurring";
+
+/** Hero amount type size — one step under the fund balance, which is the
+ * bigger number on the screen the donor just came from. */
+const AMOUNT_SIZE = 40;
+/** Gold glyph tile above the amount, same language as the fund hero's. */
+const GLYPH_TILE = 44;
+
+export interface MonthlyGivingScreenViewProps {
+  /** `undefined` while loading, `null` when there's no monthly gift here. */
+  recurring: RecurringSummary | null | undefined;
+  /** Preset chips for the inline amount editor — the give sheet's own. */
+  suggestedAmountsCents: readonly number[];
+  /** Whether the inline amount editor has replaced the "Change amount" cell. */
+  editing: boolean;
+  editSelectedPresetCents: number | null;
+  editAmountText: string;
+  editCoverFees: boolean;
+  saving: boolean;
+  /** Disables the destructive cell while the cancel is in flight. */
+  canceling: boolean;
+  /** Disables the card row while the portal session is being created. */
+  updatingCard: boolean;
+  error: string | null;
+  onBack: () => void;
+  onStartEdit: () => void;
+  onCancelEdit: () => void;
+  onSelectPreset: (cents: number) => void;
+  onAmountChange: (text: string) => void;
+  onToggleCoverFees: (value: boolean) => void;
+  onSaveAmount: () => void;
+  onUpdateCard: () => void;
+  onCancelRecurring: () => void;
+}
+
+export function MonthlyGivingScreenView({
+  recurring,
+  suggestedAmountsCents,
+  editing,
+  editSelectedPresetCents,
+  editAmountText,
+  editCoverFees,
+  saving,
+  canceling,
+  updatingCard,
+  error,
+  onBack,
+  onStartEdit,
+  onCancelEdit,
+  onSelectPreset,
+  onAmountChange,
+  onToggleCoverFees,
+  onSaveAmount,
+  onUpdateCard,
+  onCancelRecurring,
+}: MonthlyGivingScreenViewProps) {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const nextGift = recurring ? formatRecurringDate(recurring.currentPeriodEnd) : null;
+
+  return (
+    <View
+      style={[
+        styles.screen,
+        { backgroundColor: colors.backgroundGrouped, paddingTop: insets.top },
+      ]}
+    >
+      <WaSubScreenHeader title="Monthly giving" onBack={onBack} />
+
+      {recurring === undefined ? (
+        <View style={styles.loadingContainer} testID="monthly-giving-loading">
+          <Skeleton height={160} borderRadius={WA_GROUP_RADIUS} style={styles.loadingBlock} />
+          <Skeleton height={180} borderRadius={WA_GROUP_RADIUS} />
+        </View>
+      ) : recurring === null ? (
+        <EmptyState
+          icon="repeat"
+          title="No monthly gift here"
+          message="You're not giving monthly to this fund right now."
+          style={styles.emptyState}
+        />
+      ) : (
+        <ScrollView
+          contentContainerStyle={[
+            styles.scrollContent,
+            { paddingBottom: insets.bottom + 40 },
+          ]}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {/* PAST DUE — first, because it is the only state where every other
+              row on this screen is describing a gift that isn't collecting. */}
+          {recurring.status === "past_due" && (
+            <View>
+              <WaInsetGroup>
+                <WaCell
+                  testID="monthly-past-due-banner"
+                  icon="alert-circle-outline"
+                  iconColor={colors.warning}
+                  title="A payment didn't go through"
+                  description="Update your card to keep this gift going"
+                  descriptionColor={colors.warning}
+                  onPress={onUpdateCard}
+                  disabled={updatingCard}
+                />
+              </WaInsetGroup>
+            </View>
+          )}
+
+          {/* HERO — what the gift IS, in the donor's own words back to them. */}
+          <View style={recurring.status === "past_due" ? styles.group : undefined}>
+            <WaInsetGroup>
+              <View style={styles.hero}>
+                <View style={[styles.glyphTile, { backgroundColor: GIVING_GOLD_TINT }]}>
+                  <Ionicons name="repeat" size={24} color={GIVING_GOLD} />
+                </View>
+                <Text style={[styles.amount, { color: colors.text }]}>
+                  {formatCents(recurring.amountCents)}
+                </Text>
+                <Text
+                  style={[styles.heroCaption, { color: colors.textSecondary }]}
+                  numberOfLines={2}
+                >
+                  every month to {recurring.fundName}
+                </Text>
+              </View>
+            </WaInsetGroup>
+          </View>
+
+          {/* THE FACTS — when, on what card, and whether the fee is covered. */}
+          <View style={styles.group}>
+            <WaInsetGroup>
+              <WaCell
+                icon="calendar-outline"
+                title="Next gift"
+                trailingAccessory={
+                  <Text
+                    testID="monthly-next-gift"
+                    style={[styles.trailingValue, { color: colors.textTertiary }]}
+                  >
+                    {/* Stripe hasn't reported a period on a gift bound seconds
+                        ago — say so rather than print a fabricated date. */}
+                    {nextGift ?? "Scheduled"}
+                  </Text>
+                }
+              />
+              <WaCell
+                testID="monthly-update-card"
+                icon="card-outline"
+                title="Update payment method"
+                description="Opens Stripe's secure page"
+                onPress={onUpdateCard}
+                disabled={updatingCard}
+              />
+              <WaCell
+                icon="pricetag-outline"
+                title="Fee cover"
+                trailingAccessory={
+                  <Text
+                    testID="monthly-fee-cover"
+                    style={[styles.trailingValue, { color: colors.textTertiary }]}
+                  >
+                    {formatFeeCoverValue(recurring.feeCoverCents)}
+                  </Text>
+                }
+              />
+            </WaInsetGroup>
+          </View>
+
+          {/* CHANGE AMOUNT — the editor takes the cell's place rather than
+              opening below it, so there is never a stale "$25.00 monthly" row
+              sitting above a field that says something else. */}
+          <View style={styles.group}>
+            {editing ? (
+              <AmountEditor
+                suggestedAmountsCents={suggestedAmountsCents}
+                selectedPresetCents={editSelectedPresetCents}
+                amountText={editAmountText}
+                coverFees={editCoverFees}
+                saving={saving}
+                onSelectPreset={onSelectPreset}
+                onAmountChange={onAmountChange}
+                onToggleCoverFees={onToggleCoverFees}
+                onSave={onSaveAmount}
+                onCancel={onCancelEdit}
+              />
+            ) : (
+              <WaInsetGroup footer="A new amount starts with your next gift — this month is already paid.">
+                <WaCell
+                  testID="monthly-change-amount"
+                  icon="pencil-outline"
+                  title="Change amount"
+                  onPress={onStartEdit}
+                />
+              </WaInsetGroup>
+            )}
+          </View>
+
+          {!!error && (
+            <Text testID="monthly-giving-error" style={[styles.errorText, { color: colors.error }]}>
+              {error}
+            </Text>
+          )}
+
+          {/* STOP — alone in its own card, last, and never while the editor is
+              open: a donor mid-edit is deciding how much to give, not whether. */}
+          {!editing && (
+            <View style={styles.group}>
+              <WaInsetGroup footer="Ends future gifts. Past gifts stay.">
+                <WaCell
+                  testID="monthly-cancel"
+                  variant="destructive"
+                  title="Cancel monthly giving"
+                  onPress={onCancelRecurring}
+                  disabled={canceling}
+                />
+              </WaInsetGroup>
+            </View>
+          )}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+/**
+ * The inline amount editor — deliberately the give sheet's own vocabulary
+ * (big typed number as the display, preset chips that write into it, one
+ * fee-cover toggle), because "change my monthly amount" is the same decision
+ * the donor already made once and should not have to relearn.
+ */
+function AmountEditor({
+  suggestedAmountsCents,
+  selectedPresetCents,
+  amountText,
+  coverFees,
+  saving,
+  onSelectPreset,
+  onAmountChange,
+  onToggleCoverFees,
+  onSave,
+  onCancel,
+}: {
+  suggestedAmountsCents: readonly number[];
+  selectedPresetCents: number | null;
+  amountText: string;
+  coverFees: boolean;
+  saving: boolean;
+  onSelectPreset: (cents: number) => void;
+  onAmountChange: (text: string) => void;
+  onToggleCoverFees: (value: boolean) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  const { colors } = useTheme();
+  const amountCents = resolveGiveAmountCents(selectedPresetCents, amountText);
+  const canSave = !!amountCents && !saving;
+
+  // Same one-field rule as the give sheet: a tapped preset writes its dollars
+  // into the field the donor types in, so there is one amount on screen.
+  const displayText =
+    selectedPresetCents !== null ? String(selectedPresetCents / 100) : amountText;
+
+  return (
+    <View testID="monthly-amount-editor">
+      <WaInsetGroup>
+        <View style={styles.editorCard}>
+          <View style={styles.amountRow}>
+            <Text style={[styles.amountPrefix, { color: colors.textSecondary }]}>$</Text>
+            <TextInput
+              value={displayText}
+              onChangeText={onAmountChange}
+              selectTextOnFocus
+              keyboardType="number-pad"
+              placeholder="0"
+              placeholderTextColor={colors.textTertiary}
+              accessibilityLabel="New monthly amount in dollars"
+              testID="monthly-amount-input"
+              style={[styles.amountInput, { color: colors.text }]}
+            />
+          </View>
+
+          <View style={styles.presetRow}>
+            {suggestedAmountsCents.map((cents) => {
+              const selected = selectedPresetCents === cents;
+              return (
+                <Pressable
+                  key={cents}
+                  onPress={() => onSelectPreset(cents)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${formatCents(cents)} preset`}
+                  accessibilityState={{ selected }}
+                  style={({ pressed }) => [
+                    styles.presetChip,
+                    {
+                      backgroundColor: selected
+                        ? colors.buttonPrimary
+                        : colors.backgroundGrouped,
+                    },
+                    pressed && styles.pressed,
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.presetChipText,
+                      { color: selected ? colors.buttonPrimaryText : colors.text },
+                    ]}
+                  >
+                    {formatCents(cents)}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+      </WaInsetGroup>
+
+      <View style={styles.group}>
+        <WaInsetGroup>
+          <WaCell
+            variant="toggle"
+            title="Cover the processing fee"
+            description={
+              amountCents
+                ? `+${formatCents(estimateCoverFeesCents(amountCents))} so the fund gets the full ${formatCents(amountCents)}`
+                : "Stripe's cut comes out of the gift unless you cover it."
+            }
+            toggleValue={coverFees}
+            onToggleChange={onToggleCoverFees}
+            accent={GIVING_GOLD}
+          />
+        </WaInsetGroup>
+      </View>
+
+      <View style={styles.editorActions}>
+        <Pressable
+          onPress={onSave}
+          disabled={!canSave}
+          accessibilityRole="button"
+          accessibilityLabel="Save new amount"
+          accessibilityState={{ disabled: !canSave }}
+          testID="monthly-save-amount"
+          style={({ pressed }) => [
+            styles.pill,
+            { backgroundColor: canSave ? colors.buttonPrimary : colors.buttonDisabled },
+            pressed && styles.pressed,
+          ]}
+        >
+          <Text
+            style={[
+              styles.pillLabel,
+              { color: canSave ? colors.buttonPrimaryText : colors.textSecondary },
+            ]}
+          >
+            {amountCents ? `Give ${formatCents(amountCents)} monthly` : "Save"}
+          </Text>
+        </Pressable>
+
+        <Pressable
+          onPress={onCancel}
+          accessibilityRole="button"
+          accessibilityLabel="Keep the current amount"
+          testID="monthly-cancel-edit"
+          style={({ pressed }) => [styles.ghostPill, pressed && styles.pressed]}
+        >
+          <Text style={[styles.ghostLabel, { color: colors.textSecondary }]}>
+            Keep the current amount
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1 },
+  loadingContainer: { padding: WA_GROUP_MARGIN },
+  loadingBlock: { marginBottom: 16 },
+  emptyState: { flex: 1, justifyContent: "center" },
+  scrollContent: { paddingTop: 16 },
+  group: { marginTop: WA_GROUP_SPACING },
+  pressed: { opacity: 0.85 },
+
+  hero: { alignItems: "center", paddingHorizontal: WA_CELL_PADDING, paddingVertical: 24 },
+  glyphTile: {
+    width: GLYPH_TILE,
+    height: GLYPH_TILE,
+    borderRadius: GLYPH_TILE / 2,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 12,
+  },
+  amount: {
+    fontSize: AMOUNT_SIZE,
+    fontWeight: WA_WEIGHT_BOLD,
+    fontVariant: ["tabular-nums"],
+  },
+  heroCaption: { fontSize: WA_TYPE_SUBTITLE, textAlign: "center", marginTop: 4 },
+
+  trailingValue: { fontSize: WA_TYPE_ROW_TITLE },
+
+  editorCard: { paddingHorizontal: WA_CELL_PADDING, paddingTop: 20, paddingBottom: 16 },
+  amountRow: { flexDirection: "row", alignItems: "flex-start", justifyContent: "center" },
+  amountPrefix: {
+    fontSize: 22,
+    fontWeight: WA_WEIGHT_SEMIBOLD,
+    marginTop: 10,
+    marginRight: 2,
+  },
+  amountInput: {
+    fontSize: 48,
+    fontWeight: WA_WEIGHT_BOLD,
+    fontVariant: ["tabular-nums"],
+    minWidth: 80,
+    paddingVertical: 0,
+    textAlign: "center",
+  },
+  presetRow: { flexDirection: "row", gap: 10, marginTop: 20 },
+  presetChip: { flex: 1, borderRadius: 22, paddingVertical: 12, alignItems: "center" },
+  presetChipText: { fontSize: WA_TYPE_SUBTITLE, fontWeight: WA_WEIGHT_SEMIBOLD },
+
+  editorActions: {
+    marginTop: WA_GROUP_SPACING,
+    paddingHorizontal: WA_GROUP_MARGIN,
+    gap: 8,
+  },
+  pill: { height: 50, borderRadius: 25, alignItems: "center", justifyContent: "center" },
+  pillLabel: {
+    fontSize: WA_TYPE_ROW_TITLE,
+    fontWeight: WA_WEIGHT_SEMIBOLD,
+    fontVariant: ["tabular-nums"],
+  },
+  ghostPill: { height: 44, alignItems: "center", justifyContent: "center" },
+  ghostLabel: { fontSize: WA_TYPE_SUBTITLE },
+
+  errorText: {
+    fontSize: WA_TYPE_FOOTNOTE,
+    textAlign: "center",
+    marginTop: 16,
+    paddingHorizontal: WA_GROUP_MARGIN,
+  },
+});

--- a/apps/mobile/features/finance/member/MonthlyGivingScreenView.tsx
+++ b/apps/mobile/features/finance/member/MonthlyGivingScreenView.tsx
@@ -420,8 +420,48 @@ function AmountEditor({
   );
 }
 
+/**
+ * What the donor sees when Stripe's Billing Portal hands them back inside its
+ * auth-less in-app browser (`?portal_return=1` with no stored token — see
+ * `MonthlyGivingScreen`). There is no session in that browser, so every query
+ * behind the manage screen skips and its skeleton never fills; this is the
+ * terminal notice that replaces it, the same shape as `GiveCancelledNotice`.
+ *
+ * It deliberately does NOT claim the card was changed — the donor may have hit
+ * the portal's own "Return" link without touching anything, and this screen has
+ * no way to know. It says where the truth will show up instead.
+ */
+export function MonthlyGivingPortalReturnNotice() {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  return (
+    <View
+      style={[
+        styles.screen,
+        styles.notice,
+        { backgroundColor: colors.backgroundGrouped, paddingTop: insets.top },
+      ]}
+      testID="monthly-portal-return-notice"
+    >
+      <Ionicons name="card-outline" size={44} color={colors.textSecondary} />
+      <Text style={[styles.noticeTitle, { color: colors.text }]}>Back to the app</Text>
+      <Text style={[styles.noticeCopy, { color: colors.textSecondary }]}>
+        You can close this window. Any change you made shows up in the app on its own.
+      </Text>
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   screen: { flex: 1 },
+  notice: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+    gap: 10,
+  },
+  noticeTitle: { fontSize: 20, fontWeight: WA_WEIGHT_SEMIBOLD },
+  noticeCopy: { fontSize: WA_TYPE_SUBTITLE, textAlign: "center" },
   loadingContainer: { padding: WA_GROUP_MARGIN },
   loadingBlock: { marginBottom: 16 },
   emptyState: { flex: 1, justifyContent: "center" },

--- a/apps/mobile/features/finance/member/__tests__/FundScreenView.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/FundScreenView.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react-native";
 import { FundScreenView } from "../FundScreenView";
 import type { FundOverview, MyExpense } from "../types";
+import type { RecurringSummary } from "../recurring";
 import { formatCents, formatSignedCents } from "../../format";
 
 jest.mock("@hooks/useTheme", () => ({
@@ -356,6 +357,99 @@ describe("FundScreenView", () => {
       renderWith(baseExpenses);
       expect(screen.getByText("Pending")).toBeTruthy();
       expect(screen.queryByTestId("expense-note-exp1")).toBeNull();
+    });
+  });
+
+  // The monthly box is standing money the donor should be able to see and stop
+  // without hunting — but only when there IS one collecting.
+  describe("the monthly-giving box", () => {
+    const activeMonthly: RecurringSummary = {
+      id: "rec1",
+      fundId: "fund1",
+      groupId: "group1",
+      fundName: "Small Group Fund",
+      amountCents: 2500,
+      feeCoverCents: 0,
+      status: "active",
+      // 2026-09-01T12:00:00Z, rendered in the runner's local zone.
+      currentPeriodEnd: Date.UTC(2026, 8, 1, 12),
+      createdAt: 1,
+    };
+
+    const renderWith = (
+      recurring: RecurringSummary | null | undefined,
+      onManageRecurringPress: () => void = noop,
+    ) =>
+      render(
+        <FundScreenView
+          overview={baseOverview}
+          myExpenses={baseExpenses}
+          onBack={noop}
+          onGivePress={noop}
+          onGetReimbursedPress={noop}
+          recurring={recurring}
+          onManageRecurringPress={onManageRecurringPress}
+        />,
+      );
+
+    it("names the gift and where it goes next", () => {
+      renderWith(activeMonthly);
+      expect(screen.getByText("You give $25.00 monthly")).toBeTruthy();
+      expect(screen.getByText(/^Next gift .+ · Manage or cancel$/)).toBeTruthy();
+    });
+
+    it("opens the manage screen when tapped", () => {
+      const onManageRecurringPress = jest.fn();
+      renderWith(activeMonthly, onManageRecurringPress);
+      fireEvent.press(screen.getByText("You give $25.00 monthly"));
+      expect(onManageRecurringPress).toHaveBeenCalledTimes(1);
+    });
+
+    // A failing card is the one thing on this screen a donor has to act on —
+    // "Next gift Sep 1" over a declined payment would stop them fixing it.
+    it("swaps the sub-line for the fix-it prompt when the payment failed", () => {
+      renderWith({ ...activeMonthly, status: "past_due" });
+      expect(screen.getByText("Payment issue — tap to fix")).toBeTruthy();
+      expect(screen.queryByText(/Next gift/)).toBeNull();
+    });
+
+    it("colors that sub-line as a warning rather than leaving it neutral gray", () => {
+      renderWith({ ...activeMonthly, status: "past_due" });
+      const line = screen.getByText("Payment issue — tap to fix");
+      // `warning` from the theme mock above.
+      expect(line.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ color: "#e0a800" })]),
+      );
+    });
+
+    // A gift still inside Stripe Checkout has charged nothing yet, and a
+    // canceled one has nothing left to manage. Neither gets a box.
+    it("renders nothing at all for a pending gift", () => {
+      renderWith({ ...activeMonthly, status: "pending" });
+      expect(screen.queryByTestId("fund-monthly-box")).toBeNull();
+      expect(screen.queryByText(/You give/)).toBeNull();
+    });
+
+    it("renders nothing at all for a canceled gift", () => {
+      renderWith({ ...activeMonthly, status: "canceled" });
+      expect(screen.queryByTestId("fund-monthly-box")).toBeNull();
+    });
+
+    it("renders nothing when the donor has no monthly gift", () => {
+      renderWith(null);
+      expect(screen.queryByTestId("fund-monthly-box")).toBeNull();
+    });
+
+    it("renders nothing while the query is still loading", () => {
+      renderWith(undefined);
+      expect(screen.queryByTestId("fund-monthly-box")).toBeNull();
+    });
+
+    // Stripe hasn't reported a period on a just-bound gift; the row still has
+    // to be usable rather than printing a fabricated date.
+    it("drops the date when there isn't one yet", () => {
+      renderWith({ ...activeMonthly, currentPeriodEnd: null });
+      expect(screen.getByText("Manage or cancel")).toBeTruthy();
     });
   });
 

--- a/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
@@ -61,6 +61,7 @@ jest.mock("../GiveScreenView", () => {
     GiveScreenView: ({
       step,
       frequency,
+      error,
       onContinue,
       onBack,
       onSelectPreset,
@@ -70,6 +71,7 @@ jest.mock("../GiveScreenView", () => {
       <>
         <Text testID="give-step">{step}</Text>
         <Text testID="give-frequency">{frequency}</Text>
+        <Text testID="give-error">{error ?? ""}</Text>
         <Text testID="give-can-auto-advance">{String(canAutoAdvance)}</Text>
         <Pressable testID="give-monthly" onPress={() => onSelectFrequency("monthly")}>
           <Text>Monthly</Text>
@@ -448,6 +450,29 @@ describe("GiveScreen", () => {
         "https://checkout.stripe.com/c/pay/cs_sub_123",
       );
       expect(WebBrowser.dismissBrowser).toHaveBeenCalled();
+    });
+
+    // The rejection this call actually returns in production: a ConvexError
+    // whose text is on `.data`, with `.message` reduced to an opaque
+    // "[CONVEX A(...)] ... Server Error". A message-parsing formatter would
+    // swap "finish that checkout, or try again in a few minutes" — the only
+    // sentence that tells the donor what to DO during the grace window — for a
+    // generic "couldn't start this gift".
+    it("shows the server's actual reason a monthly gift was refused", async () => {
+      mockCreateRecurringSession.mockRejectedValue(
+        Object.assign(
+          new Error(
+            "[CONVEX A(functions/finance/giving:createRecurringDonationCheckoutSession)] [Request ID: abc] Server Error",
+          ),
+          { data: "Finish that checkout, or try again in a few minutes." },
+        ),
+      );
+      const { getByTestId } = render(<GiveScreen />);
+      await pressGiveMonthly(getByTestId);
+
+      expect(getByTestId("give-error").props.children).toBe(
+        "Finish that checkout, or try again in a few minutes.",
+      );
     });
 
     // One active monthly per fund is a backend rule; the container refuses

--- a/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
@@ -20,7 +20,6 @@ const GET_RECURRING_FOR_FUND = "api.functions.finance.giving.getRecurringForFund
 const CREATE_ONE_OFF = "api.functions.finance.giving.createDonationCheckoutSession";
 const CREATE_RECURRING =
   "api.functions.finance.giving.createRecurringDonationCheckoutSession";
-const CANCEL_RECURRING = "api.functions.finance.giving.cancelRecurringDonation";
 
 jest.mock("@services/api/convex", () => ({
   api: {
@@ -35,8 +34,6 @@ jest.mock("@services/api/convex", () => ({
             "api.functions.finance.giving.createDonationCheckoutSession",
           createRecurringDonationCheckoutSession:
             "api.functions.finance.giving.createRecurringDonationCheckoutSession",
-          cancelRecurringDonation:
-            "api.functions.finance.giving.cancelRecurringDonation",
         },
       },
     },
@@ -99,7 +96,6 @@ const mockReplace = jest.fn();
 const mockPush = jest.fn();
 const mockCreateSession = jest.fn();
 const mockCreateRecurringSession = jest.fn();
-const mockCancelRecurring = jest.fn();
 
 let liveContext: Record<string, unknown> = {
   fundId: "fund_1",
@@ -187,12 +183,9 @@ describe("GiveScreen", () => {
       back: jest.fn(),
       canGoBack: () => true,
     });
-    (useAuthenticatedAction as jest.Mock).mockImplementation((fn: string) => {
-      if (fn === CREATE_RECURRING) return mockCreateRecurringSession;
-      if (fn === CANCEL_RECURRING) return mockCancelRecurring;
-      return mockCreateSession;
-    });
-    mockCancelRecurring.mockResolvedValue({ canceled: true });
+    (useAuthenticatedAction as jest.Mock).mockImplementation((fn: string) =>
+      fn === CREATE_RECURRING ? mockCreateRecurringSession : mockCreateSession,
+    );
     mockCreateSession.mockResolvedValue({
       url: "https://checkout.stripe.com/c/pay/cs_test_123",
       sessionId: "cs_test_123",
@@ -455,55 +448,6 @@ describe("GiveScreen", () => {
         "https://checkout.stripe.com/c/pay/cs_sub_123",
       );
       expect(WebBrowser.dismissBrowser).toHaveBeenCalled();
-    });
-
-    // Backing out of the waiting step leaves a `pending` recurringDonations
-    // row on the server, and that row blocks a new monthly gift to this fund
-    // for the whole 30-minute grace window while its Stripe page stays live.
-    // "Cancel this gift" that only cleared local state would therefore mean
-    // "you may not give monthly for half an hour".
-    describe("backing out of a monthly checkout", () => {
-      it("releases the pending row so the donor can immediately try again", async () => {
-        const { getByTestId } = render(<GiveScreen />);
-        await pressGiveMonthly(getByTestId);
-        expect(getByTestId("give-step").props.children).toBe("confirmation");
-
-        await act(async () => {
-          fireEvent.press(getByTestId("give-back"));
-        });
-
-        expect(mockCancelRecurring).toHaveBeenCalledWith({
-          recurringDonationId: "rec_1",
-        });
-        expect(getByTestId("give-step").props.children).toBe("amount");
-      });
-
-      // A one-off has no server-side row to release — cancelling something
-      // there would be cancelling a stranger's gift or nothing at all.
-      it("touches nothing on the server backing out of a one-off", async () => {
-        const { getByTestId } = render(<GiveScreen />);
-        await pressGive(getByTestId);
-
-        await act(async () => {
-          fireEvent.press(getByTestId("give-back"));
-        });
-
-        expect(mockCancelRecurring).not.toHaveBeenCalled();
-      });
-
-      // The release is a courtesy, not a precondition: a donor who is already
-      // walking away must still get back to the amount step.
-      it("still goes back when the release fails", async () => {
-        mockCancelRecurring.mockRejectedValue(new Error("network"));
-        const { getByTestId } = render(<GiveScreen />);
-        await pressGiveMonthly(getByTestId);
-
-        await act(async () => {
-          fireEvent.press(getByTestId("give-back"));
-        });
-
-        expect(getByTestId("give-step").props.children).toBe("amount");
-      });
     });
 
     // One active monthly per fund is a backend rule; the container refuses

--- a/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
@@ -16,6 +16,10 @@ import { GiveScreen } from "../GiveScreen";
 
 const GET_GIVING_CONTEXT = "api.functions.finance.giving.getGivingContext";
 const GET_CHECKOUT_STATUS = "api.functions.finance.giving.getCheckoutSessionStatus";
+const GET_RECURRING_FOR_FUND = "api.functions.finance.giving.getRecurringForFund";
+const CREATE_ONE_OFF = "api.functions.finance.giving.createDonationCheckoutSession";
+const CREATE_RECURRING =
+  "api.functions.finance.giving.createRecurringDonationCheckoutSession";
 
 jest.mock("@services/api/convex", () => ({
   api: {
@@ -25,8 +29,11 @@ jest.mock("@services/api/convex", () => ({
           getGivingContext: "api.functions.finance.giving.getGivingContext",
           getCheckoutSessionStatus:
             "api.functions.finance.giving.getCheckoutSessionStatus",
+          getRecurringForFund: "api.functions.finance.giving.getRecurringForFund",
           createDonationCheckoutSession:
             "api.functions.finance.giving.createDonationCheckoutSession",
+          createRecurringDonationCheckoutSession:
+            "api.functions.finance.giving.createRecurringDonationCheckoutSession",
         },
       },
     },
@@ -51,10 +58,22 @@ jest.mock("expo-web-browser", () => ({
 jest.mock("../GiveScreenView", () => {
   const { Text, Pressable } = require("react-native");
   return {
-    GiveScreenView: ({ step, onContinue, onBack, onSelectPreset, canAutoAdvance }: any) => (
+    GiveScreenView: ({
+      step,
+      frequency,
+      onContinue,
+      onBack,
+      onSelectPreset,
+      onSelectFrequency,
+      canAutoAdvance,
+    }: any) => (
       <>
         <Text testID="give-step">{step}</Text>
+        <Text testID="give-frequency">{frequency}</Text>
         <Text testID="give-can-auto-advance">{String(canAutoAdvance)}</Text>
+        <Pressable testID="give-monthly" onPress={() => onSelectFrequency("monthly")}>
+          <Text>Monthly</Text>
+        </Pressable>
         <Pressable testID="give-preset" onPress={() => onSelectPreset(5000)}>
           <Text>$50</Text>
         </Pressable>
@@ -76,18 +95,22 @@ const { useRouter } = jest.requireMock("expo-router");
 const mockReplace = jest.fn();
 const mockPush = jest.fn();
 const mockCreateSession = jest.fn();
+const mockCreateRecurringSession = jest.fn();
 
-const liveContext = {
+let liveContext: Record<string, unknown> = {
   fundId: "fund_1",
   fundName: "Young Adults — Manhattan",
   communityLegalName: "First Church Inc.",
   givingLive: true,
   suggestedAmountsCents: [2500, 5000],
+  existingRecurring: null,
 };
 
 /** Convex hands back a fresh object per update; identity churn is what the
  * navigate-once guard has to survive. */
 let checkoutStatus: Record<string, unknown> | undefined;
+/** What `getRecurringForFund` reports while the monthly gift is being set up. */
+let recurringStatus: Record<string, unknown> | null | undefined;
 
 function mockQueries() {
   (useAuthenticatedQuery as jest.Mock).mockImplementation(
@@ -95,6 +118,10 @@ function mockQueries() {
       if (fn === GET_GIVING_CONTEXT) return liveContext;
       if (fn === GET_CHECKOUT_STATUS) {
         return args === "skip" || !checkoutStatus ? undefined : { ...checkoutStatus };
+      }
+      if (fn === GET_RECURRING_FOR_FUND) {
+        if (args === "skip") return undefined;
+        return recurringStatus ? { ...recurringStatus } : recurringStatus;
       }
       return undefined;
     },
@@ -109,6 +136,14 @@ function lastStatusArgs() {
   return calls[calls.length - 1]?.[1];
 }
 
+/** The args the monthly waiting step passed to `getRecurringForFund`. */
+function lastRecurringArgs() {
+  const calls = (useAuthenticatedQuery as jest.Mock).mock.calls.filter(
+    ([fn]) => fn === GET_RECURRING_FOR_FUND,
+  );
+  return calls[calls.length - 1]?.[1];
+}
+
 /** Picks an amount, then submits — `handleContinue` no-ops without one. */
 async function pressGive(getByTestId: (id: string) => unknown) {
   await act(async () => {
@@ -119,10 +154,27 @@ async function pressGive(getByTestId: (id: string) => unknown) {
   });
 }
 
+/** Switches to Monthly, picks an amount, then submits. */
+async function pressGiveMonthly(getByTestId: (id: string) => unknown) {
+  await act(async () => {
+    fireEvent.press(getByTestId("give-monthly") as never);
+  });
+  await pressGive(getByTestId);
+}
+
 describe("GiveScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     checkoutStatus = undefined;
+    recurringStatus = null;
+    liveContext = {
+      fundId: "fund_1",
+      fundName: "Young Adults — Manhattan",
+      communityLegalName: "First Church Inc.",
+      givingLive: true,
+      suggestedAmountsCents: [2500, 5000],
+      existingRecurring: null,
+    };
     (useLocalSearchParams as jest.Mock).mockReturnValue({ group_id: "group_1" });
     (useStoredAuthToken as jest.Mock).mockReturnValue("token_abc");
     (useRouter as jest.Mock).mockReturnValue({
@@ -131,11 +183,20 @@ describe("GiveScreen", () => {
       back: jest.fn(),
       canGoBack: () => true,
     });
-    (useAuthenticatedAction as jest.Mock).mockReturnValue(mockCreateSession);
+    (useAuthenticatedAction as jest.Mock).mockImplementation((fn: string) =>
+      fn === CREATE_RECURRING ? mockCreateRecurringSession : mockCreateSession,
+    );
     mockCreateSession.mockResolvedValue({
       url: "https://checkout.stripe.com/c/pay/cs_test_123",
       sessionId: "cs_test_123",
       paymentIntentId: "pi_test_123",
+    });
+    // Subscription-mode Checkout returns no PaymentIntent — the recurring row
+    // id is the only join key this path has.
+    mockCreateRecurringSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/c/pay/cs_sub_123",
+      sessionId: "cs_sub_123",
+      recurringDonationId: "rec_1",
     });
     mockQueries();
   });
@@ -242,6 +303,178 @@ describe("GiveScreen", () => {
       "https://checkout.stripe.com/c/pay/cs_test_123",
     );
     expect(WebBrowser.dismissBrowser).toHaveBeenCalled();
+  });
+
+  // A monthly gift has no PaymentIntent to watch — subscription-mode Checkout
+  // doesn't create one. The waiting step watches the recurring row instead,
+  // which Stripe flips to `active` via checkout.session.completed →
+  // invoice.paid.
+  describe("a monthly gift", () => {
+    it("creates a subscription Checkout session, not a one-off", async () => {
+      const { getByTestId } = render(<GiveScreen />);
+      await pressGiveMonthly(getByTestId);
+
+      expect(mockCreateRecurringSession).toHaveBeenCalledWith(
+        expect.objectContaining({ fundId: "fund_1", amountCents: 5000 }),
+      );
+      expect(mockCreateSession).not.toHaveBeenCalled();
+      expect(useAuthenticatedAction).toHaveBeenCalledWith(CREATE_ONE_OFF);
+      expect(useAuthenticatedAction).toHaveBeenCalledWith(CREATE_RECURRING);
+    });
+
+    it("watches the recurring row's fund, and nothing PaymentIntent-shaped", async () => {
+      const { getByTestId } = render(<GiveScreen />);
+      await pressGiveMonthly(getByTestId);
+
+      expect(lastRecurringArgs()).toEqual({ fundId: "fund_1" });
+      expect(lastStatusArgs()).toBe("skip");
+      // ...and the wait is still a watched one, so no manual escape hatch.
+      expect(getByTestId("give-can-auto-advance").props.children).toBe("true");
+    });
+
+    it("does not watch anything until the donor is actually waiting", () => {
+      render(<GiveScreen />);
+      expect(lastRecurringArgs()).toBe("skip");
+    });
+
+    it("routes to the thank-you with recurring=1 once the gift activates", async () => {
+      recurringStatus = {
+        id: "rec_1",
+        fundId: "fund_1",
+        fundName: "Young Adults — Manhattan",
+        amountCents: 5000,
+        feeCoverCents: 175,
+        status: "active",
+        currentPeriodEnd: 1,
+        createdAt: 1,
+      };
+      const { getByTestId } = render(<GiveScreen />);
+      await pressGiveMonthly(getByTestId);
+
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/groups/group_1/give-success?amount=5175" +
+          `&fund=${encodeURIComponent("Young Adults — Manhattan")}` +
+          `&community=${encodeURIComponent("First Church Inc.")}` +
+          "&recurring=1",
+      );
+    });
+
+    it("stays put while the row is still pending (nothing charged yet)", async () => {
+      recurringStatus = null; // getRecurringForFund excludes pending rows.
+      const { getByTestId } = render(<GiveScreen />);
+      await pressGiveMonthly(getByTestId);
+
+      expect(mockReplace).not.toHaveBeenCalled();
+      expect(getByTestId("give-step").props.children).toBe("confirmation");
+    });
+
+    // Thanking someone for a declined card is the one screen that would stop
+    // them fixing it — the failed first invoice keeps them on the waiting step.
+    it("does not thank the donor when the first invoice failed", async () => {
+      recurringStatus = {
+        id: "rec_1",
+        fundId: "fund_1",
+        fundName: "Young Adults — Manhattan",
+        amountCents: 5000,
+        feeCoverCents: 0,
+        status: "past_due",
+        currentPeriodEnd: 1,
+        createdAt: 1,
+      };
+      const { getByTestId } = render(<GiveScreen />);
+      await pressGiveMonthly(getByTestId);
+
+      expect(mockReplace).not.toHaveBeenCalled();
+      expect(getByTestId("give-step").props.children).toBe("confirmation");
+    });
+
+    // A live gift belonging to some OTHER submission must not fake a thank-you
+    // for this one.
+    it("ignores a live row that isn't the one this submission created", async () => {
+      recurringStatus = {
+        id: "rec_someone_elses_tab",
+        fundId: "fund_1",
+        fundName: "Young Adults — Manhattan",
+        amountCents: 9900,
+        feeCoverCents: 0,
+        status: "active",
+        currentPeriodEnd: 1,
+        createdAt: 1,
+      };
+      const { getByTestId } = render(<GiveScreen />);
+      await pressGiveMonthly(getByTestId);
+
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it("navigates exactly once no matter how many times 'active' re-renders", async () => {
+      recurringStatus = {
+        id: "rec_1",
+        fundId: "fund_1",
+        fundName: "Young Adults — Manhattan",
+        amountCents: 5000,
+        feeCoverCents: 0,
+        status: "active",
+        currentPeriodEnd: 1,
+        createdAt: 1,
+      };
+      const { getByTestId, rerender } = render(<GiveScreen />);
+      await pressGiveMonthly(getByTestId);
+
+      await act(async () => {
+        rerender(<GiveScreen />);
+        rerender(<GiveScreen />);
+      });
+
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+    });
+
+    it("dismisses the browser sheet it opened before handing over", async () => {
+      recurringStatus = {
+        id: "rec_1",
+        fundId: "fund_1",
+        fundName: "Young Adults — Manhattan",
+        amountCents: 5000,
+        feeCoverCents: 0,
+        status: "active",
+        currentPeriodEnd: 1,
+        createdAt: 1,
+      };
+      const { getByTestId } = render(<GiveScreen />);
+      await pressGiveMonthly(getByTestId);
+
+      expect(WebBrowser.openBrowserAsync).toHaveBeenCalledWith(
+        "https://checkout.stripe.com/c/pay/cs_sub_123",
+      );
+      expect(WebBrowser.dismissBrowser).toHaveBeenCalled();
+    });
+
+    // One active monthly per fund is a backend rule; the container refuses
+    // before spending a Stripe call to be told the same thing.
+    it("never starts a second monthly gift to the same fund", async () => {
+      liveContext = {
+        ...liveContext,
+        existingRecurring: { amountCents: 2500, feeCoverCents: 0 },
+      };
+      const { getByTestId } = render(<GiveScreen />);
+      await pressGiveMonthly(getByTestId);
+
+      expect(mockCreateRecurringSession).not.toHaveBeenCalled();
+      expect(getByTestId("give-step").props.children).toBe("amount");
+    });
+
+    it("still lets that donor give a one-off", async () => {
+      liveContext = {
+        ...liveContext,
+        existingRecurring: { amountCents: 2500, feeCoverCents: 0 },
+      };
+      const { getByTestId } = render(<GiveScreen />);
+      await pressGive(getByTestId);
+
+      expect(mockCreateSession).toHaveBeenCalledTimes(1);
+      expect(getByTestId("give-step").props.children).toBe("confirmation");
+    });
   });
 
   describe("the cancel return", () => {

--- a/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/GiveScreen.test.tsx
@@ -20,6 +20,7 @@ const GET_RECURRING_FOR_FUND = "api.functions.finance.giving.getRecurringForFund
 const CREATE_ONE_OFF = "api.functions.finance.giving.createDonationCheckoutSession";
 const CREATE_RECURRING =
   "api.functions.finance.giving.createRecurringDonationCheckoutSession";
+const CANCEL_RECURRING = "api.functions.finance.giving.cancelRecurringDonation";
 
 jest.mock("@services/api/convex", () => ({
   api: {
@@ -34,6 +35,8 @@ jest.mock("@services/api/convex", () => ({
             "api.functions.finance.giving.createDonationCheckoutSession",
           createRecurringDonationCheckoutSession:
             "api.functions.finance.giving.createRecurringDonationCheckoutSession",
+          cancelRecurringDonation:
+            "api.functions.finance.giving.cancelRecurringDonation",
         },
       },
     },
@@ -96,6 +99,7 @@ const mockReplace = jest.fn();
 const mockPush = jest.fn();
 const mockCreateSession = jest.fn();
 const mockCreateRecurringSession = jest.fn();
+const mockCancelRecurring = jest.fn();
 
 let liveContext: Record<string, unknown> = {
   fundId: "fund_1",
@@ -183,9 +187,12 @@ describe("GiveScreen", () => {
       back: jest.fn(),
       canGoBack: () => true,
     });
-    (useAuthenticatedAction as jest.Mock).mockImplementation((fn: string) =>
-      fn === CREATE_RECURRING ? mockCreateRecurringSession : mockCreateSession,
-    );
+    (useAuthenticatedAction as jest.Mock).mockImplementation((fn: string) => {
+      if (fn === CREATE_RECURRING) return mockCreateRecurringSession;
+      if (fn === CANCEL_RECURRING) return mockCancelRecurring;
+      return mockCreateSession;
+    });
+    mockCancelRecurring.mockResolvedValue({ canceled: true });
     mockCreateSession.mockResolvedValue({
       url: "https://checkout.stripe.com/c/pay/cs_test_123",
       sessionId: "cs_test_123",
@@ -448,6 +455,55 @@ describe("GiveScreen", () => {
         "https://checkout.stripe.com/c/pay/cs_sub_123",
       );
       expect(WebBrowser.dismissBrowser).toHaveBeenCalled();
+    });
+
+    // Backing out of the waiting step leaves a `pending` recurringDonations
+    // row on the server, and that row blocks a new monthly gift to this fund
+    // for the whole 30-minute grace window while its Stripe page stays live.
+    // "Cancel this gift" that only cleared local state would therefore mean
+    // "you may not give monthly for half an hour".
+    describe("backing out of a monthly checkout", () => {
+      it("releases the pending row so the donor can immediately try again", async () => {
+        const { getByTestId } = render(<GiveScreen />);
+        await pressGiveMonthly(getByTestId);
+        expect(getByTestId("give-step").props.children).toBe("confirmation");
+
+        await act(async () => {
+          fireEvent.press(getByTestId("give-back"));
+        });
+
+        expect(mockCancelRecurring).toHaveBeenCalledWith({
+          recurringDonationId: "rec_1",
+        });
+        expect(getByTestId("give-step").props.children).toBe("amount");
+      });
+
+      // A one-off has no server-side row to release — cancelling something
+      // there would be cancelling a stranger's gift or nothing at all.
+      it("touches nothing on the server backing out of a one-off", async () => {
+        const { getByTestId } = render(<GiveScreen />);
+        await pressGive(getByTestId);
+
+        await act(async () => {
+          fireEvent.press(getByTestId("give-back"));
+        });
+
+        expect(mockCancelRecurring).not.toHaveBeenCalled();
+      });
+
+      // The release is a courtesy, not a precondition: a donor who is already
+      // walking away must still get back to the amount step.
+      it("still goes back when the release fails", async () => {
+        mockCancelRecurring.mockRejectedValue(new Error("network"));
+        const { getByTestId } = render(<GiveScreen />);
+        await pressGiveMonthly(getByTestId);
+
+        await act(async () => {
+          fireEvent.press(getByTestId("give-back"));
+        });
+
+        expect(getByTestId("give-step").props.children).toBe("amount");
+      });
     });
 
     // One active monthly per fund is a backend rule; the container refuses

--- a/apps/mobile/features/finance/member/__tests__/GiveScreenView.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/GiveScreenView.test.tsx
@@ -91,6 +91,7 @@ const noop = () => {};
 const baseProps = {
   context: liveContext,
   step: "amount" as const,
+  frequency: "once" as const,
   selectedPresetCents: null,
   customAmountText: "",
   coverFees: false,
@@ -98,12 +99,14 @@ const baseProps = {
   error: null,
   checkoutSession: null,
   onBack: noop,
+  onSelectFrequency: noop,
   onSelectPreset: noop,
   onCustomAmountChange: noop,
   onToggleCoverFees: noop,
   onContinue: noop,
   onReopenCheckout: noop,
   onFinishManually: noop,
+  onManageRecurringPress: noop,
   canAutoAdvance: true,
 };
 
@@ -198,6 +201,114 @@ describe("GiveScreenView", () => {
     ).toBeTruthy();
   });
 
+  // Frequency sits ABOVE the amount: the number a donor picks depends on how
+  // often they're being asked for it.
+  describe("frequency", () => {
+    it("offers One time and Monthly as chips", () => {
+      render(<GiveScreenView {...baseProps} />);
+      expect(screen.getByTestId("give-frequency-once")).toBeTruthy();
+      expect(screen.getByTestId("give-frequency-monthly")).toBeTruthy();
+    });
+
+    it("marks the chosen frequency as selected, and only that one", () => {
+      render(<GiveScreenView {...baseProps} frequency="monthly" />);
+      expect(
+        screen.getByTestId("give-frequency-monthly").props.accessibilityState.selected,
+      ).toBe(true);
+      expect(
+        screen.getByTestId("give-frequency-once").props.accessibilityState.selected,
+      ).toBe(false);
+    });
+
+    it("reports a frequency change upward", () => {
+      const onSelectFrequency = jest.fn();
+      render(<GiveScreenView {...baseProps} onSelectFrequency={onSelectFrequency} />);
+      fireEvent.press(screen.getByTestId("give-frequency-monthly"));
+      expect(onSelectFrequency).toHaveBeenCalledWith("monthly");
+    });
+
+    // The CTA is the last thing read before a card is charged — it has to say
+    // whether this is once or every month.
+    it("says 'monthly' on the CTA when monthly is chosen", () => {
+      render(
+        <GiveScreenView {...baseProps} frequency="monthly" selectedPresetCents={5000} />,
+      );
+      expect(screen.getByLabelText(`Give ${formatCents(5000)} monthly`)).toBeTruthy();
+      expect(screen.queryByLabelText(`Give ${formatCents(5000)}`)).toBeNull();
+    });
+
+    it("leaves the one-off CTA alone", () => {
+      render(<GiveScreenView {...baseProps} selectedPresetCents={5000} />);
+      expect(screen.getByLabelText(`Give ${formatCents(5000)}`)).toBeTruthy();
+      expect(screen.queryByLabelText(/monthly/)).toBeNull();
+    });
+
+    it("adds the covered fee to the monthly CTA's total too", () => {
+      render(
+        <GiveScreenView
+          {...baseProps}
+          frequency="monthly"
+          selectedPresetCents={5000}
+          coverFees
+        />,
+      );
+      const fee = estimateCoverFeesCents(5000);
+      expect(
+        screen.getByLabelText(`Give ${formatCents(5000 + fee)} monthly`),
+      ).toBeTruthy();
+    });
+  });
+
+  // One active monthly per fund is a backend rule. The UI never offers a
+  // second — it points at the one they have instead of letting them find out
+  // from an error after a tap.
+  describe("when the donor already gives monthly to this fund", () => {
+    const withExisting = {
+      ...baseProps,
+      context: {
+        ...liveContext,
+        existingRecurring: { amountCents: 2500, feeCoverCents: 105 },
+      },
+      selectedPresetCents: 5000,
+    };
+
+    it("replaces the CTA with a notice naming the gift they already have", () => {
+      render(<GiveScreenView {...withExisting} frequency="monthly" />);
+      expect(screen.getByTestId("give-existing-recurring-notice")).toBeTruthy();
+      expect(screen.getByText(/You already give/)).toBeTruthy();
+      expect(screen.getByText(/\$25\.00\/month/)).toBeTruthy();
+      expect(screen.queryByLabelText(/^Give /)).toBeNull();
+    });
+
+    // The notice names the GIFT, not the charge: a donor covering the fee
+    // chose $25, and restating it as $26.05 is a number they never picked.
+    it("names the gift amount, not the fee-inclusive charge", () => {
+      render(<GiveScreenView {...withExisting} frequency="monthly" />);
+      expect(screen.queryByText(/\$26\.05/)).toBeNull();
+    });
+
+    it("offers a way through to managing it", () => {
+      const onManageRecurringPress = jest.fn();
+      render(
+        <GiveScreenView
+          {...withExisting}
+          frequency="monthly"
+          onManageRecurringPress={onManageRecurringPress}
+        />,
+      );
+      fireEvent.press(screen.getByLabelText("Manage your monthly gift"));
+      expect(onManageRecurringPress).toHaveBeenCalledTimes(1);
+    });
+
+    // Non-blocking: an existing monthly gift must not stop a one-off.
+    it("leaves the one-time CTA fully usable", () => {
+      render(<GiveScreenView {...withExisting} frequency="once" />);
+      expect(screen.queryByTestId("give-existing-recurring-notice")).toBeNull();
+      const cta = screen.getByLabelText(`Give ${formatCents(5000)}`);
+      expect(cta.props.accessibilityState.disabled).toBe(false);
+    });
+  });
+
   describe("waiting step", () => {
     const waitingProps = {
       ...baseProps,
@@ -215,6 +326,13 @@ describe("GiveScreenView", () => {
       expect(screen.getByText("Finish in the browser")).toBeTruthy();
       expect(screen.getByText(formatCents(5000))).toBeTruthy();
       expect(screen.getByText("Young Adults — Manhattan")).toBeTruthy();
+    });
+
+    // A monthly gift's summary must not read as a one-off total — the donor is
+    // committing to this number every month, not once.
+    it("marks the amount as monthly on a monthly gift", () => {
+      render(<GiveScreenView {...waitingProps} frequency="monthly" />);
+      expect(screen.getByText(`${formatCents(5000)}/month`)).toBeTruthy();
     });
 
     it("calls onReopenCheckout when 'Reopen payment page' is tapped", () => {

--- a/apps/mobile/features/finance/member/__tests__/MonthlyGivingScreen.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/MonthlyGivingScreen.test.tsx
@@ -1,0 +1,325 @@
+/**
+ * MonthlyGivingScreen (container) — the wiring the view can't be asked about:
+ * that stopping a gift is confirmed through the web-safe helper (not
+ * `Alert.alert`, which is a no-op on web), that a declined confirm changes
+ * nothing, and that the card row leaves for Stripe rather than trying to
+ * collect a card in-app.
+ */
+import React from "react";
+import { render, fireEvent, act } from "@testing-library/react-native";
+import * as WebBrowser from "expo-web-browser";
+import { useAuthenticatedQuery } from "@services/api/convex";
+import { useLocalSearchParams } from "expo-router";
+import { confirmAsync } from "@/utils/platformAlert";
+import { MonthlyGivingScreen } from "../MonthlyGivingScreen";
+import { estimateCoverFeesCents } from "../amount";
+
+const GET_GIVING_CONTEXT = "api.functions.finance.giving.getGivingContext";
+const GET_RECURRING_FOR_FUND = "api.functions.finance.giving.getRecurringForFund";
+const UPDATE_AMOUNT = "api.functions.finance.giving.updateRecurringAmount";
+const CANCEL = "api.functions.finance.giving.cancelRecurringDonation";
+const CARD_UPDATE = "api.functions.finance.giving.createCardUpdateSession";
+
+jest.mock("@services/api/convex", () => ({
+  api: {
+    functions: {
+      finance: {
+        giving: {
+          getGivingContext: "api.functions.finance.giving.getGivingContext",
+          getRecurringForFund: "api.functions.finance.giving.getRecurringForFund",
+          updateRecurringAmount: "api.functions.finance.giving.updateRecurringAmount",
+          cancelRecurringDonation:
+            "api.functions.finance.giving.cancelRecurringDonation",
+          createCardUpdateSession:
+            "api.functions.finance.giving.createCardUpdateSession",
+        },
+      },
+    },
+  },
+  useAuthenticatedQuery: jest.fn(),
+  useAuthenticatedAction: jest.fn(),
+}));
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+jest.mock("expo-web-browser", () => ({
+  openBrowserAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/utils/platformAlert", () => ({
+  confirmAsync: jest.fn(),
+}));
+
+// Stubbed to the handful of affordances the container drives, so these tests
+// fail for container reasons only.
+jest.mock("../MonthlyGivingScreenView", () => {
+  const { Text, Pressable } = require("react-native");
+  return {
+    MonthlyGivingScreenView: ({
+      recurring,
+      editing,
+      editAmountText,
+      error,
+      onStartEdit,
+      onAmountChange,
+      onSaveAmount,
+      onUpdateCard,
+      onCancelRecurring,
+    }: any) => (
+      <>
+        <Text testID="mg-recurring">{recurring === undefined ? "loading" : String(recurring?.status ?? "none")}</Text>
+        <Text testID="mg-editing">{String(editing)}</Text>
+        <Text testID="mg-amount-text">{editAmountText}</Text>
+        <Text testID="mg-error">{error ?? ""}</Text>
+        <Pressable testID="mg-start-edit" onPress={onStartEdit}>
+          <Text>Change amount</Text>
+        </Pressable>
+        <Pressable testID="mg-type-50" onPress={() => onAmountChange("50")}>
+          <Text>Type 50</Text>
+        </Pressable>
+        <Pressable testID="mg-save" onPress={onSaveAmount}>
+          <Text>Save</Text>
+        </Pressable>
+        <Pressable testID="mg-update-card" onPress={onUpdateCard}>
+          <Text>Update card</Text>
+        </Pressable>
+        <Pressable testID="mg-cancel" onPress={onCancelRecurring}>
+          <Text>Cancel monthly giving</Text>
+        </Pressable>
+      </>
+    ),
+  };
+});
+
+const { useAuthenticatedAction } = jest.requireMock("@services/api/convex");
+const { useRouter } = jest.requireMock("expo-router");
+
+const mockBack = jest.fn();
+const mockReplace = jest.fn();
+const mockUpdateAmount = jest.fn();
+const mockCancel = jest.fn();
+const mockCardUpdate = jest.fn();
+
+const context = {
+  fundId: "fund_1",
+  fundName: "Young Adults — Manhattan",
+  communityLegalName: "First Church Inc.",
+  givingLive: true,
+  suggestedAmountsCents: [1000, 2500, 5000],
+  existingRecurring: { amountCents: 2500, feeCoverCents: 105 },
+};
+
+const activeRow = {
+  id: "rec_1",
+  fundId: "fund_1",
+  groupId: "group_1",
+  fundName: "Young Adults — Manhattan",
+  amountCents: 2500,
+  feeCoverCents: 105,
+  status: "active",
+  currentPeriodEnd: Date.UTC(2026, 8, 1, 12),
+  createdAt: 1,
+};
+
+let recurring: Record<string, unknown> | null | undefined = activeRow;
+
+describe("MonthlyGivingScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    recurring = activeRow;
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ group_id: "group_1" });
+    (useRouter as jest.Mock).mockReturnValue({
+      back: mockBack,
+      replace: mockReplace,
+      push: jest.fn(),
+      canGoBack: () => true,
+    });
+    (useAuthenticatedQuery as jest.Mock).mockImplementation((fn: string) => {
+      if (fn === GET_GIVING_CONTEXT) return context;
+      if (fn === GET_RECURRING_FOR_FUND) return recurring;
+      return undefined;
+    });
+    (useAuthenticatedAction as jest.Mock).mockImplementation((fn: string) => {
+      if (fn === UPDATE_AMOUNT) return mockUpdateAmount;
+      if (fn === CANCEL) return mockCancel;
+      if (fn === CARD_UPDATE) return mockCardUpdate;
+      return jest.fn();
+    });
+    mockUpdateAmount.mockResolvedValue({ amountCents: 5000, feeCoverCents: 0 });
+    mockCancel.mockResolvedValue({ canceled: true });
+    mockCardUpdate.mockResolvedValue({
+      url: "https://billing.stripe.com/p/session/test_123",
+    });
+    (confirmAsync as jest.Mock).mockResolvedValue(true);
+  });
+
+  it("reads the donor's gift for the fund the group's giving context names", () => {
+    const { getByTestId } = render(<MonthlyGivingScreen />);
+    const call = (useAuthenticatedQuery as jest.Mock).mock.calls.find(
+      ([fn]) => fn === GET_RECURRING_FOR_FUND,
+    );
+    expect(call?.[1]).toEqual({ fundId: "fund_1" });
+    expect(getByTestId("mg-recurring").props.children).toBe("active");
+  });
+
+  // Giving not being set up for the group at all is the same answer as "you
+  // have no monthly gift here" — but neither may be confused with loading.
+  it("reports no gift when giving isn't set up for the group", () => {
+    (useAuthenticatedQuery as jest.Mock).mockImplementation((fn: string) =>
+      fn === GET_GIVING_CONTEXT ? null : undefined,
+    );
+    const { getByTestId } = render(<MonthlyGivingScreen />);
+    expect(getByTestId("mg-recurring").props.children).toBe("none");
+  });
+
+  it("stays on the loading state while the context is still resolving", () => {
+    (useAuthenticatedQuery as jest.Mock).mockReturnValue(undefined);
+    const { getByTestId } = render(<MonthlyGivingScreen />);
+    expect(getByTestId("mg-recurring").props.children).toBe("loading");
+  });
+
+  // Opening on an empty field would make the donor re-derive what they already
+  // give before they can change it.
+  it("seeds the editor with the amount they currently give", () => {
+    const { getByTestId } = render(<MonthlyGivingScreen />);
+    act(() => {
+      fireEvent.press(getByTestId("mg-start-edit"));
+    });
+    expect(getByTestId("mg-editing").props.children).toBe("true");
+    expect(getByTestId("mg-amount-text").props.children).toBe("25");
+  });
+
+  // The fee-cover choice carries over too, and is RE-QUOTED for the new
+  // amount: sending the old $1.05 with a $50 gift would silently under-cover
+  // the fund by exactly the difference.
+  it("submits the new amount with a fee re-quoted for it, then closes the editor", async () => {
+    const { getByTestId } = render(<MonthlyGivingScreen />);
+    act(() => {
+      fireEvent.press(getByTestId("mg-start-edit"));
+    });
+    act(() => {
+      fireEvent.press(getByTestId("mg-type-50"));
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId("mg-save"));
+    });
+
+    expect(mockUpdateAmount).toHaveBeenCalledWith({
+      recurringDonationId: "rec_1",
+      amountCents: 5000,
+      coverFeesCents: estimateCoverFeesCents(5000),
+    });
+    expect(getByTestId("mg-editing").props.children).toBe("false");
+  });
+
+  it("sends no fee at all when the donor never covered one", async () => {
+    recurring = { ...(recurring as object), feeCoverCents: 0 } as typeof recurring;
+    const { getByTestId } = render(<MonthlyGivingScreen />);
+    act(() => {
+      fireEvent.press(getByTestId("mg-start-edit"));
+    });
+    act(() => {
+      fireEvent.press(getByTestId("mg-type-50"));
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId("mg-save"));
+    });
+
+    expect(mockUpdateAmount).toHaveBeenCalledWith(
+      expect.objectContaining({ coverFeesCents: 0 }),
+    );
+  });
+
+  it("keeps the editor open and shows why when the change is rejected", async () => {
+    mockUpdateAmount.mockRejectedValue(new Error("Donation amount must be between"));
+    const { getByTestId } = render(<MonthlyGivingScreen />);
+    act(() => {
+      fireEvent.press(getByTestId("mg-start-edit"));
+    });
+    act(() => {
+      fireEvent.press(getByTestId("mg-type-50"));
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId("mg-save"));
+    });
+
+    expect(getByTestId("mg-editing").props.children).toBe("true");
+    expect(getByTestId("mg-error").props.children).toMatch(/must be between/);
+  });
+
+  describe("stopping the gift", () => {
+    // `Alert.alert` is a no-op on web in this codebase — a confirm built on it
+    // would silently never stop anything there.
+    it("confirms through the web-safe helper, naming what is and isn't ended", async () => {
+      const { getByTestId } = render(<MonthlyGivingScreen />);
+      await act(async () => {
+        fireEvent.press(getByTestId("mg-cancel"));
+      });
+
+      expect(confirmAsync).toHaveBeenCalledTimes(1);
+      const opts = (confirmAsync as jest.Mock).mock.calls[0][0];
+      expect(opts.message).toBe("Ends future gifts. Past gifts stay.");
+      expect(opts.destructive).toBe(true);
+    });
+
+    it("stops the gift and returns to the fund once confirmed", async () => {
+      const { getByTestId } = render(<MonthlyGivingScreen />);
+      await act(async () => {
+        fireEvent.press(getByTestId("mg-cancel"));
+      });
+
+      expect(mockCancel).toHaveBeenCalledWith({ recurringDonationId: "rec_1" });
+      expect(mockBack).toHaveBeenCalledTimes(1);
+    });
+
+    it("does nothing at all when the donor backs out of the confirm", async () => {
+      (confirmAsync as jest.Mock).mockResolvedValue(false);
+      const { getByTestId } = render(<MonthlyGivingScreen />);
+      await act(async () => {
+        fireEvent.press(getByTestId("mg-cancel"));
+      });
+
+      expect(mockCancel).not.toHaveBeenCalled();
+      expect(mockBack).not.toHaveBeenCalled();
+    });
+
+    it("stays put and says why when the stop fails", async () => {
+      mockCancel.mockRejectedValue(new Error("Network request failed"));
+      const { getByTestId } = render(<MonthlyGivingScreen />);
+      await act(async () => {
+        fireEvent.press(getByTestId("mg-cancel"));
+      });
+
+      expect(mockBack).not.toHaveBeenCalled();
+      expect(getByTestId("mg-error").props.children).toBeTruthy();
+    });
+  });
+
+  describe("updating the card", () => {
+    it("opens the Stripe portal URL it was handed", async () => {
+      const { getByTestId } = render(<MonthlyGivingScreen />);
+      await act(async () => {
+        fireEvent.press(getByTestId("mg-update-card"));
+      });
+
+      expect(mockCardUpdate).toHaveBeenCalledWith({ recurringDonationId: "rec_1" });
+      expect(WebBrowser.openBrowserAsync).toHaveBeenCalledWith(
+        "https://billing.stripe.com/p/session/test_123",
+      );
+    });
+
+    it("surfaces a failure rather than opening nothing silently", async () => {
+      mockCardUpdate.mockRejectedValue(new Error("still being set up"));
+      const { getByTestId } = render(<MonthlyGivingScreen />);
+      await act(async () => {
+        fireEvent.press(getByTestId("mg-update-card"));
+      });
+
+      expect(WebBrowser.openBrowserAsync).not.toHaveBeenCalled();
+      expect(getByTestId("mg-error").props.children).toMatch(/still being set up/);
+    });
+  });
+});

--- a/apps/mobile/features/finance/member/__tests__/MonthlyGivingScreen.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/MonthlyGivingScreen.test.tsx
@@ -38,6 +38,7 @@ jest.mock("@services/api/convex", () => ({
   },
   useAuthenticatedQuery: jest.fn(),
   useAuthenticatedAction: jest.fn(),
+  useStoredAuthToken: jest.fn(),
 }));
 
 jest.mock("expo-router", () => ({
@@ -91,10 +92,13 @@ jest.mock("../MonthlyGivingScreenView", () => {
         </Pressable>
       </>
     ),
+    MonthlyGivingPortalReturnNotice: () => <Text testID="mg-portal-notice">close me</Text>,
   };
 });
 
-const { useAuthenticatedAction } = jest.requireMock("@services/api/convex");
+const { useAuthenticatedAction, useStoredAuthToken } = jest.requireMock(
+  "@services/api/convex",
+);
 const { useRouter } = jest.requireMock("expo-router");
 
 const mockBack = jest.fn();
@@ -131,6 +135,7 @@ describe("MonthlyGivingScreen", () => {
     jest.clearAllMocks();
     recurring = activeRow;
     (useLocalSearchParams as jest.Mock).mockReturnValue({ group_id: "group_1" });
+    (useStoredAuthToken as jest.Mock).mockReturnValue("token_abc");
     (useRouter as jest.Mock).mockReturnValue({
       back: mockBack,
       replace: mockReplace,
@@ -248,6 +253,70 @@ describe("MonthlyGivingScreen", () => {
 
     expect(getByTestId("mg-editing").props.children).toBe("true");
     expect(getByTestId("mg-error").props.children).toMatch(/must be between/);
+  });
+
+  // The shape a rejection ACTUALLY has in production: Convex puts the
+  // `ConvexError` payload on `.data` and reduces `.message` to an opaque
+  // "[CONVEX A(...)] ... Server Error". A message-parsing formatter would swap
+  // the fee ceiling — the one rejection the donor can act on — for a generic
+  // "please try again", so the reason has to come off `.data`.
+  it("surfaces the server's reason from a production-shaped ConvexError", async () => {
+    mockUpdateAmount.mockRejectedValue(
+      Object.assign(
+        new Error(
+          "[CONVEX A(functions/finance/giving:updateRecurringAmount)] [Request ID: abc] Server Error",
+        ),
+        { data: "Fee cover can't be more than the gift itself." },
+      ),
+    );
+    const { getByTestId } = render(<MonthlyGivingScreen />);
+    act(() => {
+      fireEvent.press(getByTestId("mg-start-edit"));
+    });
+    act(() => {
+      fireEvent.press(getByTestId("mg-type-50"));
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId("mg-save"));
+    });
+
+    expect(getByTestId("mg-error").props.children).toBe(
+      "Fee cover can't be more than the gift itself.",
+    );
+  });
+
+  // Stripe's Billing Portal returns to this route, and on native that return
+  // lands in the portal's own auth-less in-app browser: no session, every
+  // query skips, and the skeleton would never fill.
+  describe("returning from Stripe's Billing Portal", () => {
+    it("shows a terminal close-this-window notice when there is no session", () => {
+      (useLocalSearchParams as jest.Mock).mockReturnValue({
+        group_id: "group_1",
+        portal_return: "1",
+      });
+      (useStoredAuthToken as jest.Mock).mockReturnValue(null);
+      const { getByTestId, queryByTestId } = render(<MonthlyGivingScreen />);
+      expect(getByTestId("mg-portal-notice")).toBeTruthy();
+      expect(queryByTestId("mg-recurring")).toBeNull();
+    });
+
+    it("renders the real manage screen when the donor IS signed in", () => {
+      (useLocalSearchParams as jest.Mock).mockReturnValue({
+        group_id: "group_1",
+        portal_return: "1",
+      });
+      const { getByTestId, queryByTestId } = render(<MonthlyGivingScreen />);
+      expect(queryByTestId("mg-portal-notice")).toBeNull();
+      expect(getByTestId("mg-recurring").props.children).toBe("active");
+    });
+
+    // Without the flag a signed-out visitor is just an ordinary unauthenticated
+    // hit on the route, not someone stuck in Stripe's browser.
+    it("does not hijack an ordinary signed-out visit to the route", () => {
+      (useStoredAuthToken as jest.Mock).mockReturnValue(null);
+      const { queryByTestId } = render(<MonthlyGivingScreen />);
+      expect(queryByTestId("mg-portal-notice")).toBeNull();
+    });
   });
 
   describe("stopping the gift", () => {

--- a/apps/mobile/features/finance/member/__tests__/MonthlyGivingScreen.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/MonthlyGivingScreen.test.tsx
@@ -317,6 +317,23 @@ describe("MonthlyGivingScreen", () => {
       const { queryByTestId } = render(<MonthlyGivingScreen />);
       expect(queryByTestId("mg-portal-notice")).toBeNull();
     });
+
+    // `canGoBack()` is true even on a cold deep link, because the root layout
+    // pins `(tabs)` as its initial route — so popping would land the donor on
+    // the tab bar rather than the fund they were managing.
+    it("replaces to the fund rather than popping to the tab frame", async () => {
+      (useLocalSearchParams as jest.Mock).mockReturnValue({
+        group_id: "group_1",
+        portal_return: "1",
+      });
+      const { getByTestId } = render(<MonthlyGivingScreen />);
+      await act(async () => {
+        fireEvent.press(getByTestId("mg-cancel"));
+      });
+
+      expect(mockBack).not.toHaveBeenCalled();
+      expect(mockReplace).toHaveBeenCalledWith("/groups/group_1/fund");
+    });
   });
 
   describe("stopping the gift", () => {

--- a/apps/mobile/features/finance/member/__tests__/MonthlyGivingScreenView.test.tsx
+++ b/apps/mobile/features/finance/member/__tests__/MonthlyGivingScreenView.test.tsx
@@ -1,0 +1,305 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { MonthlyGivingScreenView } from "../MonthlyGivingScreenView";
+import { estimateCoverFeesCents } from "../amount";
+import { formatCents } from "../../format";
+import type { RecurringSummary } from "../recurring";
+
+jest.mock("@hooks/useTheme", () => ({
+  useTheme: () => ({
+    colors: {
+      background: "#fff",
+      surface: "#fff",
+      surfaceSecondary: "#f5f5f5",
+      text: "#111",
+      textSecondary: "#666",
+      textTertiary: "#999",
+      textInverse: "#fff",
+      border: "#e0e0e0",
+      buttonPrimary: "#222",
+      buttonSecondary: "#fafafa",
+      buttonDisabled: "#ccc",
+      success: "#2e7d32",
+      error: "#c00",
+      warning: "#e0a800",
+      link: "#06f",
+      destructive: "#c00",
+      iconSecondary: "#999",
+      separator: "#e0e0e0",
+      backgroundGrouped: "#F2F2F2",
+      surfaceGrouped: "#FFFFFF",
+      buttonPrimaryText: "#fff",
+    },
+    isDark: false,
+  }),
+}));
+
+jest.mock("@components/ui", () => {
+  const ReactActual = jest.requireActual("react");
+  const RN = jest.requireActual("react-native");
+  return {
+    Skeleton: (props: any) =>
+      ReactActual.createElement(RN.View, { testID: "skeleton", ...props }),
+    EmptyState: ({ title, message }: any) =>
+      ReactActual.createElement(
+        RN.View,
+        null,
+        ReactActual.createElement(RN.Text, null, title),
+        message ? ReactActual.createElement(RN.Text, null, message) : null,
+      ),
+  };
+});
+
+const activeMonthly: RecurringSummary = {
+  id: "rec1",
+  fundId: "fund1",
+  groupId: "group1",
+  fundName: "Young Adults — Manhattan",
+  amountCents: 2500,
+  feeCoverCents: 105,
+  status: "active",
+  currentPeriodEnd: Date.UTC(2026, 8, 1, 12),
+  createdAt: 1,
+};
+
+const noop = () => {};
+
+const baseProps = {
+  recurring: activeMonthly,
+  suggestedAmountsCents: [1000, 2500, 5000] as readonly number[],
+  editing: false,
+  editSelectedPresetCents: null,
+  editAmountText: "",
+  editCoverFees: false,
+  saving: false,
+  canceling: false,
+  updatingCard: false,
+  error: null,
+  onBack: noop,
+  onStartEdit: noop,
+  onCancelEdit: noop,
+  onSelectPreset: noop,
+  onAmountChange: noop,
+  onToggleCoverFees: noop,
+  onSaveAmount: noop,
+  onUpdateCard: noop,
+  onCancelRecurring: noop,
+};
+
+describe("MonthlyGivingScreenView", () => {
+  it("shows a loading skeleton while the gift is still loading", () => {
+    render(<MonthlyGivingScreenView {...baseProps} recurring={undefined} />);
+    expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0);
+  });
+
+  it("says plainly when there's nothing to manage", () => {
+    render(<MonthlyGivingScreenView {...baseProps} recurring={null} />);
+    expect(screen.getByText("No monthly gift here")).toBeTruthy();
+    expect(screen.queryByTestId("monthly-cancel")).toBeNull();
+  });
+
+  describe("the hero", () => {
+    it("shows the gift and where it goes, every month", () => {
+      render(<MonthlyGivingScreenView {...baseProps} />);
+      expect(screen.getByText("$25.00")).toBeTruthy();
+      expect(screen.getByText(/every month to Young Adults/)).toBeTruthy();
+    });
+
+    // The card is charged $26.05; the GIFT is $25. The hero shows the gift and
+    // the fee gets its own row, so neither number is a surprise.
+    it("shows the gift, not the fee-inclusive charge", () => {
+      render(<MonthlyGivingScreenView {...baseProps} />);
+      expect(screen.queryByText("$26.05")).toBeNull();
+    });
+  });
+
+  describe("the facts", () => {
+    it("dates the next gift", () => {
+      render(<MonthlyGivingScreenView {...baseProps} />);
+      expect(screen.getByTestId("monthly-next-gift").props.children).toMatch(
+        /^[A-Z][a-z]{2} \d{1,2}$/,
+      );
+    });
+
+    // Stripe hasn't reported a period on a just-bound gift — never fabricate
+    // one.
+    it("says 'Scheduled' rather than a fabricated date when there isn't one", () => {
+      render(
+        <MonthlyGivingScreenView
+          {...baseProps}
+          recurring={{ ...activeMonthly, currentPeriodEnd: null }}
+        />,
+      );
+      expect(screen.getByTestId("monthly-next-gift").props.children).toBe("Scheduled");
+    });
+
+    it("names the covered fee, and says Off when it isn't", () => {
+      render(<MonthlyGivingScreenView {...baseProps} />);
+      expect(screen.getByTestId("monthly-fee-cover").props.children).toBe("On · +$1.05");
+
+      screen.rerender(
+        <MonthlyGivingScreenView
+          {...baseProps}
+          recurring={{ ...activeMonthly, feeCoverCents: 0 }}
+        />,
+      );
+      expect(screen.getByTestId("monthly-fee-cover").props.children).toBe("Off");
+    });
+
+    // The card row leaves the app. Saying so up front is the difference
+    // between a trusted redirect and a jarring one.
+    it("warns that the card row opens Stripe", () => {
+      const onUpdateCard = jest.fn();
+      render(<MonthlyGivingScreenView {...baseProps} onUpdateCard={onUpdateCard} />);
+      expect(screen.getByText("Opens Stripe's secure page")).toBeTruthy();
+      fireEvent.press(screen.getByText("Update payment method"));
+      expect(onUpdateCard).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("past due", () => {
+    const pastDue = { ...activeMonthly, status: "past_due" as const };
+
+    it("banners the failure at the very top and links the card fix", () => {
+      const onUpdateCard = jest.fn();
+      render(
+        <MonthlyGivingScreenView
+          {...baseProps}
+          recurring={pastDue}
+          onUpdateCard={onUpdateCard}
+        />,
+      );
+      expect(screen.getByTestId("monthly-past-due-banner")).toBeTruthy();
+      fireEvent.press(screen.getByText("A payment didn't go through"));
+      expect(onUpdateCard).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows no banner on a healthy gift", () => {
+      render(<MonthlyGivingScreenView {...baseProps} />);
+      expect(screen.queryByTestId("monthly-past-due-banner")).toBeNull();
+    });
+  });
+
+  describe("changing the amount", () => {
+    it("offers the change as a cell, and promises when it takes effect", () => {
+      const onStartEdit = jest.fn();
+      render(<MonthlyGivingScreenView {...baseProps} onStartEdit={onStartEdit} />);
+      expect(
+        screen.getByText(
+          "A new amount starts with your next gift — this month is already paid.",
+        ),
+      ).toBeTruthy();
+      fireEvent.press(screen.getByText("Change amount"));
+      expect(onStartEdit).toHaveBeenCalledTimes(1);
+    });
+
+    const editing = { ...baseProps, editing: true, editAmountText: "25" };
+
+    it("replaces the cell with the editor rather than opening below it", () => {
+      render(<MonthlyGivingScreenView {...editing} />);
+      expect(screen.getByTestId("monthly-amount-editor")).toBeTruthy();
+      expect(screen.queryByTestId("monthly-change-amount")).toBeNull();
+    });
+
+    it("reuses the give form's vocabulary — typed amount, presets, fee toggle", () => {
+      render(<MonthlyGivingScreenView {...editing} />);
+      expect(screen.getByTestId("monthly-amount-input").props.value).toBe("25");
+      expect(screen.getByLabelText(`${formatCents(5000)} preset`)).toBeTruthy();
+      expect(screen.getByText("Cover the processing fee")).toBeTruthy();
+    });
+
+    it("shows a tapped preset's dollars in the same field the donor types in", () => {
+      render(
+        <MonthlyGivingScreenView
+          {...editing}
+          editAmountText=""
+          editSelectedPresetCents={5000}
+        />,
+      );
+      expect(screen.getByTestId("monthly-amount-input").props.value).toBe("50");
+    });
+
+    it("explains the fee toggle in terms of what the fund ends up with", () => {
+      render(<MonthlyGivingScreenView {...editing} editCoverFees />);
+      const fee = estimateCoverFeesCents(2500);
+      expect(
+        screen.getByText(
+          `+${formatCents(fee)} so the fund gets the full ${formatCents(2500)}`,
+        ),
+      ).toBeTruthy();
+    });
+
+    it("labels the save with the new monthly amount, and submits it", () => {
+      const onSaveAmount = jest.fn();
+      render(<MonthlyGivingScreenView {...editing} onSaveAmount={onSaveAmount} />);
+      const save = screen.getByLabelText("Save new amount");
+      expect(save.props.accessibilityState.disabled).toBe(false);
+      expect(screen.getByText("Give $25.00 monthly")).toBeTruthy();
+      fireEvent.press(save);
+      expect(onSaveAmount).toHaveBeenCalledTimes(1);
+    });
+
+    it("can't be saved without an amount", () => {
+      render(<MonthlyGivingScreenView {...editing} editAmountText="" />);
+      expect(
+        screen.getByLabelText("Save new amount").props.accessibilityState.disabled,
+      ).toBe(true);
+    });
+
+    it("offers a way out that keeps the current amount", () => {
+      const onCancelEdit = jest.fn();
+      render(<MonthlyGivingScreenView {...editing} onCancelEdit={onCancelEdit} />);
+      fireEvent.press(screen.getByLabelText("Keep the current amount"));
+      expect(onCancelEdit).toHaveBeenCalledTimes(1);
+    });
+
+    // A donor mid-edit is deciding how much to give, not whether — the stop
+    // control has no business under their thumb while they type.
+    it("hides the cancel-giving cell while the editor is open", () => {
+      render(<MonthlyGivingScreenView {...editing} />);
+      expect(screen.queryByTestId("monthly-cancel")).toBeNull();
+    });
+  });
+
+  describe("stopping the gift", () => {
+    it("is the last thing on the screen, and says what it does and doesn't do", () => {
+      render(<MonthlyGivingScreenView {...baseProps} />);
+      expect(screen.getByText("Cancel monthly giving")).toBeTruthy();
+      expect(screen.getByText("Ends future gifts. Past gifts stay.")).toBeTruthy();
+    });
+
+    it("hands the confirmation upward rather than stopping anything itself", () => {
+      const onCancelRecurring = jest.fn();
+      render(
+        <MonthlyGivingScreenView
+          {...baseProps}
+          onCancelRecurring={onCancelRecurring}
+        />,
+      );
+      fireEvent.press(screen.getByText("Cancel monthly giving"));
+      expect(onCancelRecurring).toHaveBeenCalledTimes(1);
+    });
+
+    it("goes disabled while the cancel is in flight, so it can't be double-tapped", () => {
+      const onCancelRecurring = jest.fn();
+      render(
+        <MonthlyGivingScreenView
+          {...baseProps}
+          canceling
+          onCancelRecurring={onCancelRecurring}
+        />,
+      );
+      fireEvent.press(screen.getByText("Cancel monthly giving"));
+      expect(onCancelRecurring).not.toHaveBeenCalled();
+    });
+  });
+
+  it("surfaces an action failure instead of swallowing it", () => {
+    render(
+      <MonthlyGivingScreenView {...baseProps} error="Couldn't change this amount." />,
+    );
+    expect(screen.getByTestId("monthly-giving-error").props.children).toBe(
+      "Couldn't change this amount.",
+    );
+  });
+});

--- a/apps/mobile/features/finance/member/__tests__/giveSuccessParams.test.ts
+++ b/apps/mobile/features/finance/member/__tests__/giveSuccessParams.test.ts
@@ -48,6 +48,38 @@ describe("parseGiveSuccessParams", () => {
     expect(parseGiveSuccessParams({}).fundLine).toBeNull();
   });
 
+  // The amount above the fund line is ONE MONTH's charge. Without "every
+  // month", the screen reads as a one-off for the same money.
+  describe("a monthly gift", () => {
+    it("says the gift repeats, and to where", () => {
+      expect(
+        parseGiveSuccessParams({ fund: "Young Adults", recurring: "1" }).fundLine,
+      ).toBe("every month to Young Adults");
+    });
+
+    it("still says it repeats when the fund name is missing", () => {
+      expect(parseGiveSuccessParams({ recurring: "1" }).fundLine).toBe("every month");
+    });
+
+    it("acknowledges the monthly commitment in the thank-you", () => {
+      expect(
+        parseGiveSuccessParams({ community: "First Church Inc.", recurring: "1" })
+          .thankYouLine,
+      ).toBe("First Church Inc. says thank you for giving monthly");
+      expect(parseGiveSuccessParams({ recurring: "1" }).thankYouLine).toBe(
+        "Thank you for giving monthly 🎉",
+      );
+    });
+
+    // Only the flag the backend and the native watcher actually set counts —
+    // anything else is a hand-typed URL and reads as a one-off.
+    it.each(["0", "true", "yes", ""])("ignores recurring=%p", (recurring) => {
+      expect(parseGiveSuccessParams({ fund: "Young Adults", recurring }).fundLine).toBe(
+        "to Young Adults",
+      );
+    });
+  });
+
   // expo-router hands repeated query keys back as an array.
   it("takes the first value when a param repeats", () => {
     expect(

--- a/apps/mobile/features/finance/member/__tests__/recurring.test.ts
+++ b/apps/mobile/features/finance/member/__tests__/recurring.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The phrasing rules every monthly-giving surface shares. Pure functions, so
+ * the copy contract ("never restate the gift as the charge", "never print a
+ * date Stripe hasn't given us") is asserted once instead of per screen.
+ */
+import {
+  isLiveRecurring,
+  formatMonthlyTitle,
+  formatMonthlyRate,
+  formatMonthlySubtitle,
+  formatRecurringDate,
+  formatFeeCoverValue,
+  type RecurringSummary,
+} from "../recurring";
+
+const base: RecurringSummary = {
+  id: "rec1",
+  fundId: "fund1",
+  groupId: "group1",
+  fundName: "Young Adults — Manhattan",
+  amountCents: 2500,
+  feeCoverCents: 0,
+  status: "active",
+  currentPeriodEnd: Date.UTC(2026, 8, 1, 12),
+  createdAt: 1,
+};
+
+describe("isLiveRecurring", () => {
+  it.each(["active", "past_due"] as const)("counts %s as live", (status) => {
+    expect(isLiveRecurring({ ...base, status })).toBe(true);
+  });
+
+  // `pending` means the donor is still inside Stripe Checkout and nothing has
+  // been charged; `canceled` has nothing left to manage.
+  it.each(["pending", "canceled"] as const)("does not count %s", (status) => {
+    expect(isLiveRecurring({ ...base, status })).toBe(false);
+  });
+
+  it("handles the loading and none cases", () => {
+    expect(isLiveRecurring(undefined)).toBe(false);
+    expect(isLiveRecurring(null)).toBe(false);
+  });
+});
+
+describe("formatMonthlyTitle / formatMonthlyRate", () => {
+  it("states the gift in the donor's own words", () => {
+    expect(formatMonthlyTitle(2500)).toBe("You give $25.00 monthly");
+    expect(formatMonthlyRate(2500)).toBe("$25.00/month");
+  });
+
+  // The card is charged gift + fee cover, but the GIFT is what the donor
+  // chose. Restating it as the charge shows them a number they never picked.
+  it("says nothing about the fee cover", () => {
+    expect(formatMonthlyTitle(2500)).not.toContain("26");
+    expect(formatMonthlyRate(2500)).not.toContain("26");
+  });
+});
+
+describe("formatRecurringDate", () => {
+  it("renders a short absolute date, never a countdown", () => {
+    const label = formatRecurringDate(Date.UTC(2026, 8, 1, 12));
+    expect(label).toMatch(/^[A-Z][a-z]{2} \d{1,2}$/);
+    expect(label).not.toMatch(/\bin\b|\bdays?\b/);
+  });
+
+  it("returns null rather than 'Invalid Date' for anything unusable", () => {
+    expect(formatRecurringDate(null)).toBeNull();
+    expect(formatRecurringDate(NaN)).toBeNull();
+    expect(formatRecurringDate(Infinity)).toBeNull();
+  });
+});
+
+describe("formatMonthlySubtitle", () => {
+  it("leads with the next gift date", () => {
+    expect(formatMonthlySubtitle(base)).toMatch(/^Next gift .+ · Manage or cancel$/);
+  });
+
+  it("drops the date when Stripe hasn't reported a period yet", () => {
+    expect(formatMonthlySubtitle({ ...base, currentPeriodEnd: null })).toBe(
+      "Manage or cancel",
+    );
+  });
+
+  // A donor whose card is failing has no next date worth promising, and the
+  // sub-line is the only place to tell them.
+  it("replaces the whole line when the payment is failing", () => {
+    const line = formatMonthlySubtitle({ ...base, status: "past_due" });
+    expect(line).toBe("Payment issue — tap to fix");
+    expect(line).not.toMatch(/Next gift/);
+  });
+});
+
+describe("formatFeeCoverValue", () => {
+  it("names the amount when the fee is covered", () => {
+    expect(formatFeeCoverValue(105)).toBe("On · +$1.05");
+  });
+
+  it("says Off without a number when it isn't", () => {
+    expect(formatFeeCoverValue(0)).toBe("Off");
+  });
+});

--- a/apps/mobile/features/finance/member/giveSuccessParams.ts
+++ b/apps/mobile/features/finance/member/giveSuccessParams.ts
@@ -51,7 +51,11 @@ export interface GiveSuccessDisplay {
   amountLabel: string | null;
   /** e.g. "First Church Inc. says thank you", or the community-agnostic fallback. */
   thankYouLine: string;
-  /** e.g. "to Young Adults — Manhattan", or `null` when `fund` is missing. */
+  /**
+   * e.g. "to Young Adults — Manhattan" — or "every month to …" for a monthly
+   * gift, which is the one thing that number under it doesn't say on its own.
+   * `null` when neither a fund nor `recurring` is set.
+   */
   fundLine: string | null;
 }
 
@@ -81,10 +85,14 @@ export function parseGiveSuccessParams(params: {
   amount?: string | string[];
   fund?: string | string[];
   community?: string | string[];
+  /** `"1"` for a monthly gift — set by `buildGiveReturnUrls` and by
+   * `GiveScreen`'s own recurring watcher. Anything else reads as one-off. */
+  recurring?: string | string[];
 }): GiveSuccessDisplay {
   const amountRaw = firstParam(params.amount);
   const fund = firstParam(params.fund);
   const community = firstParam(params.community);
+  const recurring = firstParam(params.recurring) === "1";
 
   // `Number("")` is 0 and `Number(" 12 ")` is 12, so the string is validated by
   // shape first — only digits — rather than by whatever Number() tolerates.
@@ -99,7 +107,25 @@ export function parseGiveSuccessParams(params: {
     amountLabel,
     // "Thank you 🎉" is the community-agnostic fallback: with no community
     // name there is no one to speak for, so the screen thanks in its own voice.
-    thankYouLine: community ? `${community} says thank you` : "Thank you 🎉",
-    fundLine: fund ? `to ${fund}` : null,
+    //
+    // A monthly gift gets its own thanks because the donor just committed to
+    // something ongoing, and a thank-you identical to a one-off's leaves the
+    // biggest thing they did unacknowledged.
+    thankYouLine: recurring
+      ? community
+        ? `${community} says thank you for giving monthly`
+        : "Thank you for giving monthly 🎉"
+      : community
+        ? `${community} says thank you`
+        : "Thank you 🎉",
+    // The amount above this line is one month's charge, not a total — without
+    // "every month" the screen reads as a one-off for the same money.
+    fundLine: recurring
+      ? fund
+        ? `every month to ${fund}`
+        : "every month"
+      : fund
+        ? `to ${fund}`
+        : null,
   };
 }

--- a/apps/mobile/features/finance/member/recurring.ts
+++ b/apps/mobile/features/finance/member/recurring.ts
@@ -1,0 +1,99 @@
+/**
+ * Monthly-giving display helpers (ADR-032 recurring gifts).
+ *
+ * Pure functions — no Convex, no React — so the fund dashboard's monthly box,
+ * the give sheet's frequency notice and the manage screen all phrase the same
+ * gift the same way, and every phrasing rule is testable without rendering.
+ *
+ * The amount these format is the GIFT (`amountCents`), never the charge
+ * (`amountCents + feeCoverCents`). A donor who turned fee-cover on chose to
+ * give $25 and to pay Stripe's cut on top; a box that read "$25.79 monthly"
+ * would quietly restate their gift as a number they never picked. The fee is
+ * shown as its own line on the manage screen instead.
+ */
+import { formatCents } from "../format";
+
+/** Lifecycle of a `recurringDonations` row, mirroring the Convex schema. */
+export type RecurringStatus = "pending" | "active" | "past_due" | "canceled";
+
+/**
+ * Return shape of `getRecurringForFund` / `listMyRecurringDonations`.
+ * Duplicated here (rather than imported from the generated Convex types) so
+ * the presentational Views stay Convex-free — same contract as `types.ts`.
+ */
+export interface RecurringSummary {
+  id: string;
+  fundId: string;
+  groupId: string | null;
+  fundName: string;
+  amountCents: number;
+  feeCoverCents: number;
+  status: RecurringStatus;
+  /** Epoch ms the current period ends — i.e. when the next gift is charged. */
+  currentPeriodEnd: number | null;
+  createdAt: number;
+}
+
+/**
+ * Whether a gift is actually collecting, and therefore worth a box on the
+ * fund dashboard.
+ *
+ * `pending` means the donor is still inside Stripe Checkout and nothing has
+ * been charged — telling them "you give $25 monthly" then would be a lie the
+ * next screen contradicts. `canceled` has nothing left to manage. Matches the
+ * backend's own `LIVE_RECURRING_STATUSES`.
+ */
+export function isLiveRecurring(
+  recurring: RecurringSummary | null | undefined,
+): recurring is RecurringSummary {
+  return (
+    !!recurring &&
+    (recurring.status === "active" || recurring.status === "past_due")
+  );
+}
+
+/** "You give $25.00 monthly" — the dashboard box's title. */
+export function formatMonthlyTitle(amountCents: number): string {
+  return `You give ${formatCents(amountCents)} monthly`;
+}
+
+/** "$25.00/month" — the give sheet's already-giving notice. */
+export function formatMonthlyRate(amountCents: number): string {
+  return `${formatCents(amountCents)}/month`;
+}
+
+/**
+ * "Sep 1" — the same short, absolute date the fund's activity rows use. Never
+ * a relative "in 12 days": a billing date is a fact, and a countdown drifts
+ * the moment the screen is left open.
+ *
+ * `null` when Stripe hasn't reported a period yet (a gift bound seconds ago),
+ * so callers can drop the line rather than print "Next gift Invalid Date".
+ */
+export function formatRecurringDate(timestamp: number | null): string | null {
+  if (timestamp === null || !Number.isFinite(timestamp)) return null;
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+/**
+ * The dashboard box's sub-line.
+ *
+ * A `past_due` gift says what is wrong and what to do about it instead of the
+ * next date: there IS no next date worth promising while the card is failing,
+ * and "Next gift Sep 1" over a declined payment is the one sentence that would
+ * stop a donor from fixing it.
+ */
+export function formatMonthlySubtitle(recurring: RecurringSummary): string {
+  if (recurring.status === "past_due") {
+    return "Payment issue — tap to fix";
+  }
+  const next = formatRecurringDate(recurring.currentPeriodEnd);
+  return next ? `Next gift ${next} · Manage or cancel` : "Manage or cancel";
+}
+
+/** "On · +$1.05" / "Off" — the manage screen's fee-cover row value. */
+export function formatFeeCoverValue(feeCoverCents: number): string {
+  return feeCoverCents > 0 ? `On · +${formatCents(feeCoverCents)}` : "Off";
+}

--- a/apps/mobile/features/finance/member/types.ts
+++ b/apps/mobile/features/finance/member/types.ts
@@ -59,6 +59,16 @@ export interface GivingContext {
   communityLegalName: string;
   suggestedAmountsCents: readonly number[];
   givingLive: boolean;
+  /**
+   * The viewer's own live monthly gift to this fund, or `null`. Set only for
+   * `active`/`past_due` — the backend's `findLiveRecurring` excludes a
+   * `pending` row (donor still in Checkout) and a canceled one.
+   *
+   * Its presence is what turns the give sheet's Monthly option from "start a
+   * monthly gift" into "you already give $X/month" — one active monthly per
+   * fund is a backend rule, so the UI never offers a second.
+   */
+  existingRecurring?: { amountCents: number; feeCoverCents: number } | null;
 }
 
 /** Return shape of `createDonationCheckoutSession` — the hosted Stripe
@@ -74,6 +84,15 @@ export interface CheckoutSession {
    *
    * `null` when Stripe deferred creating the PaymentIntent — the gift still
    * lands via the webhook, but the wait degrades to manual (Reopen/Cancel).
+   *
+   * Also `null` for a MONTHLY gift: `mode: "subscription"` Checkout has no
+   * PaymentIntent at all, and that path watches `recurringDonationId` instead.
    */
   paymentIntentId: string | null;
+  /**
+   * Set only by `createRecurringDonationCheckoutSession` — the
+   * `recurringDonations` row this Checkout will bind to, and the join key the
+   * monthly waiting step watches (see `GiveScreen`).
+   */
+  recurringDonationId?: string | null;
 }


### PR DESCRIPTION
## Summary

The UI for monthly recurring giving (approved artifact v5, R1–R3), completing the stack on #736/#737.

- **R1 — dashboard box**: gold-tiled cell between Recent activity and Reimbursements — "You give $25.00 monthly · Next gift Sep 1 · Manage or cancel" — rendered only when an active/past_due monthly exists; past_due reads "Payment issue — tap to fix" in the warning color.
- **R2 — give form**: One time / Monthly chips above the amount; CTA "Give $X.XX monthly"; if you already give monthly to this fund, the CTA becomes a notice + Manage link (backend enforces one per fund). Monthly waiting step watches the recurring row itself — it advances only when **this** submission's row turns *active*, so a declined first charge keeps you on the waiting screen with Reopen/Cancel instead of a false thank-you. Success screen says "every month to «fund»" when `recurring=1`.
- **R3 — manage screen** (`/groups/[id]/monthly-giving`): amount hero, next-gift date, fee cover, "Update payment method" via Stripe's portal (portal now returns here — one-line backend fix included, exactly the change #737's comment promised), inline Change-amount editor reusing the give-form vocabulary, and a red **Cancel monthly giving** cell ("Ends future gifts. Past gifts stay.") with a platform-safe confirm (Alert.alert is a no-op on web — uses platformAlert).
- Additive `descriptionColor` prop on the shared `WaCell` (the past_due warning line needed a color hook).

## Evidence
```
jest features/finance + app/groups: 262 passed / 16 suites
components/wa + components: 982 passed / 105 suites
vitest finance-recurring-giving: 56/56 (return-url assertion updated with the fix)
apps/mobile tsc: zero errors in touched files (repo baseline dropped 58→39)
```

> ⚠️ Staging verify wanted: no visual/device check was run. The full loop — set up monthly on staging, watch the invoice credit, change amount, update card via portal, cancel — is the acceptance test, and also settles #737's Invoice.payments question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcamCRXMUU1DhocRpr59YD