### PR TITLE
fix(runsheet): expand rows on web instead of clipping to two lines

### DIFF
--- a/apps/mobile/app/ui-test/run-sheet-expand.tsx
+++ b/apps/mobile/app/ui-test/run-sheet-expand.tsx
@@ -1,0 +1,106 @@
+/**
+ * Visual harness for the run sheet's expandable rows (the chevron "dropdowns").
+ *
+ * The real sheet (`PlanRunSheet`) reads its event + items from Convex, so it
+ * can't be exercised without a backend. This route renders the real
+ * `RunSheetItemList` — the component that owns the expand/collapse state and
+ * the chevrons — over fixture items, so `pnpm --filter mobile web` + Playwright
+ * can click the chevrons on web and confirm rows actually expand
+ * (`tests/e2e/run-sheet-expand.spec.ts`). See CLAUDE.md's "Visual Verification".
+ */
+import React from "react";
+import { View, Text, StyleSheet, ScrollView } from "react-native";
+import { useTheme } from "@hooks/useTheme";
+import {
+  RunSheetItemList,
+  type RunSheetItem,
+  type Segment,
+} from "@features/leader-tools/components/NativeRunSheetView";
+
+const NOTE_TEXT =
+  "hello there i am a test comment hello there i am a test comment hello there i am a test comment";
+
+function item(
+  id: string,
+  title: string,
+  segment: Segment,
+  extra: Partial<RunSheetItem> = {},
+): RunSheetItem {
+  return {
+    _id: id as RunSheetItem["_id"],
+    segment,
+    type: "item",
+    title,
+    description: null,
+    durationSec: 300,
+    notes: [],
+    songDetails: null,
+    assignments: [],
+    ...extra,
+  };
+}
+
+const LONG_TEXT = Array.from(
+  { length: 8 },
+  (_, i) => `Line ${i + 1}: the run sheet note keeps going well past two lines.`,
+).join(" ");
+
+const ITEMS: RunSheetItem[] = [
+  item("before-1", "New item", "before", {
+    notes: [{ category: "", content: NOTE_TEXT }],
+  }),
+  item("before-2", "New item", "before"),
+  item("before-3", "New item", "before", { description: NOTE_TEXT }),
+  item("before-4", "New item", "before"),
+  item("before-5", "Long note", "before", {
+    notes: [{ category: "Tech", content: LONG_TEXT }],
+  }),
+  item("before-6", "Long description", "before", { description: LONG_TEXT }),
+  item("during-header", "Setup", "during", { type: "header" }),
+  item("during-1", "New item", "during", {
+    notes: [{ category: "", content: NOTE_TEXT }],
+  }),
+];
+
+const ITEMS_BY_SEGMENT: Record<Segment, RunSheetItem[]> = {
+  before: ITEMS.filter((i) => i.segment === "before"),
+  during: ITEMS.filter((i) => i.segment === "during"),
+  after: [],
+};
+
+const CLOCK_TIMES: Record<string, number | null> = Object.fromEntries(
+  ITEMS.map((i) => [i._id as string, Date.UTC(2026, 7, 2, 13, 0, 0)]),
+);
+
+export default function RunSheetExpandHarness() {
+  const { colors } = useTheme();
+  return (
+    <ScrollView
+      testID="run-sheet-expand-harness"
+      style={{ backgroundColor: colors.background }}
+      contentContainerStyle={styles.container}
+    >
+      <Text style={[styles.title, { color: colors.text }]}>
+        Untitled event plan
+      </Text>
+      <RunSheetItemList
+        itemsBySegment={ITEMS_BY_SEGMENT}
+        clockTimes={CLOCK_TIMES}
+        peopleByRole={{}}
+        viewMode="all"
+        viewerRoleIds={new Set()}
+        hasAnyViewerRole={false}
+        mineHasContent
+        currentItemId={null}
+        groupId={"harness-group" as never}
+      />
+      <View style={styles.spacer} />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16 },
+  title: { fontSize: 20, fontWeight: "700" },
+  spacer: { height: 80 },
+});

