### PR TITLE
test(runsheet): don't let Expo's error overlay swallow the chevron click

### DIFF
--- a/tests/e2e/run-sheet-expand.spec.ts
+++ b/tests/e2e/run-sheet-expand.spec.ts
@@ -19,6 +19,16 @@ test.describe("Run sheet expandable rows (web)", () => {
     page,
   }) => {
     await page.goto("/ui-test/run-sheet-expand");
+    // Expo's dev error overlay is an absolutely-positioned `#error-overlay`
+    // that swallows pointer events for the whole page. Every `ui-test` route
+    // mounts the app root, whose Convex client is pointed at the stub
+    // `EXPO_PUBLIC_CONVEX_URL` this suite sets, so a failed connection can raise
+    // it — unrelated to anything under test here, but it makes the chevron
+    // unclickable. Hide it rather than let it intercept clicks; a genuine app
+    // error still fails the assertions below.
+    await page.addStyleTag({
+      content: "#error-overlay { display: none !important; }",
+    });
     await page
       .getByTestId("run-sheet-expand-harness")
       .waitFor({ state: "visible", timeout: 30000 });

--- a/tests/e2e/run-sheet-expand.spec.ts
+++ b/tests/e2e/run-sheet-expand.spec.ts
@@ -14,18 +14,33 @@ import { expect, test } from "@playwright/test";
  * `RunSheetItemList` over fixtures (no Convex backend needed). The fixture's
  * `before-5` row carries an eight-line note.
  */
+/**
+ * The one runtime error this spec tolerates: every `ui-test` route mounts the
+ * app root, whose Convex client is pointed at the stub `EXPO_PUBLIC_CONVEX_URL`
+ * that `playwright.config.ts` sets, so the connection to it can fail. Anything
+ * else is a real bug and must fail the run.
+ */
+const EXPECTED_RUNTIME_ERROR = /convex/i;
+
 test.describe("Run sheet expandable rows (web)", () => {
   test("expanding a row reveals the whole note, not a clipped textarea", async ({
     page,
   }) => {
+    const unexpectedErrors: string[] = [];
+    page.on("pageerror", (err) => {
+      if (!EXPECTED_RUNTIME_ERROR.test(err.message)) {
+        unexpectedErrors.push(err.message);
+      }
+    });
+
     await page.goto("/ui-test/run-sheet-expand");
     // Expo's dev error overlay is an absolutely-positioned `#error-overlay`
-    // that swallows pointer events for the whole page. Every `ui-test` route
-    // mounts the app root, whose Convex client is pointed at the stub
-    // `EXPO_PUBLIC_CONVEX_URL` this suite sets, so a failed connection can raise
-    // it — unrelated to anything under test here, but it makes the chevron
-    // unclickable. Hide it rather than let it intercept clicks; a genuine app
-    // error still fails the assertions below.
+    // that swallows pointer events for the whole page, which makes the chevron
+    // unclickable when the stub-backend connection above fails. Take it out of
+    // hit-testing so the interaction can proceed — but the run still fails on
+    // any error that isn't the expected one, both via the `pageerror` listener
+    // above and the overlay check at the end. Without those, hiding it here
+    // would let an exception thrown after the harness DOM rendered sail past.
     await page.addStyleTag({
       content: "#error-overlay { display: none !important; }",
     });
@@ -71,5 +86,14 @@ test.describe("Run sheet expandable rows (web)", () => {
     await expect
       .poll(() => row.evaluate((el) => el.clientHeight))
       .toBeLessThan(expandedHeight);
+
+    // Nothing above can see the hidden overlay, so check it explicitly: it may
+    // only ever be the tolerated stub-backend failure. Read `textContent`, not
+    // `innerText` — the latter is empty for a `display: none` element.
+    const overlay = page.locator("#error-overlay");
+    if (await overlay.count()) {
+      expect(await overlay.textContent()).toMatch(EXPECTED_RUNTIME_ERROR);
+    }
+    expect(unexpectedErrors).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

`main` went red on the E2E job immediately after #741 merged, on the spec that PR added — which had passed on the PR head minutes earlier.

The failure is not an assertion. Playwright retried the chevron click until timeout, each retry reporting:

```
<div id="error-overlay">…</div> subtree intercepts pointer events
```

with the overlay's visible text being a stack frame inside `node_modules/.pnpm/convex@1.31.7_.../…`.

## Cause

Expo's dev error overlay is an absolutely-positioned `#error-overlay` that swallows pointer events for the whole page. Every `ui-test` route mounts the app root, whose Convex client is pointed at the stub `EXPO_PUBLIC_CONVEX_URL` (`https://demo.convex.cloud`) that `playwright.config.ts`'s `webServer` sets — so a failed connection can raise it.

That has nothing to do with what the spec asserts. It's simply the only e2e spec here that *clicks*, so it's the one that gets blocked. Supporting evidence that this is environmental and pre-existing rather than a regression from #741:

- The overlay's stack is inside the `convex` package; #741 touched `SelectableText` and the run sheet's expansion state, neither of which imports convex, and the harness route issues no Convex query.
- In the same failing run, the pre-existing `event-rsvp-refresh` spec also failed its first attempt on a `page.goto` timeout and was marked flaky.
- Not reproducible locally, where the stub URL fails faster and never escalates to an overlay.

## Fix

Take the overlay out of hit-testing so the interaction can proceed — and, per review, make sure that doesn't turn into a blanket error suppressor:

- a `pageerror` listener registered before `goto` collects any message that isn't the tolerated stub-backend failure, asserted empty at the end;
- if an overlay exists at all by the end of the test, its `textContent` must match that same expected pattern.

Without those, an exception thrown *after* the harness DOM rendered would leave the DOM intact, and the spec would report green over a real error.

## Verification

Spec passes locally against the repo's Playwright config (Desktop Chrome, real Chromium), both before and after the review hardening.

## Follow-ups, deliberately not in this hotfix

- **Isolate the harness routes from Convex.** The cleanest fix — the overlay could then never appear — but it means changing how `ui-test` routes mount relative to the app root's providers. Structural, and not something to do while `main` is red.
- **`event-rsvp-refresh` has the same exposure** and flaked in the same run. It passed on retry and isn't what's keeping `main` red, so it's untouched here; if the overlay guard proves useful it belongs in a shared fixture for the whole suite.
- **Gating the `ui-test` route group out of production builds.** Noted on #741 — these harness routes are currently reachable on production web.