--- a/apps/mobile/app/ui-test/run-sheet-expand.tsx
+++ b/apps/mobile/app/ui-test/run-sheet-expand.tsx
@@ -13,9 +13,13 @@ import { View, Text, StyleSheet, ScrollView } from "react-native";
 import { useTheme } from "@hooks/useTheme";
 import {
   RunSheetItemList,
+  useRunSheetExpansion,
   type RunSheetItem,
   type Segment,
 } from "@features/leader-tools/components/NativeRunSheetView";
+
+/** Namespaced so the harness's persisted collapse state can't hit a real group. */
+const HARNESS_GROUP_ID = "ui-test-run-sheet-expand" as never;
 
 const NOTE_TEXT =
   "hello there i am a test comment hello there i am a test comment hello there i am a test comment";
@@ -74,6 +78,9 @@ const CLOCK_TIMES: Record<string, number | null> = Object.fromEntries(
 
 export default function RunSheetExpandHarness() {
   const { colors } = useTheme();
+  // Same hook the real screen uses, on a harness-only group id so its persisted
+  // collapsed-header key can't collide with a real group's.
+  const expansion = useRunSheetExpansion(HARNESS_GROUP_ID);
   return (
     <ScrollView
       testID="run-sheet-expand-harness"
@@ -92,7 +99,7 @@ export default function RunSheetExpandHarness() {
         hasAnyViewerRole={false}
         mineHasContent
         currentItemId={null}
-        groupId={"harness-group" as never}
+        expansion={expansion}
       />
       <View style={styles.spacer} />
     </ScrollView>

--- a/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
+++ b/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
@@ -425,6 +425,11 @@ export function PlanRunSheet({
     [effItems],
   );
 
+  // Owned here, above the loading/empty early returns below, so a transient
+  // `items === undefined` doesn't wipe what the user has expanded — see the
+  // hook's note.
+  const expansion = useRunSheetExpansion(groupId);
+
   // Live "current item": match the item whose computed [start, start +
   // durationSec) window contains `now` (ticked above). Because `clockTimes` is
   // anchored to the active/selected service, this highlights the right rows on
@@ -570,7 +575,7 @@ export function PlanRunSheet({
             hasAnyViewerRole={hasAnyViewerRole}
             mineHasContent={mineHasContent}
             currentItemId={currentItemId}
-            groupId={groupId}
+            expansion={expansion}
           />
         </>
       )}
@@ -578,39 +583,31 @@ export function PlanRunSheet({
   );
 }
 
-/**
- * The run sheet's item list: segment labels, collapsible headers and expandable
- * rows, plus the "Mine" empty state.
- *
- * Split out of `PlanRunSheet` so the expand/collapse behaviour can be rendered
- * from fixtures without a Convex backend (`/ui-test/run-sheet-expand`, driven by
- * `tests/e2e/run-sheet-expand.spec.ts`) — the data-fetching wrapper stays above.
- */
-export function RunSheetItemList({
-  itemsBySegment,
-  clockTimes,
-  peopleByRole,
-  viewMode,
-  viewerRoleIds,
-  hasAnyViewerRole,
-  mineHasContent,
-  currentItemId,
-  groupId,
-}: {
-  itemsBySegment: Record<Segment, RunSheetItem[]>;
-  clockTimes: Record<string, number | null>;
-  peopleByRole: Record<string, string[]>;
-  viewMode: ViewMode;
-  viewerRoleIds: Set<string>;
-  hasAnyViewerRole: boolean;
-  mineHasContent: boolean;
-  currentItemId: string | null;
-  /** Scopes the persisted collapsed-header state. */
-  groupId: Id<"groups">;
-}) {
-  const { colors, isDark } = useTheme();
+export type RunSheetExpansion = {
+  /** Item ids whose description/notes are revealed. */
+  expandedItemIds: Set<string>;
+  toggleItemExpanded: (itemId: string) => void;
+  /** Header ids whose following rows are hidden. */
+  collapsedHeaders: Set<string>;
+  toggleHeaderCollapsed: (headerId: string) => void;
+};
 
-  // Expandable rows: which items have their description/notes revealed.
+/**
+ * Which run sheet rows are expanded, and which section headers are collapsed.
+ *
+ * This MUST be owned by the data-fetching wrapper, not by `RunSheetItemList` —
+ * the list only renders once items have arrived, so holding the state there
+ * would tie it to the list's mount. Any bounce back to the loading branch (an
+ * offline→online flip or an auth-token refresh both return the Convex query to
+ * `undefined` for a beat) would then unmount it and silently collapse every row
+ * the user had opened. Owning it above the loading branch also means the
+ * AsyncStorage restore below starts in parallel with the query, while the
+ * spinner is up, instead of racing the user's first tap on a live list.
+ *
+ * Collapsed headers are persisted per group under a native-specific key so they
+ * never collide with the PCO viewer's collapse state.
+ */
+export function useRunSheetExpansion(groupId: Id<"groups">): RunSheetExpansion {
   const [expandedItemIds, setExpandedItemIds] = useState<Set<string>>(
     () => new Set(),
   );
@@ -623,9 +620,6 @@ export function RunSheetItemList({
     });
   }, []);
 
-  // Collapsible sections: header ids whose following items are hidden.
-  // Persisted to AsyncStorage per group (native-specific key so it never
-  // collides with the PCO viewer's collapse state) and restored on reopen.
   const [collapsedHeaders, setCollapsedHeaders] = useState<Set<string>>(
     () => new Set(),
   );
@@ -667,6 +661,53 @@ export function RunSheetItemList({
       JSON.stringify(Array.from(collapsedHeaders)),
     ).catch((err) => console.error("Failed to save collapsed state:", err));
   }, [collapsedHeaders, collapsedHeadersLoaded, collapsedStorageKey]);
+
+  return {
+    expandedItemIds,
+    toggleItemExpanded,
+    collapsedHeaders,
+    toggleHeaderCollapsed,
+  };
+}
+
+/**
+ * The run sheet's item list: segment labels, collapsible headers and expandable
+ * rows, plus the "Mine" empty state. Presentational — its expand/collapse state
+ * comes in from `useRunSheetExpansion`.
+ *
+ * Split out of `PlanRunSheet` so the expand/collapse behaviour can be rendered
+ * from fixtures without a Convex backend (`/ui-test/run-sheet-expand`, driven by
+ * `tests/e2e/run-sheet-expand.spec.ts`) — the data-fetching wrapper stays above.
+ */
+export function RunSheetItemList({
+  itemsBySegment,
+  clockTimes,
+  peopleByRole,
+  viewMode,
+  viewerRoleIds,
+  hasAnyViewerRole,
+  mineHasContent,
+  currentItemId,
+  expansion,
+}: {
+  itemsBySegment: Record<Segment, RunSheetItem[]>;
+  clockTimes: Record<string, number | null>;
+  peopleByRole: Record<string, string[]>;
+  viewMode: ViewMode;
+  viewerRoleIds: Set<string>;
+  hasAnyViewerRole: boolean;
+  mineHasContent: boolean;
+  currentItemId: string | null;
+  /** From `useRunSheetExpansion`, owned by the caller — see that hook's note. */
+  expansion: RunSheetExpansion;
+}) {
+  const { colors, isDark } = useTheme();
+  const {
+    expandedItemIds,
+    toggleItemExpanded,
+    collapsedHeaders,
+    toggleHeaderCollapsed,
+  } = expansion;
 
   if (viewMode === "mine" && !mineHasContent) {
     return (

--- a/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
+++ b/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
@@ -60,7 +60,7 @@ const CURRENT_ITEM_BG_DARK = "#2a2700";
 const CURRENT_ITEM_BORDER = "#D4A017";
 
 /** When an item happens relative to the event's service times. */
-type Segment = "before" | "during" | "after";
+export type Segment = "before" | "during" | "after";
 const SEGMENT_OPTIONS: Array<{ key: Segment; label: string }> = [
   { key: "before", label: "Before event" },
   { key: "during", label: "During event" },
@@ -74,7 +74,7 @@ type PlanSummary = {
   times: Array<{ label: string; startsAt: number }>;
 };
 
-type RunSheetItem = {
+export type RunSheetItem = {
   _id: Id<"eventItems">;
   segment: string;
   type: string;
@@ -258,7 +258,7 @@ export function PlanRunSheet({
    */
   embedded?: boolean;
 }) {
-  const { colors, isDark } = useTheme();
+  const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
   const { isNetworkAvailable } = useConnectionStatus();
   const { user } = useAuth();
@@ -425,64 +425,6 @@ export function PlanRunSheet({
     [effItems],
   );
 
-  // Expandable rows: which items have their description/notes revealed.
-  const [expandedItemIds, setExpandedItemIds] = useState<Set<string>>(
-    () => new Set(),
-  );
-  const toggleItemExpanded = useCallback((itemId: string) => {
-    setExpandedItemIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(itemId)) next.delete(itemId);
-      else next.add(itemId);
-      return next;
-    });
-  }, []);
-
-  // Collapsible sections: header ids whose following items are hidden.
-  // Persisted to AsyncStorage per group (native-specific key so it never
-  // collides with the PCO viewer's collapse state) and restored on reopen.
-  const [collapsedHeaders, setCollapsedHeaders] = useState<Set<string>>(
-    () => new Set(),
-  );
-  const [collapsedHeadersLoaded, setCollapsedHeadersLoaded] = useState(false);
-  const toggleHeaderCollapsed = useCallback((headerId: string) => {
-    setCollapsedHeaders((prev) => {
-      const next = new Set(prev);
-      if (next.has(headerId)) next.delete(headerId);
-      else next.add(headerId);
-      return next;
-    });
-  }, []);
-
-  const collapsedStorageKey = `native_runsheet_collapsed_${groupId}`;
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const saved = await AsyncStorage.getItem(collapsedStorageKey);
-        if (!cancelled && saved) {
-          setCollapsedHeaders(new Set(JSON.parse(saved)));
-        }
-      } catch (err) {
-        console.error("Failed to load collapsed state:", err);
-      } finally {
-        if (!cancelled) setCollapsedHeadersLoaded(true);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [collapsedStorageKey]);
-  useEffect(() => {
-    // Don't persist until the initial load finishes, to avoid clobbering
-    // saved state with the empty default on first render.
-    if (!collapsedHeadersLoaded) return;
-    AsyncStorage.setItem(
-      collapsedStorageKey,
-      JSON.stringify(Array.from(collapsedHeaders)),
-    ).catch((err) => console.error("Failed to save collapsed state:", err));
-  }, [collapsedHeaders, collapsedHeadersLoaded, collapsedStorageKey]);
-
   // Live "current item": match the item whose computed [start, start +
   // durationSec) window contains `now` (ticked above). Because `clockTimes` is
   // anchored to the active/selected service, this highlights the right rows on
@@ -619,62 +561,171 @@ export function PlanRunSheet({
             })}
           </View>
 
-          {viewMode === "mine" && !mineHasContent ? (
-            <View style={styles.mineEmptyState}>
-              <Ionicons name="person-outline" size={22} color={colors.textTertiary} />
-              <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-                {hasAnyViewerRole
-                  ? "None of the run sheet items are tagged with your roles yet."
-                  : "You're not assigned a role on this plan yet."}
-              </Text>
-            </View>
-          ) : (
-            SEGMENT_OPTIONS.map((seg) => {
-              const segItems = itemsBySegment[seg.key];
-              const modeItems =
-                viewMode === "mine"
-                  ? segItems.filter((it) => runSheetItemMatchesViewer(it, viewerRoleIds))
-                  : segItems;
-              if (modeItems.length === 0) return null;
-              // In "Mine", a segment whose only matches are headers has no
-              // actual content to show — skip the whole segment rather than
-              // render a label + bare header row (see runSheetViewerFilter).
-              if (
-                viewMode === "mine" &&
-                !segmentHasContentForViewer(segItems, viewerRoleIds)
-              ) {
-                return null;
-              }
-              // Hide items that follow a collapsed header (positional: a header
-              // owns the rows after it until the next header in the segment).
-              const visibleItems = filterVisible(modeItems, collapsedHeaders);
-              return (
-                <View key={seg.key}>
-                  <Text style={[styles.segmentLabel, { color: colors.textSecondary }]}>
-                    {seg.label.toUpperCase()}
-                  </Text>
-                  {visibleItems.map((item) => (
-                    <ReadOnlyRow
-                      key={item._id}
-                      item={item}
-                      clockMs={clockTimes[item._id]}
-                      peopleByRole={peopleByRole}
-                      colors={colors}
-                      isDark={isDark}
-                      isCurrent={item._id === currentItemId}
-                      isExpanded={expandedItemIds.has(item._id)}
-                      onToggleExpand={() => toggleItemExpanded(item._id)}
-                      isCollapsed={collapsedHeaders.has(item._id)}
-                      onToggleCollapse={() => toggleHeaderCollapsed(item._id)}
-                    />
-                  ))}
-                </View>
-              );
-            })
-          )}
+          <RunSheetItemList
+            itemsBySegment={itemsBySegment}
+            clockTimes={clockTimes}
+            peopleByRole={peopleByRole}
+            viewMode={viewMode}
+            viewerRoleIds={viewerRoleIds}
+            hasAnyViewerRole={hasAnyViewerRole}
+            mineHasContent={mineHasContent}
+            currentItemId={currentItemId}
+            groupId={groupId}
+          />
         </>
       )}
     </Root>
+  );
+}
+
+/**
+ * The run sheet's item list: segment labels, collapsible headers and expandable
+ * rows, plus the "Mine" empty state.
+ *
+ * Split out of `PlanRunSheet` so the expand/collapse behaviour can be rendered
+ * from fixtures without a Convex backend (`/ui-test/run-sheet-expand`, driven by
+ * `tests/e2e/run-sheet-expand.spec.ts`) — the data-fetching wrapper stays above.
+ */
+export function RunSheetItemList({
+  itemsBySegment,
+  clockTimes,
+  peopleByRole,
+  viewMode,
+  viewerRoleIds,
+  hasAnyViewerRole,
+  mineHasContent,
+  currentItemId,
+  groupId,
+}: {
+  itemsBySegment: Record<Segment, RunSheetItem[]>;
+  clockTimes: Record<string, number | null>;
+  peopleByRole: Record<string, string[]>;
+  viewMode: ViewMode;
+  viewerRoleIds: Set<string>;
+  hasAnyViewerRole: boolean;
+  mineHasContent: boolean;
+  currentItemId: string | null;
+  /** Scopes the persisted collapsed-header state. */
+  groupId: Id<"groups">;
+}) {
+  const { colors, isDark } = useTheme();
+
+  // Expandable rows: which items have their description/notes revealed.
+  const [expandedItemIds, setExpandedItemIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const toggleItemExpanded = useCallback((itemId: string) => {
+    setExpandedItemIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(itemId)) next.delete(itemId);
+      else next.add(itemId);
+      return next;
+    });
+  }, []);
+
+  // Collapsible sections: header ids whose following items are hidden.
+  // Persisted to AsyncStorage per group (native-specific key so it never
+  // collides with the PCO viewer's collapse state) and restored on reopen.
+  const [collapsedHeaders, setCollapsedHeaders] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [collapsedHeadersLoaded, setCollapsedHeadersLoaded] = useState(false);
+  const toggleHeaderCollapsed = useCallback((headerId: string) => {
+    setCollapsedHeaders((prev) => {
+      const next = new Set(prev);
+      if (next.has(headerId)) next.delete(headerId);
+      else next.add(headerId);
+      return next;
+    });
+  }, []);
+
+  const collapsedStorageKey = `native_runsheet_collapsed_${groupId}`;
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const saved = await AsyncStorage.getItem(collapsedStorageKey);
+        if (!cancelled && saved) {
+          setCollapsedHeaders(new Set(JSON.parse(saved)));
+        }
+      } catch (err) {
+        console.error("Failed to load collapsed state:", err);
+      } finally {
+        if (!cancelled) setCollapsedHeadersLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [collapsedStorageKey]);
+  useEffect(() => {
+    // Don't persist until the initial load finishes, to avoid clobbering
+    // saved state with the empty default on first render.
+    if (!collapsedHeadersLoaded) return;
+    AsyncStorage.setItem(
+      collapsedStorageKey,
+      JSON.stringify(Array.from(collapsedHeaders)),
+    ).catch((err) => console.error("Failed to save collapsed state:", err));
+  }, [collapsedHeaders, collapsedHeadersLoaded, collapsedStorageKey]);
+
+  if (viewMode === "mine" && !mineHasContent) {
+    return (
+      <View style={styles.mineEmptyState}>
+        <Ionicons name="person-outline" size={22} color={colors.textTertiary} />
+        <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+          {hasAnyViewerRole
+            ? "None of the run sheet items are tagged with your roles yet."
+            : "You're not assigned a role on this plan yet."}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      {SEGMENT_OPTIONS.map((seg) => {
+        const segItems = itemsBySegment[seg.key];
+        const modeItems =
+          viewMode === "mine"
+            ? segItems.filter((it) => runSheetItemMatchesViewer(it, viewerRoleIds))
+            : segItems;
+        if (modeItems.length === 0) return null;
+        // In "Mine", a segment whose only matches are headers has no actual
+        // content to show — skip the whole segment rather than render a label +
+        // bare header row (see runSheetViewerFilter).
+        if (
+          viewMode === "mine" &&
+          !segmentHasContentForViewer(segItems, viewerRoleIds)
+        ) {
+          return null;
+        }
+        // Hide items that follow a collapsed header (positional: a header owns
+        // the rows after it until the next header in the segment).
+        const visibleItems = filterVisible(modeItems, collapsedHeaders);
+        return (
+          <View key={seg.key}>
+            <Text style={[styles.segmentLabel, { color: colors.textSecondary }]}>
+              {seg.label.toUpperCase()}
+            </Text>
+            {visibleItems.map((item) => (
+              <ReadOnlyRow
+                key={item._id}
+                item={item}
+                clockMs={clockTimes[item._id]}
+                peopleByRole={peopleByRole}
+                colors={colors}
+                isDark={isDark}
+                isCurrent={item._id === currentItemId}
+                isExpanded={expandedItemIds.has(item._id)}
+                onToggleExpand={() => toggleItemExpanded(item._id)}
+                isCollapsed={collapsedHeaders.has(item._id)}
+                onToggleCollapse={() => toggleHeaderCollapsed(item._id)}
+              />
+            ))}
+          </View>
+        );
+      })}
+    </>
   );
 }
 
@@ -761,6 +812,7 @@ function ReadOnlyRow({
 
   return (
     <View
+      testID={`run-sheet-row-${item._id}`}
       style={[
         styles.row,
         { backgroundColor: colors.surfaceSecondary },

--- a/apps/mobile/features/leader-tools/utils/runSheetLinks.tsx
+++ b/apps/mobile/features/leader-tools/utils/runSheetLinks.tsx
@@ -16,6 +16,7 @@ import {
   TextInput,
   Pressable,
   Linking,
+  Platform,
   StyleSheet,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
@@ -61,6 +62,20 @@ export function SelectableText({
   children: string;
   style?: object;
 }) {
+  // Web: react-native-web renders a multiline TextInput as a `<textarea>` and
+  // ignores `scrollEnabled={false}`, so it stays at its default two-row height
+  // and clips everything below — expanding a run sheet row revealed no more
+  // text than its two-line collapsed preview ("the dropdown arrows don't
+  // expand"). DOM text is already selectable, and `<Text>` grows with its
+  // content, so plain selectable Text is both correct and simpler here.
+  if (Platform.OS === "web") {
+    return (
+      <Text selectable style={style}>
+        {children}
+      </Text>
+    );
+  }
+
   return (
     <TextInput
       value={children}

--- a/tests/e2e/run-sheet-expand.spec.ts
+++ b/tests/e2e/run-sheet-expand.spec.ts
@@ -52,8 +52,14 @@ test.describe("Run sheet expandable rows (web)", () => {
     const expandedHeight = await row.evaluate((el) => el.clientHeight);
     expect(expandedHeight).toBeGreaterThan(collapsedHeight);
 
-    // And it collapses again.
+    // And it collapses again. Re-measured rather than pinned to the exact
+    // pixel height captured above: the row's height is
+    // `max(title line box, chevron line box)`, and the Ionicons web font lands
+    // asynchronously, so a measurement taken before it resolves can be ~1px off
+    // the settled value.
     await row.getByRole("button", { name: /Long note/ }).click();
-    await expect(row).toHaveJSProperty("clientHeight", collapsedHeight);
+    await expect
+      .poll(() => row.evaluate((el) => el.clientHeight))
+      .toBeLessThan(expandedHeight);
   });
 });

--- a/tests/e2e/run-sheet-expand.spec.ts
+++ b/tests/e2e/run-sheet-expand.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Run sheet rows expand on web (the chevron "dropdown" arrows).
+ *
+ * The bug: expanded descriptions/notes render through `SelectableText`, which
+ * used a multiline `TextInput`. react-native-web turns that into a `<textarea>`
+ * and ignores `scrollEnabled={false}`, so it stayed at its default two-row
+ * height and clipped everything below — tapping the chevron flipped the arrow
+ * but revealed no more text than the two-line collapsed preview, i.e. "the
+ * dropdown arrows don't expand".
+ *
+ * Driven against `/ui-test/run-sheet-expand`, which renders the real
+ * `RunSheetItemList` over fixtures (no Convex backend needed). The fixture's
+ * `before-5` row carries an eight-line note.
+ */
+test.describe("Run sheet expandable rows (web)", () => {
+  test("expanding a row reveals the whole note, not a clipped textarea", async ({
+    page,
+  }) => {
+    await page.goto("/ui-test/run-sheet-expand");
+    await page
+      .getByTestId("run-sheet-expand-harness")
+      .waitFor({ state: "visible", timeout: 30000 });
+
+    const row = page.getByTestId("run-sheet-row-before-5");
+    const collapsedHeight = await row.evaluate((el) => el.clientHeight);
+
+    await row.getByRole("button", { name: /Long note/ }).click();
+
+    // A `<textarea>` here IS the regression — it clips to two rows on web.
+    await expect(row.locator("textarea")).toHaveCount(0);
+
+    // The tail of the note is rendered as real text…
+    const note = row.getByText(/Line 8:/).first();
+    await expect(note).toBeVisible();
+    // …and nothing is clipped away inside it.
+    const clipped = await note.evaluate(
+      (el) => el.scrollHeight > el.clientHeight + 1,
+    );
+    expect(clipped).toBe(false);
+
+    // The whole note is part of the row's rendered text. A `<textarea>` holds
+    // its content in `value`, not in the DOM text, so this fails pre-fix.
+    await expect(row).toContainText(
+      "Line 8: the run sheet note keeps going well past two lines.",
+    );
+
+    // And the row genuinely grew rather than swapping one clipped box for
+    // another (kept relative — how many lines the note wraps to is viewport
+    // dependent).
+    const expandedHeight = await row.evaluate((el) => el.clientHeight);
+    expect(expandedHeight).toBeGreaterThan(collapsedHeight);
+
+    // And it collapses again.
+    await row.getByRole("button", { name: /Long note/ }).click();
+    await expect(row).toHaveJSProperty("clientHeight", collapsedHeight);
+  });
+});


### PR DESCRIPTION
## Problem

Tapping a run sheet row's chevron on web flipped the arrow but revealed no more text than the collapsed two-line preview, so the dropdowns looked dead ("these dropdown arrows don't work on web for run sheets").

The press was firing all along. The bug is in what the expanded state renders.

## Root cause

Expanded descriptions and notes render through `SelectableText` (`apps/mobile/features/leader-tools/utils/runSheetLinks.tsx`), which used a multiline `TextInput` for reliable iOS text selection. react-native-web turns that into a `<textarea>` and **ignores `scrollEnabled={false}`**, so it kept its default two-row height and clipped everything below.

Measured in Chromium on an eight-line note:

```
clientHeight: 32   scrollHeight: 160   rows: 2   clipped: true
```

Native is unaffected — there the `TextInput` auto-sizes, which is why this only shows up in the browser.

## Fix

On web, render a plain selectable `<Text>` — DOM text is already selectable and `<Text>` grows with its content. The `TextInput` stays on native. This also unclips the PCO run sheet's role notes, which share the same helper.

## Verification

Real Chromium at iPhone-13 width against the actual component. Both rows in the comparison are in the **expanded** state (chevron up): before, an eight-line note is still clipped to two lines; after, the full note renders.

- Added `apps/mobile/app/ui-test/run-sheet-expand.tsx`, a fixture harness (same pattern as `/ui-test/attendance`) so the rows can be driven without a Convex backend. To get there, the item list — segment labels, collapsible headers, expandable rows, "Mine" empty state — was split out of `PlanRunSheet` into a presentational `RunSheetItemList`, with the expand/collapse state in a `useRunSheetExpansion` hook that the data-fetching wrapper owns (see "Review findings" below for why that placement matters).
- Added `tests/e2e/run-sheet-expand.spec.ts`: clicks the chevron and asserts no `<textarea>`, and that the full note is present as real, unclipped DOM text. **Confirmed failing on the pre-fix renderer and passing after** — the `textarea` count, `getByText(/Line 8:/)` and `toContainText` assertions are the three that fail pre-fix.
- `tsc --noEmit` clean on the touched files, `eslint` clean, 458 jest tests under `features/leader-tools` + `features/scheduling` pass.

## Review findings (both fixed)

Two independent review passes ran over the diff; threads are inline and resolved.

1. **The extraction regressed offline/reconnect behaviour.** Putting the expand/collapse state in `RunSheetItemList` tied it to that component's mount, and the list only renders *past* `PlanRunSheet`'s loading/empty early returns — so any bounce back to loading (an offline→online flip or an auth-token refresh both return the Convex query to `undefined` for a beat) silently collapsed every row the user had opened. It also moved the AsyncStorage restore from "parallel with the query, behind the spinner" to "racing the user's first tap on a live list". Fixed in 426c099 by hoisting both into `useRunSheetExpansion`, called above the early returns.
2. **A flaky exact-pixel assertion in the spec.** The re-collapse check pinned `clientHeight` to a baseline measured before the Ionicons web font resolved, a ~1px difference that could fail on a cold CI runner with retries masking it as a flake. Fixed in 91037cc — re-measures and asserts the row is shorter than its expanded height.

## Known limitation

For notes short enough to fit the two-line preview, expanding still looks near-identical by design — the preview already showed everything. Hiding the chevron when nothing is truncated (or shortening the preview) is a separate design call, not included here.

Also noted during review, pre-existing and not introduced here: the `ui-test` route group has no `__DEV__` guard or build-time filter, so these harness routes are reachable on production web. This is the third one; gating the group is worth doing once, separately.