### PR TITLE
feat(finance): BILL Spend & Expense card-provider adapter (BYOC Phase 2)

### DIFF
--- a/apps/convex/__tests__/finance-bill-adapter.test.ts
+++ b/apps/convex/__tests__/finance-bill-adapter.test.ts
@@ -103,7 +103,13 @@ beforeEach(() => {
       });
     }
     const { status = 200, body = {} } = match.handler(call);
-    return new Response(status === 204 ? "" : JSON.stringify(body), { status });
+    // A 204 must be constructed with a NULL body — `new Response("", {status:
+    // 204})` throws in undici, which would make an empty-response test fail for
+    // a reason that has nothing to do with the adapter. `body: null` on any
+    // status is the other way to say "empty", which is what the client's
+    // `if (!text) return null` branch actually keys on.
+    const empty = status === 204 || body === null;
+    return new Response(empty ? null : JSON.stringify(body), { status });
   }) as unknown as typeof fetch;
 });
 
@@ -599,6 +605,56 @@ describe("createCard", () => {
     });
   });
 
+  test("A MONTHLY CARD IS PATCHED TO RENEW — the create body has no recurrence", async () => {
+    // `POST /v3/spend/cards` takes `limit` and `shareBudgetFunds` and nothing
+    // about periods; only PATCH has `recurring`/`recurringLimit`. Without this
+    // follow-up a "$500 a month" card spends $500 once and then stops forever —
+    // and a dead card just looks like a decline, so nobody reports it as a bug.
+    seedAccount();
+    route("PATCH", "/v3/spend/cards/crd_new", () => ({
+      body: { uuid: "crd_new", status: "ACTIVATED", lastFour: "4242" },
+    }));
+
+    await adapter().createCard(CREATE_INPUT);
+
+    const [patched] = callsTo("PATCH", "/v3/spend/cards/crd_new");
+    expect(patched.body).toEqual({
+      recurring: true,
+      // BOTH: this period's allowance and every future one, exactly as
+      // setSpendLimit sends them.
+      availableFunds: 500,
+      recurringLimit: 500,
+    });
+  });
+
+  test("a WEEK/CHARGE card is NOT made recurring — the flat cap is deliberate", async () => {
+    // toBillCardLimit degrades these to a non-resetting cap on purpose
+    // (stricter than asked, never looser). Making them recurring would hand the
+    // cardholder four weeks of runway under a "/ week" label.
+    seedAccount();
+    await adapter().createCard({
+      ...CREATE_INPUT,
+      limit: { limitCents: 20_000, period: "charge" as const },
+    });
+    expect(callsTo("PATCH", "/v3/spend/cards/crd_new")).toHaveLength(0);
+  });
+
+  test("a FAILED recurrence PATCH warns but still returns the live card", async () => {
+    // The card exists and is spendable this period. Throwing here would record
+    // "failed" over a live card and orphan it at the bank — strictly worse than
+    // a card that needs its limit re-saved.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    seedAccount();
+    route("PATCH", "/v3/spend/cards/crd_new", () => ({
+      status: 500,
+      body: { message: "nope" },
+    }));
+
+    const card = await adapter().createCard(CREATE_INPUT);
+    expect(card.providerCardId).toBe("crd_new");
+    expect(warn.mock.calls.flat().join(" ")).toMatch(/spend \$500 once and then stop/);
+  });
+
   test("the token rides in an `apiToken` header, not Authorization", async () => {
     seedAccount();
     await adapter().createCard(CREATE_INPUT);
@@ -616,6 +672,21 @@ describe("createCard", () => {
     );
     expect(callsTo("POST", "/v3/spend/budgets")).toHaveLength(0);
     expect(callsTo("POST", "/v3/spend/cards")).toHaveLength(0);
+  });
+
+  test("A NUMERIC-ISH `id` IS NOT ACCEPTED AS A UUID", async () => {
+    // Every BILL write takes the prefixed uuid. A card recorded under the
+    // numeric `id` would never match the `cardUuid` on a webhook, so its
+    // settlements would route to nothing forever — with no error anywhere.
+    // Refusing is loud; the fallback was silent.
+    seedAccount();
+    route("POST", "/v3/spend/cards", () => ({
+      body: { id: "884422", status: "ACTIVATED", lastFour: "4242" },
+    }));
+
+    await expect(adapter().createCard(CREATE_INPUT)).rejects.toThrow(
+      /returned no uuid/i,
+    );
   });
 
   test("a card with no uuid is refused rather than recorded", async () => {
@@ -691,6 +762,28 @@ describe("setCardState", () => {
     route("PATCH", "/v3/spend/cards/crd_1", (call) => ({
       body: { uuid: "crd_1", name: call.body.name, status: "FROZEN", lastFour: "4242" },
     }));
+  });
+
+  test("AN EMPTY 204 SUCCESS IS THE REQUESTED STATE, not `failed`", async () => {
+    // The client treats an empty successful body as the success it is. An empty
+    // card has no status, and an unknown status is `failed` — so without this,
+    // a pause BILL really applied persists as a broken-looking card in Togather
+    // while working perfectly at the bank.
+    routes = [];
+    route("POST", "/v3/spend/cards/crd_1/freeze", () => ({ status: 204, body: null }));
+    route("POST", "/v3/spend/cards/crd_1/unfreeze", () => ({ status: 204, body: null }));
+
+    const paused = await adapter().setCardState("crd_1", "paused");
+    expect(paused).toEqual({
+      providerCardId: "crd_1",
+      state: "paused",
+      // BILL said no word, so we invent none for the field whose whole contract
+      // is to carry the vendor's word unedited.
+      providerStatus: "",
+    });
+
+    const active = await adapter().setCardState("crd_1", "active");
+    expect(active.state).toBe("active");
   });
 
   test("paused is a plain freeze", async () => {

--- a/apps/convex/__tests__/finance-bill-adapter.test.ts
+++ b/apps/convex/__tests__/finance-bill-adapter.test.ts
@@ -42,6 +42,10 @@ import {
   exactUsdCents,
   type BillTransaction,
 } from "../lib/finance/bill";
+import {
+  requiresSpendLimit,
+  supportsWeeklyLimits,
+} from "../lib/finance/cardProviders";
 
 const API_TOKEN = "bill-test-api-token";
 const BASE = "https://gateway.stage.bill.com/connect";
@@ -195,6 +199,34 @@ describe("capabilities", () => {
   test("repayment is in-product — Togather can neither show nor reconcile it", () => {
     expect(BILL_CAPABILITIES.repaymentVisibility).toBe("in_product");
     expect(BILL_CAPABILITIES.maxCardsPerMonth).toBeNull();
+  });
+
+  test("the NAME-keyed gates cannot drift from the capabilities", () => {
+    // `supportsWeeklyLimits` / `requiresSpendLimit` are keyed on the provider
+    // NAME because the mutations that gate a limit have no credential to build
+    // an adapter from. That duplication is the risk these two lines exist to
+    // catch: a capability flipped here without the gate following it is a
+    // promise the app then makes and the bank then breaks.
+    expect(supportsWeeklyLimits("bill")).toBe(BILL_CAPABILITIES.weeklyLimits);
+    expect(requiresSpendLimit("bill")).toBe(!BILL_CAPABILITIES.hardFundIsolation);
+  });
+
+  test("an UNCAPPED BILL card is refused, for the same reason as Privacy", () => {
+    // BILL cards are a charge card against the org's shared credit line —
+    // there is no per-fund pot at the bank, so an uncapped card draws the whole
+    // budget and the card limit is the only boundary Togather controls.
+    expect(requiresSpendLimit("bill")).toBe(true);
+    // Increase is the contrast: a fund owns its Account, so the bank enforces
+    // the boundary and "no limit" honestly means "up to this fund's balance".
+    expect(requiresSpendLimit("increase")).toBe(false);
+  });
+
+  test("a WEEKLY BILL limit is refused rather than silently flattened", () => {
+    // toBillCardLimit would map it to a non-recurring cap at the same number —
+    // safe for the money, but the card screen still says "/ week" and the
+    // cardholder learns the truth by being declined for three weeks.
+    expect(supportsWeeklyLimits("bill")).toBe(false);
+    expect(supportsWeeklyLimits("increase")).toBe(true);
   });
 });
 
@@ -547,6 +579,40 @@ describe("createCard", () => {
       /Budget has insufficient funds/,
     );
   });
+
+  test("a vendor error that ECHOES THE TOKEN is redacted before it is thrown", async () => {
+    // That message ends up on a finance admin's screen via
+    // recordCardProvisionFailed. A provider echoing the credential it just
+    // rejected would put a live spending token somewhere we deliberately never
+    // write one.
+    seedAccount();
+    route("POST", "/v3/spend/cards", () => ({
+      status: 401,
+      body: { message: `Token ${API_TOKEN} is not authorized` },
+    }));
+
+    await expect(adapter().createCard(CREATE_INPUT)).rejects.toThrow(
+      /\[redacted\] is not authorized/,
+    );
+    await expect(adapter().createCard(CREATE_INPUT)).rejects.not.toThrow(
+      new RegExp(API_TOKEN),
+    );
+  });
+
+  test("the thrown error carries the STATUS the poll branches on", async () => {
+    // 401/403 deactivates a connection; everything else retries next hour.
+    // A bare Error here would silently stop revoked tokens from deactivating.
+    route("GET", "/v3/spend/users/current", () => ({ status: 401, body: {} }));
+    await expect(adapter().checkConnection!()).rejects.toMatchObject({
+      status: 401,
+    });
+
+    routes = [];
+    route("GET", "/v3/spend/users/current", () => ({ status: 429, body: {} }));
+    await expect(adapter().checkConnection!()).rejects.toMatchObject({
+      status: 429,
+    });
+  });
 });
 
 // ============================================================================
@@ -580,19 +646,22 @@ describe("setCardState", () => {
     expect(card.state).toBe("active");
   });
 
-  test("closed is freeze + rename, and reports CLOSED rather than FROZEN", async () => {
+  test("closed is freeze + rename, and reports state `closed` over BILL's FROZEN", async () => {
     const card = await adapter().setCardState("crd_1", "closed");
 
     expect(callsTo("POST", "/v3/spend/cards/crd_1/freeze")).toHaveLength(1);
     const [renamed] = callsTo("PATCH", "/v3/spend/cards/crd_1");
     expect(renamed.body.name).toBe(`Youth Ministry — Supplies${BILL_CLOSED_SUFFIX}`);
 
-    // Load-bearing: `cards.status` stores this string and
-    // countLiveProviderCards decides "still spending?" from it. FROZEN here
-    // would mean a church that closed every card could never disconnect BILL
-    // without --force.
-    expect(card.providerStatus).toBe("CLOSED");
+    // Load-bearing: `state` is what cardStateToStoredStatus turns into
+    // `cards.status`, and countLiveProviderCards decides "still spending?"
+    // from that. `paused` here would store "disabled" — a live card — and a
+    // church that closed every card could never disconnect BILL without --force.
     expect(card.state).toBe("closed");
+    // But BILL's own word is carried through UNEDITED, because that is
+    // literally what the card is at the bank and providerStatus's whole
+    // contract is to be the vendor's string.
+    expect(card.providerStatus).toBe("FROZEN");
   });
 
   test("a close whose RENAME fails still reports closed — the card is stopped", async () => {
@@ -602,7 +671,7 @@ describe("setCardState", () => {
     route("PATCH", "/v3/spend/cards/crd_1", () => ({ status: 500, body: { message: "nope" } }));
 
     const card = await adapter().setCardState("crd_1", "closed");
-    expect(card.providerStatus).toBe("CLOSED");
+    expect(card.state).toBe("closed");
     expect(warn).toHaveBeenCalled();
   });
 
@@ -776,16 +845,78 @@ describe("listTransactions", () => {
     vi.useRealTimers();
   });
 
-  test("A BACKLOG PAST THE PAGE CAP STALLS the cursor rather than skipping ahead", async () => {
-    // A stall is something an operator notices. A skip is a hole in a church's
-    // books that nobody notices for weeks. Everything fetched is still returned.
+  test("A BACKLOG PAST THE PAGE CAP STALLS the cursor and says so", async () => {
+    // A stall is something an operator notices — `truncated` is what
+    // pollOneConnection turns into a visible error. A silent skip is a hole in
+    // a church's books that nobody notices for weeks. Everything fetched is
+    // still returned and recorded.
     route("GET", "/v3/spend/transactions", () => ({
       body: { results: [CLEARED], nextPage: "always-more" },
     }));
 
     const page = await adapter().listTransactions!("2026-07-01T00:00:00.000Z");
     expect(page.nextCursor).toBe("2026-07-01T00:00:00.000Z");
+    expect(page.truncated).toBe(true);
     expect(callsTo("GET", "/v3/spend/transactions")).toHaveLength(20);
+  });
+
+  test("a complete read is not truncated", async () => {
+    route("GET", "/v3/spend/transactions", () => ({
+      body: { results: [CLEARED], nextPage: null },
+    }));
+    const page = await adapter().listTransactions!("2026-08-01T00:00:00.000Z");
+    expect(page.truncated).toBe(false);
+  });
+
+  test("THE CURSOR STOPS BELOW AN UNSETTLED AUTHORIZATION", async () => {
+    // The invariant Privacy's adapter holds, for the same reason. An
+    // AUTHORIZATION is one we deliberately did NOT record, and BILL turns it
+    // into a CLEAR by updating the same uuid. Advancing past it relies on BILL
+    // always bumping `updatedTime` on settlement — an unverified vendor claim,
+    // and if it is ever false the settled charge is imported by nothing.
+    route("GET", "/v3/spend/transactions", () => ({
+      body: {
+        results: [
+          { ...CLEARED, uuid: "txr_old", updatedTime: "2026-08-01T09:00:00.000+00:00" },
+          {
+            ...CLEARED,
+            uuid: "txr_pending",
+            transactionType: "AUTHORIZATION",
+            updatedTime: "2026-08-01T10:00:00.000+00:00",
+          },
+          { ...CLEARED, uuid: "txr_new", updatedTime: "2026-08-01T11:00:00.000+00:00" },
+        ],
+        nextPage: null,
+      },
+    }));
+
+    const page = await adapter().listTransactions!("2026-08-01T00:00:00.000Z");
+    // Everything read is still returned — the hold-back is about the CURSOR,
+    // not about dropping work.
+    expect(page.transactions).toHaveLength(3);
+    // Stops below the pending row, not at the newest settled one.
+    expect(page.nextCursor).toBe("2026-08-01T09:00:00.000Z");
+  });
+
+  test("a DECLINE is terminal and does not hold the cursor back", async () => {
+    // Nothing further will happen to it, so passing it strands nothing.
+    route("GET", "/v3/spend/transactions", () => ({
+      body: {
+        results: [
+          {
+            ...CLEARED,
+            uuid: "txr_declined",
+            transactionType: "DECLINE",
+            updatedTime: "2026-08-01T09:00:00.000+00:00",
+          },
+          { ...CLEARED, uuid: "txr_new", updatedTime: "2026-08-01T11:00:00.000+00:00" },
+        ],
+        nextPage: null,
+      },
+    }));
+
+    const page = await adapter().listTransactions!("2026-08-01T00:00:00.000Z");
+    expect(page.nextCursor).toBe("2026-08-01T11:00:00.000Z");
   });
 
   test("rows with no uuid or no card are dropped, not half-recorded", async () => {

--- a/apps/convex/__tests__/finance-bill-adapter.test.ts
+++ b/apps/convex/__tests__/finance-bill-adapter.test.ts
@@ -448,6 +448,45 @@ describe("findOrCreateBudget", () => {
     expect(warn.mock.calls.flat().join(" ")).toMatch(/allows \$100.*asks for \$500/);
   });
 
+  test("A LOOKUP THAT GAVE UP MID-LIST REFUSES rather than splitting history", async () => {
+    // The pagination twin of the rename hazard, and the one case where creating
+    // is NOT the recoverable direction: the fund's budget may be on page 11, and
+    // a duplicate budget cannot be merged in BILL. So the walk that never
+    // reached the end must not be allowed to conclude "no budget exists" — and
+    // the loud "someone renamed it" log would misattribute the cause anyway.
+    seedAccount();
+    route("GET", "/v3/spend/budgets", () => ({
+      body: {
+        results: [{ uuid: "bgt_unrelated", name: "Some Other Fund · Togather" }],
+        nextPage: "there-is-always-more",
+      },
+    }));
+
+    await expect(
+      findOrCreateBudget(client(), "Youth Ministry", limit),
+    ).rejects.toThrow(/could not read all of your BILL budgets/i);
+    expect(callsTo("POST", "/v3/spend/budgets")).toHaveLength(0);
+  });
+
+  test("a COMPLETE walk that finds nothing still creates — this is not a regression on the normal path", async () => {
+    // The guard above must key on "did we reach the end", not on "were there
+    // several pages". A church with two pages of budgets and no Togather one
+    // still gets a budget created.
+    seedAccount();
+    let page = 0;
+    route("GET", "/v3/spend/budgets", () => {
+      page++;
+      return page === 1
+        ? { body: { results: [{ uuid: "bgt_a", name: "A · Togather" }], nextPage: "p2" } }
+        : { body: { results: [{ uuid: "bgt_b", name: "B · Togather" }], nextPage: null } };
+    });
+
+    expect(await findOrCreateBudget(client(), "Youth Ministry", limit)).toBe(
+      "bgt_new",
+    );
+    expect(callsTo("POST", "/v3/spend/budgets")).toHaveLength(1);
+  });
+
   test("the budget name is one definition, not an inline template", () => {
     expect(billBudgetName("Youth Ministry")).toBe("Youth Ministry · Togather");
     expect(billBudgetName("  Youth Ministry  ")).toBe("Youth Ministry · Togather");
@@ -478,13 +517,35 @@ describe("resolveBillUserByEmail", () => {
     expect(callsTo("GET", "/v3/spend/users")).toHaveLength(2);
   });
 
-  test("a RETIRED BILL user is not a match", async () => {
+  test("a RETIRED BILL user is not a match, and says REACTIVATE not invite", async () => {
+    // The distinction is the whole point. "Invite them in BILL" sent to an admin
+    // whose cardholder is merely deactivated gets a SECOND BILL user created for
+    // the same human — a duplicate identity at a bank, and a card issued against
+    // the wrong one of them.
     seedAccount({
       users: [{ uuid: "usr_gone", email: "pastor@church.org", retired: true }],
     });
-    await expect(
-      resolveBillUserByEmail(client(), "pastor@church.org"),
-    ).rejects.toThrow(/invite them in BILL/i);
+    const attempt = resolveBillUserByEmail(client(), "pastor@church.org");
+    await expect(attempt).rejects.toThrow(/DEACTIVATED.*Reactivate them in BILL/s);
+    await expect(attempt).rejects.toThrow(/don't invite them again/i);
+    expect(callsTo("POST", "/v3/spend/users")).toHaveLength(0);
+  });
+
+  test("A DIRECTORY DEEPER THAN THE PAGE CAP is not reported as `no such user`", async () => {
+    // We stopped looking; that is not the same fact as "they aren't there", and
+    // conflating them tells the admin to invite someone who already exists.
+    route("GET", "/v3/spend/users", () => ({
+      body: {
+        results: [{ uuid: "usr_x", email: "someone@else.org" }],
+        nextPage: "there-is-always-more",
+      },
+    }));
+
+    const attempt = resolveBillUserByEmail(client(), "pastor@church.org");
+    await expect(attempt).rejects.toThrow(/could not read all of your BILL users/i);
+    // Explicitly NOT the "they don't exist, go invite them" answer.
+    await expect(attempt).rejects.not.toThrow(/No BILL user has the email/);
+    expect(callsTo("POST", "/v3/spend/users")).toHaveLength(0);
   });
 
   test("NO MATCH names the exact next action, and never creates a user", async () => {

--- a/apps/convex/__tests__/finance-bill-adapter.test.ts
+++ b/apps/convex/__tests__/finance-bill-adapter.test.ts
@@ -1,0 +1,885 @@
+/**
+ * BILL Spend & Expense adapter unit tests (ADR-033 Phase 2).
+ *
+ * Like finance-privacy-adapter.test.ts, `fetch` itself is the mock boundary
+ * rather than the client module: the request BODY is the part a bank acts on,
+ * so it is the part worth pinning, and mocking `lib/finance/bill` would let the
+ * adapter and the client drift apart while every test stayed green.
+ *
+ * The mock is a tiny ROUTER (method + path prefix) rather than a response
+ * queue, because a single `createCard` makes four calls in a fixed order and a
+ * queue would make every test in this file a puzzle about call ordering rather
+ * than an assertion about behaviour.
+ *
+ * Three things here are not "does the code run" tests and should not be
+ * softened:
+ * - the DOLLARS/CENTS boundary in both directions (BILL speaks dollars,
+ *   Togather speaks cents, and `53.03 * 100` is not 5303 in IEEE754),
+ * - the budget find-or-create including the documented RENAME HAZARD,
+ * - the email->user resolution, whose no-match error is the sentence a finance
+ *   admin has to act on.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/finance-bill-adapter.test.ts
+ */
+
+import { expect, test, describe, vi, beforeEach, afterEach } from "vitest";
+import {
+  BILL_CAPABILITIES,
+  BILL_CLOSED_SUFFIX,
+  billBudgetName,
+  billStatusToCardState,
+  createBillCardProvider,
+  findOrCreateBudget,
+  isDegradedBillLimitPeriod,
+  normalizeBillTransaction,
+  resolveBillUserByEmail,
+  toBillCardLimit,
+} from "../lib/finance/cardProviders/bill";
+import {
+  billClient,
+  centsToDollars,
+  dollarsToCents,
+  exactUsdCents,
+  type BillTransaction,
+} from "../lib/finance/bill";
+
+const API_TOKEN = "bill-test-api-token";
+const BASE = "https://gateway.stage.bill.com/connect";
+
+// ============================================================================
+// fetch mock — a router, not a queue
+// ============================================================================
+
+interface RecordedCall {
+  url: string;
+  path: string;
+  method: string;
+  headers: Record<string, string>;
+  body: any;
+}
+
+type Handler = (call: RecordedCall) => { status?: number; body?: unknown };
+
+let calls: RecordedCall[] = [];
+let routes: Array<{ method: string; path: string; handler: Handler }> = [];
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  calls = [];
+  routes = [];
+  process.env.BILL_API_BASE_URL = BASE;
+  globalThis.fetch = vi.fn(async (url: any, init: any) => {
+    const full = String(url);
+    const path = full.slice(BASE.length).split("?")[0];
+    const call: RecordedCall = {
+      url: full,
+      path,
+      method: init?.method ?? "GET",
+      headers: init?.headers ?? {},
+      body: init?.body ? JSON.parse(init.body) : undefined,
+    };
+    calls.push(call);
+
+    // MOST SPECIFIC route wins, then most recently registered — so
+    // `/v3/spend/users/current` is not swallowed by `/v3/spend/users`, and a
+    // test can still override a default a helper set up.
+    const match = routes
+      .map((route, index) => ({ route, index }))
+      .filter(
+        ({ route }) =>
+          route.method === call.method && path.startsWith(route.path),
+      )
+      .sort(
+        (a, b) =>
+          b.route.path.length - a.route.path.length || b.index - a.index,
+      )[0]?.route;
+    if (!match) {
+      return new Response(JSON.stringify({ error: `unrouted ${call.method} ${path}` }), {
+        status: 500,
+      });
+    }
+    const { status = 200, body = {} } = match.handler(call);
+    return new Response(status === 204 ? "" : JSON.stringify(body), { status });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  delete process.env.BILL_API_BASE_URL;
+  vi.restoreAllMocks();
+});
+
+function route(method: string, path: string, handler: Handler) {
+  routes.push({ method, path, handler });
+}
+
+/** Calls to a path, in order, for asserting what actually left the process. */
+function callsTo(method: string, path: string) {
+  return calls.filter((c) => c.method === method && c.path.startsWith(path));
+}
+
+/** The default happy-path account: one user, no budgets yet. */
+function seedAccount(
+  options: {
+    users?: any[];
+    budgets?: any[];
+  } = {},
+) {
+  route("GET", "/v3/spend/users/current", () => ({
+    body: { uuid: "usr_admin", email: "admin@church.org", companyName: "First Church" },
+  }));
+  route("GET", "/v3/spend/users", () => ({
+    body: {
+      results: options.users ?? [
+        { uuid: "usr_admin", email: "admin@church.org" },
+        { uuid: "usr_holder", email: "Pastor@Church.org" },
+      ],
+      nextPage: null,
+    },
+  }));
+  route("GET", "/v3/spend/budgets", () => ({
+    body: { results: options.budgets ?? [], nextPage: null },
+  }));
+  route("POST", "/v3/spend/budgets", (call) => ({
+    body: { uuid: "bgt_new", name: call.body.name },
+  }));
+  route("POST", "/v3/spend/cards", (call) => ({
+    body: {
+      uuid: "crd_new",
+      name: call.body.name,
+      status: "ACTIVATED",
+      lastFour: "4242",
+      budgetUuid: call.body.budgetId,
+      userUuid: call.body.userId,
+    },
+  }));
+}
+
+const adapter = () => createBillCardProvider(API_TOKEN);
+const client = () => billClient(API_TOKEN);
+
+const CREATE_INPUT = {
+  fundAccountRef: "",
+  fundName: "Youth Ministry",
+  holderEmail: "pastor@church.org",
+  description: "Youth Ministry — Supplies",
+  idempotencyKey: "finance:card:abc",
+  limit: { limitCents: 50_000, period: "month" as const },
+};
+
+// ============================================================================
+// Capabilities
+// ============================================================================
+
+describe("capabilities", () => {
+  test("declares what BILL genuinely can't do", () => {
+    // Each is read by a caller to decide what to promise a church, so a silent
+    // flip is a lie told to a user rather than a failing assertion.
+    expect(BILL_CAPABILITIES.hardFundIsolation).toBe(false);
+    expect(BILL_CAPABILITIES.weeklyLimits).toBe(false);
+  });
+
+  test("close is REVERSIBLE — the opposite of Privacy, and the UI copy depends on it", () => {
+    // BILL has no close endpoint at all. "Closed" is freeze + rename, so
+    // promising an irreversible destruction would be promising something the
+    // adapter cannot perform.
+    expect(BILL_CAPABILITIES.cardCloseReversible).toBe(true);
+    expect(BILL_CAPABILITIES.cardFreezeReversible).toBe(true);
+  });
+
+  test("webhooks are partial and declines only arrive on the poll", () => {
+    expect(BILL_CAPABILITIES.webhooks).toBe("partial");
+    expect(BILL_CAPABILITIES.declineFeed).toBe("poll");
+  });
+
+  test("repayment is in-product — Togather can neither show nor reconcile it", () => {
+    expect(BILL_CAPABILITIES.repaymentVisibility).toBe("in_product");
+    expect(BILL_CAPABILITIES.maxCardsPerMonth).toBeNull();
+  });
+});
+
+// ============================================================================
+// Money
+// ============================================================================
+
+describe("dollars <-> cents", () => {
+  test("$4.35 is 435 cents, not 434 — the reason this rounds", () => {
+    // Not a hypothetical: 4.35 * 100 is 434.99999999999994 in IEEE754 and
+    // 16.08 * 100 is 1607.9999999999998. A truncating conversion under-books a
+    // cent on ordinary amounts, and nobody notices until a church reconciles a
+    // statement by hand.
+    expect(Math.trunc(4.35 * 100)).toBe(434);
+    expect(dollarsToCents(4.35)).toBe(435);
+    expect(dollarsToCents(16.08)).toBe(1608);
+    expect(dollarsToCents(53.03)).toBe(5303);
+    expect(dollarsToCents(-12.34)).toBe(-1234);
+  });
+
+  test("cents leave as two-decimal dollars", () => {
+    expect(centsToDollars(50_000)).toBe(500);
+    expect(centsToDollars(5303)).toBe(53.03);
+  });
+
+  test("the exact minor-unit string is preferred for USD at par", () => {
+    expect(
+      exactUsdCents({
+        exchangeRate: 1.0,
+        exponent: 2,
+        originalCurrencyAmount: "5303",
+        originalCurrencyCode: "USD",
+      }),
+    ).toBe(5303);
+  });
+
+  test("a FOREIGN charge's minor-unit string is refused", () => {
+    // It is euros-worth of cents; the float `amount` is what the church was
+    // actually billed, so using the string here would book the wrong money.
+    expect(
+      exactUsdCents({
+        exchangeRate: 1.08,
+        exponent: 2,
+        originalCurrencyAmount: "5000",
+        originalCurrencyCode: "EUR",
+      }),
+    ).toBeNull();
+    expect(
+      exactUsdCents({
+        exchangeRate: 1.08,
+        exponent: 2,
+        originalCurrencyAmount: "5000",
+        originalCurrencyCode: "USD",
+      }),
+    ).toBeNull();
+    expect(exactUsdCents(undefined)).toBeNull();
+  });
+});
+
+// ============================================================================
+// Limits
+// ============================================================================
+
+describe("limit mapping", () => {
+  test("a monthly limit is recurring, at the same number in dollars", () => {
+    expect(toBillCardLimit({ limitCents: 50_000, period: "month" })).toEqual({
+      limit: 500,
+      shareBudgetFunds: false,
+      recurring: true,
+    });
+  });
+
+  test("week and charge degrade to a NON-recurring cap at the same number", () => {
+    // Stricter than asked, never looser — the card stops after one window's
+    // worth of spend rather than being handed four weeks of runway.
+    expect(toBillCardLimit({ limitCents: 10_000, period: "week" })).toEqual({
+      limit: 100,
+      shareBudgetFunds: false,
+      recurring: false,
+    });
+    expect(toBillCardLimit({ limitCents: 20_000, period: "charge" })).toEqual({
+      limit: 200,
+      shareBudgetFunds: false,
+      recurring: false,
+    });
+    expect(isDegradedBillLimitPeriod("week")).toBe(true);
+    expect(isDegradedBillLimitPeriod("charge")).toBe(true);
+    expect(isDegradedBillLimitPeriod("month")).toBe(false);
+  });
+
+  test('"no limit" is stated explicitly as shareBudgetFunds, not by omission', () => {
+    expect(toBillCardLimit(null)).toEqual({
+      shareBudgetFunds: true,
+      recurring: false,
+    });
+  });
+});
+
+// ============================================================================
+// States
+// ============================================================================
+
+describe("status mapping", () => {
+  test("BILL's words become ours", () => {
+    expect(billStatusToCardState("ACTIVATED")).toBe("active");
+    expect(billStatusToCardState("FROZEN")).toBe("paused");
+    expect(billStatusToCardState("TERMINATED")).toBe("closed");
+  });
+
+  test("an UNKNOWN status is `failed`, never `active`", () => {
+    // Guessing "active" is the dangerous direction — it would show a church a
+    // live card we know nothing about.
+    expect(billStatusToCardState("SOMETHING_NEW")).toBe("failed");
+    expect(billStatusToCardState("")).toBe("failed");
+  });
+});
+
+// ============================================================================
+// Budget find-or-create — the mapping decision, and its hazard
+// ============================================================================
+
+describe("findOrCreateBudget", () => {
+  const limit = { limitCents: 50_000, period: "month" as const };
+
+  test("an existing budget with the exact name is REUSED, and nothing is created", () => {
+    seedAccount({
+      budgets: [
+        { uuid: "bgt_other", name: "Building Fund · Togather" },
+        { uuid: "bgt_youth", name: "Youth Ministry · Togather", limit: 1000 },
+      ],
+    });
+
+    return findOrCreateBudget(client(), "Youth Ministry", limit).then((uuid) => {
+      expect(uuid).toBe("bgt_youth");
+      expect(callsTo("POST", "/v3/spend/budgets")).toHaveLength(0);
+    });
+  });
+
+  test("matching is case- and whitespace-insensitive", async () => {
+    // A church fixing the capitalization of a fund name must not silently get a
+    // second budget for it.
+    seedAccount({
+      budgets: [{ uuid: "bgt_youth", name: "  youth ministry · Togather " }],
+    });
+    expect(await findOrCreateBudget(client(), "Youth Ministry", limit)).toBe(
+      "bgt_youth",
+    );
+  });
+
+  test("a RETIRED budget of the same name is skipped, not adopted", async () => {
+    // Attaching a card to a dead container would fail later, further from the
+    // cause. Creating a live one with the same name is the recoverable
+    // direction.
+    seedAccount({
+      budgets: [
+        { uuid: "bgt_dead", name: "Youth Ministry · Togather", retired: true },
+      ],
+    });
+    expect(await findOrCreateBudget(client(), "Youth Ministry", limit)).toBe(
+      "bgt_new",
+    );
+  });
+
+  test("no budget means create one, owned by the connected admin, MONTHLY", async () => {
+    seedAccount();
+    expect(await findOrCreateBudget(client(), "Youth Ministry", limit)).toBe(
+      "bgt_new",
+    );
+
+    const [created] = callsTo("POST", "/v3/spend/budgets");
+    expect(created.body).toEqual({
+      name: "Youth Ministry · Togather",
+      owners: ["usr_admin"],
+      // DOLLARS, seeded from the card being created — the only number we have.
+      limit: 500,
+      recurringLimit: 500,
+      recurringInterval: "MONTHLY",
+    });
+  });
+
+  test("THE RENAME HAZARD: a renamed budget silently splits history, loudly logged", async () => {
+    // This is the documented cost of the no-schema mapping. A church that
+    // renames "Youth Ministry · Togather" in BILL makes the lookup miss; we
+    // create a second budget rather than fail. Nothing breaks and no money
+    // moves wrongly — but that fund's history is now in two places, and this
+    // log line is the ONLY signal support has.
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    seedAccount({
+      budgets: [{ uuid: "bgt_youth_old", name: "Youth Ministry (old) · Togather" }],
+    });
+
+    expect(await findOrCreateBudget(client(), "Youth Ministry", limit)).toBe(
+      "bgt_new",
+    );
+    expect(callsTo("POST", "/v3/spend/budgets")).toHaveLength(1);
+    expect(log.mock.calls.flat().join(" ")).toMatch(
+      /created budget "Youth Ministry · Togather".*renamed/s,
+    );
+  });
+
+  test("a budget too small for the new card WARNS but still issues", async () => {
+    // The church owns that number in BILL. Failing here would block a
+    // legitimate second card; the decline feed carries BILL's own reason if the
+    // budget really is the binding constraint.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    seedAccount({
+      budgets: [
+        {
+          uuid: "bgt_youth",
+          name: "Youth Ministry · Togather",
+          currentPeriod: { limit: 100 },
+        },
+      ],
+    });
+
+    expect(await findOrCreateBudget(client(), "Youth Ministry", limit)).toBe(
+      "bgt_youth",
+    );
+    expect(warn.mock.calls.flat().join(" ")).toMatch(/allows \$100.*asks for \$500/);
+  });
+
+  test("the budget name is one definition, not an inline template", () => {
+    expect(billBudgetName("Youth Ministry")).toBe("Youth Ministry · Togather");
+    expect(billBudgetName("  Youth Ministry  ")).toBe("Youth Ministry · Togather");
+  });
+});
+
+// ============================================================================
+// Cardholder resolution
+// ============================================================================
+
+describe("resolveBillUserByEmail", () => {
+  test("matches case-insensitively on email", async () => {
+    seedAccount();
+    expect(await resolveBillUserByEmail(client(), "PASTOR@church.org")).toBe(
+      "usr_holder",
+    );
+  });
+
+  test("walks pages", async () => {
+    let page = 0;
+    route("GET", "/v3/spend/users", () => {
+      page++;
+      return page === 1
+        ? { body: { results: [{ uuid: "usr_a", email: "a@church.org" }], nextPage: "p2" } }
+        : { body: { results: [{ uuid: "usr_b", email: "b@church.org" }], nextPage: null } };
+    });
+    expect(await resolveBillUserByEmail(client(), "b@church.org")).toBe("usr_b");
+    expect(callsTo("GET", "/v3/spend/users")).toHaveLength(2);
+  });
+
+  test("a RETIRED BILL user is not a match", async () => {
+    seedAccount({
+      users: [{ uuid: "usr_gone", email: "pastor@church.org", retired: true }],
+    });
+    await expect(
+      resolveBillUserByEmail(client(), "pastor@church.org"),
+    ).rejects.toThrow(/invite them in BILL/i);
+  });
+
+  test("NO MATCH names the exact next action, and never creates a user", async () => {
+    // Creating a person at a bank on their behalf takes personal details
+    // Togather has no business collecting from a card-issuing flow.
+    seedAccount({ users: [{ uuid: "usr_admin", email: "admin@church.org" }] });
+
+    await expect(
+      resolveBillUserByEmail(client(), "nobody@church.org"),
+    ).rejects.toThrow(
+      /No BILL user has the email nobody@church.org.*invite them in BILL Spend & Expense first/s,
+    );
+    expect(callsTo("POST", "/v3/spend/users")).toHaveLength(0);
+  });
+
+  test("a cardholder with no email fails on OUR side, naming our fix", async () => {
+    seedAccount();
+    await expect(resolveBillUserByEmail(client(), null)).rejects.toThrow(
+      /no email address on their Togather profile/i,
+    );
+    // Not one wasted call at the vendor for a question we can answer ourselves.
+    expect(calls).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// createCard
+// ============================================================================
+
+describe("createCard", () => {
+  test("sends the card into the fund's budget with its OWN limit", async () => {
+    seedAccount();
+    const card = await adapter().createCard(CREATE_INPUT);
+
+    const [created] = callsTo("POST", "/v3/spend/cards");
+    expect(created.body).toEqual({
+      name: "Youth Ministry — Supplies",
+      userId: "usr_holder",
+      budgetId: "bgt_new",
+      // DOLLARS, and the card's own cap — Togather's enforcement lever.
+      limit: 500,
+      // Never true: sharing budget funds would let one card spend the whole
+      // fund, which is exactly the control the finance admin thought they set.
+      shareBudgetFunds: false,
+    });
+    expect(card).toEqual({
+      providerCardId: "crd_new",
+      last4: "4242",
+      state: "active",
+      providerStatus: "ACTIVATED",
+    });
+  });
+
+  test("the token rides in an `apiToken` header, not Authorization", async () => {
+    seedAccount();
+    await adapter().createCard(CREATE_INPUT);
+    expect(calls[0].headers.apiToken).toBe(API_TOKEN);
+    expect(calls[0].headers.Authorization).toBeUndefined();
+  });
+
+  test("the HOLDER is resolved before any budget is created", async () => {
+    // A missing BILL user is the one failure a finance admin can act on;
+    // finding it first means a failed attempt leaves no orphan budget behind.
+    seedAccount({ users: [{ uuid: "usr_admin", email: "admin@church.org" }] });
+
+    await expect(adapter().createCard(CREATE_INPUT)).rejects.toThrow(
+      /No BILL user has the email/,
+    );
+    expect(callsTo("POST", "/v3/spend/budgets")).toHaveLength(0);
+    expect(callsTo("POST", "/v3/spend/cards")).toHaveLength(0);
+  });
+
+  test("a card with no uuid is refused rather than recorded", async () => {
+    // A card row pointing at nothing could never be frozen, re-limited, or
+    // reconciled — worse than a clean failure.
+    seedAccount();
+    route("POST", "/v3/spend/cards", () => ({ body: { status: "ACTIVATED" } }));
+
+    await expect(adapter().createCard(CREATE_INPUT)).rejects.toThrow(
+      /returned no uuid/i,
+    );
+  });
+
+  test("BILL's error text reaches the finance admin verbatim", async () => {
+    seedAccount();
+    route("POST", "/v3/spend/cards", () => ({
+      status: 400,
+      body: { message: "Budget has insufficient funds" },
+    }));
+
+    await expect(adapter().createCard(CREATE_INPUT)).rejects.toThrow(
+      /Budget has insufficient funds/,
+    );
+  });
+});
+
+// ============================================================================
+// setCardState — freeze, unfreeze, and the pseudo-close
+// ============================================================================
+
+describe("setCardState", () => {
+  beforeEach(() => {
+    route("POST", "/v3/spend/cards/crd_1/freeze", () => ({
+      body: { uuid: "crd_1", name: "Youth Ministry — Supplies", status: "FROZEN", lastFour: "4242" },
+    }));
+    route("POST", "/v3/spend/cards/crd_1/unfreeze", () => ({
+      body: { uuid: "crd_1", name: "Youth Ministry — Supplies", status: "ACTIVATED", lastFour: "4242" },
+    }));
+    route("PATCH", "/v3/spend/cards/crd_1", (call) => ({
+      body: { uuid: "crd_1", name: call.body.name, status: "FROZEN", lastFour: "4242" },
+    }));
+  });
+
+  test("paused is a plain freeze", async () => {
+    const card = await adapter().setCardState("crd_1", "paused");
+    expect(callsTo("POST", "/v3/spend/cards/crd_1/freeze")).toHaveLength(1);
+    expect(callsTo("PATCH", "/v3/spend/cards/crd_1")).toHaveLength(0);
+    expect(card.state).toBe("paused");
+    expect(card.providerStatus).toBe("FROZEN");
+  });
+
+  test("active is an unfreeze — reversible, unlike Privacy's close", async () => {
+    const card = await adapter().setCardState("crd_1", "active");
+    expect(callsTo("POST", "/v3/spend/cards/crd_1/unfreeze")).toHaveLength(1);
+    expect(card.state).toBe("active");
+  });
+
+  test("closed is freeze + rename, and reports CLOSED rather than FROZEN", async () => {
+    const card = await adapter().setCardState("crd_1", "closed");
+
+    expect(callsTo("POST", "/v3/spend/cards/crd_1/freeze")).toHaveLength(1);
+    const [renamed] = callsTo("PATCH", "/v3/spend/cards/crd_1");
+    expect(renamed.body.name).toBe(`Youth Ministry — Supplies${BILL_CLOSED_SUFFIX}`);
+
+    // Load-bearing: `cards.status` stores this string and
+    // countLiveProviderCards decides "still spending?" from it. FROZEN here
+    // would mean a church that closed every card could never disconnect BILL
+    // without --force.
+    expect(card.providerStatus).toBe("CLOSED");
+    expect(card.state).toBe("closed");
+  });
+
+  test("a close whose RENAME fails still reports closed — the card is stopped", async () => {
+    // Failing the whole close over cosmetics would leave a card that the bank
+    // has stopped looking merely paused to us.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    route("PATCH", "/v3/spend/cards/crd_1", () => ({ status: 500, body: { message: "nope" } }));
+
+    const card = await adapter().setCardState("crd_1", "closed");
+    expect(card.providerStatus).toBe("CLOSED");
+    expect(warn).toHaveBeenCalled();
+  });
+
+  test("closing an already-closed card does not stack suffixes", async () => {
+    route("POST", "/v3/spend/cards/crd_1/freeze", () => ({
+      body: { uuid: "crd_1", name: `Supplies${BILL_CLOSED_SUFFIX}`, status: "FROZEN" },
+    }));
+    await adapter().setCardState("crd_1", "closed");
+    expect(callsTo("PATCH", "/v3/spend/cards/crd_1")).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// setSpendLimit
+// ============================================================================
+
+describe("setSpendLimit", () => {
+  beforeEach(() => {
+    route("PATCH", "/v3/spend/cards/crd_1", (call) => ({
+      body: { uuid: "crd_1", status: "ACTIVATED", currentPeriod: { limit: call.body.availableFunds } },
+    }));
+  });
+
+  test("sets BOTH the current period and every future one", async () => {
+    // Sending only availableFunds would make a limit change silently a
+    // one-period change.
+    await adapter().setSpendLimit("crd_1", { limitCents: 25_000, period: "month" });
+    expect(callsTo("PATCH", "/v3/spend/cards/crd_1")[0].body).toEqual({
+      availableFunds: 250,
+      recurringLimit: 250,
+      shareBudgetFunds: false,
+      recurring: true,
+    });
+  });
+
+  test("removing a limit is stated explicitly, not by omitting fields", async () => {
+    // Omission on a PATCH means "leave it alone" — the one path where silence
+    // is most expensive.
+    await adapter().setSpendLimit("crd_1", null);
+    expect(callsTo("PATCH", "/v3/spend/cards/crd_1")[0].body).toEqual({
+      shareBudgetFunds: true,
+      recurring: false,
+    });
+  });
+});
+
+// ============================================================================
+// Transactions
+// ============================================================================
+
+const CLEARED: BillTransaction = {
+  uuid: "txr_1",
+  cardUuid: "crd_1",
+  amount: 53.03,
+  merchantName: "Amazon",
+  rawMerchantName: "AMZN Mktp US",
+  transactionType: "CLEAR",
+  occurredTime: "2026-08-01T12:00:00.000+00:00",
+  updatedTime: "2026-08-01T12:05:00.000+00:00",
+  complete: true,
+  currencyData: {
+    exchangeRate: 1.0,
+    exponent: 2,
+    originalCurrencyAmount: "5303",
+    originalCurrencyCode: "USD",
+  },
+};
+
+describe("normalizeBillTransaction", () => {
+  test("a CLEAR is settled, at the EXACT cent", () => {
+    expect(normalizeBillTransaction(CLEARED)).toEqual({
+      providerTxnId: "txr_1",
+      providerCardId: "crd_1",
+      amountCents: 5303,
+      merchantName: "Amazon",
+      description: null,
+      occurredAtMs: Date.parse("2026-08-01T12:00:00.000+00:00"),
+      state: "settled",
+    });
+  });
+
+  test("an AUTHORIZATION is pending — the SAME uuid clears later", () => {
+    // Recording it would double-book the moment it clears, since BILL updates
+    // the same object rather than sending a second one.
+    const auth = { ...CLEARED, transactionType: "AUTHORIZATION", complete: false };
+    expect(normalizeBillTransaction(auth).state).toBe("pending");
+  });
+
+  test("a DECLINE carries BILL's reason as the description", () => {
+    const declined = {
+      ...CLEARED,
+      transactionType: "DECLINE",
+      declineReason: "CVV is invalid.",
+    };
+    const txn = normalizeBillTransaction(declined);
+    expect(txn.state).toBe("declined");
+    expect(txn.description).toBe("CVV is invalid.");
+  });
+
+  test("a refund keeps its NEGATIVE sign rather than being abs()'d", () => {
+    // ProviderTxn's convention, and what lets the recorder skip refunds loudly
+    // instead of debiting the fund a second time for money coming back.
+    const refund = {
+      ...CLEARED,
+      uuid: "txr_refund",
+      amount: -53.03,
+      currencyData: { ...CLEARED.currencyData!, originalCurrencyAmount: "-5303" },
+    };
+    expect(normalizeBillTransaction(refund).amountCents).toBe(-5303);
+  });
+
+  test("a FOREIGN charge falls back to the settled dollar amount", () => {
+    const foreign = {
+      ...CLEARED,
+      amount: 54.11,
+      currencyData: {
+        exchangeRate: 1.08,
+        exponent: 2,
+        originalCurrencyAmount: "5010",
+        originalCurrencyCode: "EUR",
+      },
+    };
+    expect(normalizeBillTransaction(foreign).amountCents).toBe(5411);
+  });
+
+  test("an unknown transactionType is pending, never settled", () => {
+    expect(normalizeBillTransaction({ ...CLEARED, transactionType: "OTHER" }).state).toBe(
+      "pending",
+    );
+  });
+
+  test("the merchant falls back to the raw descriptor before going null", () => {
+    const raw = { ...CLEARED, merchantName: undefined };
+    expect(normalizeBillTransaction(raw).merchantName).toBe("AMZN Mktp US");
+  });
+});
+
+describe("listTransactions", () => {
+  test("filters on updatedTime, sorts ascending, and advances the cursor", async () => {
+    route("GET", "/v3/spend/transactions", () => ({
+      body: {
+        results: [
+          CLEARED,
+          { ...CLEARED, uuid: "txr_2", updatedTime: "2026-08-02T09:00:00.000+00:00" },
+        ],
+        nextPage: null,
+      },
+    }));
+
+    const page = await adapter().listTransactions!("2026-08-01T00:00:00.000Z");
+
+    const [call] = callsTo("GET", "/v3/spend/transactions");
+    expect(call.url).toContain(
+      `filters=${encodeURIComponent("updatedTime:gte:2026-08-01T00:00:00.000Z")}`,
+    );
+    expect(call.url).toContain(`sort=${encodeURIComponent("updatedTime:asc")}`);
+    expect(page.transactions).toHaveLength(2);
+    // updatedTime, not occurredTime: a purchase that authorized last week and
+    // CLEARS today is updated today, and an occurredTime cursor would walk past it.
+    expect(page.nextCursor).toBe("2026-08-02T09:00:00.000Z");
+  });
+
+  test("a first poll looks back 7 days rather than importing years of history", async () => {
+    route("GET", "/v3/spend/transactions", () => ({ body: { results: [], nextPage: null } }));
+    vi.setSystemTime(new Date("2026-08-10T00:00:00.000Z"));
+
+    await adapter().listTransactions!(null);
+    expect(callsTo("GET", "/v3/spend/transactions")[0].url).toContain(
+      encodeURIComponent("updatedTime:gte:2026-08-03T00:00:00.000Z"),
+    );
+    vi.useRealTimers();
+  });
+
+  test("A BACKLOG PAST THE PAGE CAP STALLS the cursor rather than skipping ahead", async () => {
+    // A stall is something an operator notices. A skip is a hole in a church's
+    // books that nobody notices for weeks. Everything fetched is still returned.
+    route("GET", "/v3/spend/transactions", () => ({
+      body: { results: [CLEARED], nextPage: "always-more" },
+    }));
+
+    const page = await adapter().listTransactions!("2026-07-01T00:00:00.000Z");
+    expect(page.nextCursor).toBe("2026-07-01T00:00:00.000Z");
+    expect(callsTo("GET", "/v3/spend/transactions")).toHaveLength(20);
+  });
+
+  test("rows with no uuid or no card are dropped, not half-recorded", async () => {
+    route("GET", "/v3/spend/transactions", () => ({
+      body: {
+        results: [CLEARED, { ...CLEARED, uuid: undefined }, { ...CLEARED, cardUuid: undefined }],
+        nextPage: null,
+      },
+    }));
+    const page = await adapter().listTransactions!("2026-08-01T00:00:00.000Z");
+    expect(page.transactions.map((t) => t.providerTxnId)).toEqual(["txr_1"]);
+  });
+});
+
+describe("fetchTransaction — the fetch half of fetch-to-verify", () => {
+  test("returns what the API says", async () => {
+    route("GET", "/v3/spend/transactions/txr_1", () => ({ body: CLEARED }));
+    const txn = await adapter().fetchTransaction!("txr_1");
+    expect(txn).toMatchObject({ providerTxnId: "txr_1", amountCents: 5303 });
+  });
+
+  test("a 404 is an ANSWER (null), not a failure", async () => {
+    // This is what a forged or stale notification looks like, and the route
+    // writes nothing on it.
+    route("GET", "/v3/spend/transactions/txr_fake", () => ({ status: 404, body: {} }));
+    expect(await adapter().fetchTransaction!("txr_fake")).toBeNull();
+  });
+
+  test("a transaction with no uuid is refused — an empty idempotency key duplicates charges", async () => {
+    route("GET", "/v3/spend/transactions/txr_1", () => ({
+      body: { ...CLEARED, uuid: undefined },
+    }));
+    expect(await adapter().fetchTransaction!("txr_1")).toBeNull();
+  });
+
+  test("an auth failure THROWS rather than looking like `no such transaction`", async () => {
+    route("GET", "/v3/spend/transactions/txr_1", () => ({ status: 401, body: {} }));
+    await expect(adapter().fetchTransaction!("txr_1")).rejects.toThrow(/401/);
+  });
+});
+
+// ============================================================================
+// checkConnection
+// ============================================================================
+
+describe("checkConnection", () => {
+  test("names the company so an admin knows WHICH BILL account they connected", async () => {
+    seedAccount();
+    expect(await adapter().checkConnection!()).toEqual({
+      accountLabel: "First Church",
+    });
+    // Read-only: validating a token must never be able to move money.
+    expect(calls.every((c) => c.method === "GET")).toBe(true);
+  });
+
+  test("falls back to the authenticated user's email", async () => {
+    route("GET", "/v3/spend/users/current", () => ({
+      body: { uuid: "usr_admin", email: "admin@church.org" },
+    }));
+    expect(await adapter().checkConnection!()).toEqual({
+      accountLabel: "admin@church.org",
+    });
+  });
+
+  test("a bad token surfaces BILL's own words", async () => {
+    route("GET", "/v3/spend/users/current", () => ({
+      status: 401,
+      body: { message: "Invalid API token" },
+    }));
+    await expect(adapter().checkConnection!()).rejects.toThrow(/Invalid API token/);
+  });
+});
+
+// ============================================================================
+// registerWebhook
+// ============================================================================
+
+describe("registerWebhook", () => {
+  test("subscribes the URL to spend.transaction.updated", async () => {
+    route("POST", "/v3/subscriptions", () => ({ body: { id: "sub_1" } }));
+    await adapter().registerWebhook!("https://example.convex.site/card-provider-webhook/bill");
+
+    expect(callsTo("POST", "/v3/subscriptions")[0].body).toEqual({
+      name: "Togather card transactions",
+      status: { enabled: true },
+      events: [{ type: "spend.transaction.updated", version: "1" }],
+      notificationUrl: "https://example.convex.site/card-provider-webhook/bill",
+    });
+  });
+
+  test("THROWS on failure — the caller decides that a failure is only a log", async () => {
+    route("POST", "/v3/subscriptions", () => ({ status: 403, body: { message: "devKey required" } }));
+    await expect(
+      adapter().registerWebhook!("https://example.convex.site/card-provider-webhook/bill"),
+    ).rejects.toThrow(/devKey required/);
+  });
+});

--- a/apps/convex/__tests__/finance-byoc-bill.test.ts
+++ b/apps/convex/__tests__/finance-byoc-bill.test.ts
@@ -1,0 +1,945 @@
+/**
+ * BILL Spend & Expense, end to end (ADR-033 Phase 2).
+ *
+ * finance-bill-adapter.test.ts pins what we SAY to BILL. This file pins what
+ * happens to a CHURCH: connecting their account, issuing a card into a budget
+ * they've never heard of, and — the reason this file exists at all — the
+ * FETCH-TO-VERIFY webhook.
+ *
+ * BILL publishes no webhook signature. None. So `/card-provider-webhook/bill`
+ * is an endpoint any stranger can POST anything to, and the only thing standing
+ * between that and a church's books is the rule that the payload ROUTES and the
+ * API DECIDES. The test named "a payload that LIES about the amount…" is the
+ * one that proves it, and if it is ever softened this integration is unsafe to
+ * ship. Read it before changing the handler.
+ *
+ * The BILL HTTP client is mocked at the module boundary — the same seam
+ * finance-byoc-cards.test.ts uses for Privacy — and the LAST describe block
+ * runs a Privacy church and a BILL church through one poll fan-out to prove
+ * they never share a client, a cursor, or a credential.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/finance-byoc-bill.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+import { generateTokens } from "../lib/auth";
+import { decryptCredential } from "../lib/finance/credentialCrypto";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+/** 32 bytes, base64 — a valid AES-256 key for the envelope crypto. */
+process.env.CREDENTIALS_MASTER_KEY = btoa(
+  String.fromCharCode(...new Uint8Array(32).fill(3)),
+);
+process.env.CONVEX_SITE_URL = "https://test-deployment.convex.site";
+
+// Same hazard as finance-byoc-cards.test.ts: mutations schedule provisioning
+// actions on a REAL setTimeout under convex-test. Frozen timers mean they only
+// run when a test invokes them deliberately.
+vi.useFakeTimers();
+
+const API_TOKEN = "bill_live_token_do_not_log";
+const PRIVACY_KEY = "privacy_live_key_do_not_log";
+const WEBHOOK_PATH = "/card-provider-webhook/bill";
+const CARD_UUID = "crd_bill_1";
+const HOLDER_EMAIL = "pastor@byoc.church";
+
+/** The transaction BILL will hand back when we re-fetch. THE source of truth. */
+const CLEARED_TXN = {
+  uuid: "txr_bill_1",
+  cardUuid: CARD_UUID,
+  amount: 42.0,
+  merchantName: "OFFICE SUPPLY CO",
+  rawMerchantName: "OFFICE SUPPLY CO #12",
+  transactionType: "CLEAR",
+  occurredTime: "2026-08-01T12:00:00.000+00:00",
+  updatedTime: "2026-08-01T12:05:00.000+00:00",
+  complete: true,
+  currencyData: {
+    exchangeRate: 1.0,
+    exponent: 2,
+    originalCurrencyAmount: "4200",
+    originalCurrencyCode: "USD",
+  },
+};
+
+/** Only the NETWORK functions are stubbed; the normalization stays real. */
+const bill = vi.hoisted(() => ({
+  getBillCurrentUser: vi.fn(async () => ({
+    uuid: "usr_admin",
+    email: "admin@byoc.church",
+    companyName: "BYOC Church",
+  })),
+  listBillUsers: vi.fn(async () => ({
+    results: [
+      { uuid: "usr_admin", email: "admin@byoc.church" },
+      { uuid: "usr_holder", email: "pastor@byoc.church" },
+    ],
+    nextPage: null,
+  })),
+  listBillBudgets: vi.fn(async () => ({ results: [], nextPage: null })),
+  createBillBudget: vi.fn(async (_c: unknown, params: any) => ({
+    uuid: "bgt_bill_1",
+    name: params.name,
+  })),
+  createBillCard: vi.fn(async (_c: unknown, params: any) => ({
+    uuid: CARD_UUID,
+    name: params.name,
+    status: "ACTIVATED",
+    lastFour: "9999",
+  })),
+  updateBillCard: vi.fn(async (_c: unknown, uuid: string, params: any) => ({
+    uuid,
+    name: params.name ?? "card",
+    status: "FROZEN",
+  })),
+  freezeBillCard: vi.fn(async (_c: unknown, uuid: string) => ({
+    uuid,
+    name: "card",
+    status: "FROZEN",
+  })),
+  unfreezeBillCard: vi.fn(async (_c: unknown, uuid: string) => ({
+    uuid,
+    status: "ACTIVATED",
+  })),
+  listBillTransactions: vi.fn(async () => ({ results: [], nextPage: null })),
+  getBillTransaction: vi.fn(async () => null as any),
+  createBillWebhookSubscription: vi.fn(async () => ({ id: "sub_1" })),
+}));
+
+vi.mock("../lib/finance/bill", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/finance/bill")>()),
+  ...bill,
+}));
+
+/** Privacy's network seam, for the cross-provider fan-out test only. */
+const privacy = vi.hoisted(() => ({
+  createPrivacyCard: vi.fn(async () => ({
+    token: "card_privacy_1",
+    state: "OPEN",
+    last_four: "1111",
+  })),
+  updatePrivacyCard: vi.fn(async () => ({ token: "card_privacy_1", state: "OPEN" })),
+  listPrivacyFundingSources: vi.fn(async () => [
+    { token: "fund_src_1", nickname: "Operations Checking" },
+  ]),
+  listPrivacyTransactions: vi.fn(async () => ({ data: [], page: 1, total_pages: 1 })),
+}));
+
+vi.mock("../lib/finance/privacy", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/finance/privacy")>()),
+  ...privacy,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  bill.getBillCurrentUser.mockResolvedValue({
+    uuid: "usr_admin",
+    email: "admin@byoc.church",
+    companyName: "BYOC Church",
+  });
+  bill.listBillUsers.mockResolvedValue({
+    results: [
+      { uuid: "usr_admin", email: "admin@byoc.church" },
+      { uuid: "usr_holder", email: "pastor@byoc.church" },
+    ],
+    nextPage: null,
+  });
+  bill.listBillBudgets.mockResolvedValue({ results: [], nextPage: null });
+  bill.listBillTransactions.mockResolvedValue({ results: [], nextPage: null });
+  bill.getBillTransaction.mockResolvedValue(null);
+  bill.createBillWebhookSubscription.mockResolvedValue({ id: "sub_1" });
+  privacy.listPrivacyTransactions.mockResolvedValue({
+    data: [],
+    page: 1,
+    total_pages: 1,
+  });
+  privacy.listPrivacyFundingSources.mockResolvedValue([
+    { token: "fund_src_1", nickname: "Operations Checking" },
+  ]);
+});
+
+const ADDRESS = {
+  addressLine1: "1 Main St",
+  city: "Austin",
+  state: "TX",
+  zipCode: "78701",
+};
+
+interface Fixture {
+  communityId: Id<"communities">;
+  fundId: Id<"funds">;
+  primaryAdminUserId: Id<"users">;
+  cardholderUserId: Id<"users">;
+}
+
+/**
+ * A community that has never touched Increase. Note what is ABSENT: no
+ * `increaseAccountId` on the fund, no `increaseEntityId` on the community.
+ * The cardholder DOES have an email, because BILL identifies cardholders by
+ * one and a fixture without it would hide the failure mode rather than test it.
+ */
+async function seed(
+  t: ReturnType<typeof convexTest>,
+  options: { fundName?: string; holderEmail?: string | null } = {},
+): Promise<Fixture> {
+  return await t.run(async (ctx) => {
+    const existingFlag = await ctx.db.query("featureFlags").first();
+    if (!existingFlag) {
+      await ctx.db.insert("featureFlags", {
+        key: "group-giving",
+        enabled: true,
+        updatedAt: Date.now(),
+      });
+    }
+    const timestamp = Date.now();
+    const suffix = Math.floor(Math.random() * 1_000_000);
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "BYOC Church",
+      slug: `byoc-bill-${suffix}`,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Group",
+      slug: "small-group",
+      isActive: true,
+      createdAt: timestamp,
+      displayOrder: 1,
+    });
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Youth",
+      isArchived: false,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    const mkUser = async (name: string, roles: number, email?: string | null) => {
+      const userId = await ctx.db.insert("users", {
+        firstName: name,
+        lastName: "User",
+        phone: `+1555${Math.floor(Math.random() * 9_000_000 + 1_000_000)}`,
+        ...(email ? { email } : {}),
+        isActive: true,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      await ctx.db.insert("userCommunities", {
+        userId,
+        communityId,
+        roles,
+        status: 1,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      await ctx.db.insert("groupMembers", {
+        groupId,
+        userId,
+        role: "member",
+        joinedAt: timestamp,
+        notificationsEnabled: true,
+      });
+      return userId;
+    };
+
+    const primaryAdminUserId = await mkUser("Primary", 4, "admin@byoc.church");
+    const cardholderUserId = await mkUser(
+      "Cardholder",
+      1,
+      options.holderEmail === undefined ? HOLDER_EMAIL : options.holderEmail,
+    );
+
+    const fundId = await ctx.db.insert("funds", {
+      communityId,
+      groupId,
+      name: options.fundName ?? "Youth Ministry",
+      type: "group",
+      status: "active",
+      balanceCents: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    await ctx.db.insert("communityFinance", {
+      communityId,
+      stripeConnectedAccountId: `acct_byoc_${suffix}`,
+      onboardingStatus: "live",
+      legalName: "BYOC Church",
+      ein: "12-3456789",
+      address: ADDRESS,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    await ctx.db.insert("fundRoles", {
+      fundId,
+      userId: primaryAdminUserId,
+      role: "finance_admin",
+      grantedBy: primaryAdminUserId,
+      grantedAt: timestamp,
+    });
+    await ctx.db.insert("fundRoles", {
+      fundId,
+      userId: cardholderUserId,
+      role: "cardholder",
+      grantedBy: primaryAdminUserId,
+      grantedAt: timestamp,
+    });
+
+    return { communityId, fundId, primaryAdminUserId, cardholderUserId };
+  });
+}
+
+async function tokenFor(userId: Id<"users">): Promise<string> {
+  return (await generateTokens(userId)).accessToken;
+}
+
+async function connect(
+  t: ReturnType<typeof convexTest>,
+  f: Fixture,
+  provider: "bill" | "privacy" = "bill",
+  apiKey = provider === "bill" ? API_TOKEN : PRIVACY_KEY,
+) {
+  return await t.action(
+    api.functions.finance.cardProviderConnections.connectCardProvider,
+    {
+      token: await tokenFor(f.primaryAdminUserId),
+      communityId: f.communityId,
+      provider,
+      apiKey,
+    },
+  );
+}
+
+/** Create + provision a card, the way createFundCard's scheduled action would. */
+async function issueCard(
+  t: ReturnType<typeof convexTest>,
+  f: Fixture,
+): Promise<Id<"cards">> {
+  const cardId: Id<"cards"> = await t.mutation(
+    api.functions.finance.cards.createFundCard,
+    {
+      token: await tokenFor(f.primaryAdminUserId),
+      fundId: f.fundId,
+      holderUserId: f.cardholderUserId,
+      name: "Supplies",
+      spendLimitCents: 50_000,
+      limitPeriod: "month",
+    },
+  );
+  await t.action(internal.functions.finance.cards.provisionCard, { cardId });
+  return cardId;
+}
+
+async function countWrites(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => ({
+    expenses: (await ctx.db.query("expenses").collect()).length,
+    ledger: (await ctx.db.query("ledgerEntries").collect()).length,
+  }));
+}
+
+// ============================================================================
+// connectCardProvider
+// ============================================================================
+
+describe("connecting BILL", () => {
+  test("proves the token, encrypts it, and switches the community over", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+
+    const result = await connect(t, f);
+    expect(result.accountLabel).toBe("BYOC Church");
+
+    const row = await t.run(async (ctx) =>
+      ctx.db.query("cardProviderConnections").first(),
+    );
+    expect(row!.provider).toBe("bill");
+    expect(row!.status).toBe("active");
+    // The token round-trips through envelope encryption, and the CIPHERTEXT is
+    // what is stored — a grep of the row must never find the token.
+    expect(JSON.stringify(row)).not.toContain(API_TOKEN);
+    expect(
+      await decryptCredential(
+        {
+          ciphertext: row!.credentialCiphertext,
+          iv: row!.credentialIv,
+          keyVersion: row!.keyVersion,
+        },
+        { communityId: f.communityId, provider: "bill", purpose: "apiKey" },
+      ),
+    ).toBe(API_TOKEN);
+
+    const finance = await t.run(async (ctx) =>
+      ctx.db.query("communityFinance").first(),
+    );
+    expect(finance!.cardProvider).toBe("bill");
+  });
+
+  test("registers THIS deployment's webhook URL, derived not configured", async () => {
+    // A hand-typed URL is how a staging connection ends up registering a
+    // production callback.
+    const t = convexTest(schema, modules);
+    await connect(t, await seed(t));
+
+    expect(bill.createBillWebhookSubscription).toHaveBeenCalledTimes(1);
+    const [, params] = bill.createBillWebhookSubscription.mock.calls[0] as any[];
+    expect(params.notificationUrl).toBe(
+      "https://test-deployment.convex.site/card-provider-webhook/bill",
+    );
+  });
+
+  test("A FAILED SUBSCRIPTION STILL CONNECTS — the poll covers it", async () => {
+    // BILL's subscriptions are production-only and may want a different
+    // credential entirely. Making registration fatal would make connecting a
+    // sandbox account impossible for a church whose cards work perfectly.
+    const t = convexTest(schema, modules);
+    bill.createBillWebhookSubscription.mockRejectedValue(
+      new Error("BILL API POST /v3/subscriptions failed (403): devKey required"),
+    );
+
+    const result = await connect(t, await seed(t));
+    expect(result.accountLabel).toBe("BYOC Church");
+    const row = await t.run(async (ctx) =>
+      ctx.db.query("cardProviderConnections").first(),
+    );
+    expect(row!.status).toBe("active");
+  });
+
+  test("a bad token is rejected BEFORE anything is stored", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    bill.getBillCurrentUser.mockRejectedValue(
+      new Error("BILL API GET /v3/spend/users/current failed (401): Invalid API token"),
+    );
+
+    await expect(connect(t, f)).rejects.toThrow(/Invalid API token/);
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("cardProviderConnections").collect(),
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test("the prompt names BILL's own word for the credential", async () => {
+    // "Enter your Privacy.com API key" shown to a church connecting BILL is how
+    // someone pastes the wrong secret.
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await expect(connect(t, f, "bill", "   ")).rejects.toThrow(
+      /BILL Spend & Expense API token/,
+    );
+  });
+});
+
+// ============================================================================
+// Issuing a card
+// ============================================================================
+
+describe("issuing a BILL card", () => {
+  test("creates the fund's budget, resolves the holder, and caps the card", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await connect(t, f);
+
+    const cardId = await issueCard(t, f);
+
+    // ONE BUDGET PER FUND, named after the fund — the mapping decision.
+    const [, budget] = bill.createBillBudget.mock.calls[0] as any[];
+    expect(budget.name).toBe("Youth Ministry · Togather");
+
+    const [, card] = bill.createBillCard.mock.calls[0] as any[];
+    expect(card).toEqual({
+      name: "Youth Ministry — Supplies",
+      // Matched from the cardholder's Togather email, never created.
+      userId: "usr_holder",
+      budgetId: "bgt_bill_1",
+      limit: 500,
+      shareBudgetFunds: false,
+    });
+
+    const row = await t.run(async (ctx) => ctx.db.get(cardId));
+    expect(row!.provider).toBe("bill");
+    expect(row!.providerCardId).toBe(CARD_UUID);
+    // The legacy Increase column stays EMPTY — writing a BILL uuid into it
+    // would put a foreign card on the Increase webhook's lookup index.
+    expect(row!.increaseCardId).toBeUndefined();
+    expect(row!.status).toBe("ACTIVATED");
+    expect(row!.last4).toBe("9999");
+  });
+
+  test("an EXISTING budget for the fund is reused rather than duplicated", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await connect(t, f);
+    bill.listBillBudgets.mockResolvedValue({
+      results: [{ uuid: "bgt_existing", name: "Youth Ministry · Togather" }],
+      nextPage: null,
+    });
+
+    await issueCard(t, f);
+    expect(bill.createBillBudget).not.toHaveBeenCalled();
+    const [, card] = bill.createBillCard.mock.calls[0] as any[];
+    expect(card.budgetId).toBe("bgt_existing");
+  });
+
+  test("a cardholder BILL has never heard of fails with the admin's next action", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await connect(t, f);
+    bill.listBillUsers.mockResolvedValue({
+      results: [{ uuid: "usr_admin", email: "admin@byoc.church" }],
+      nextPage: null,
+    });
+
+    const cardId = await issueCard(t, f);
+
+    expect(bill.createBillCard).not.toHaveBeenCalled();
+    const row = await t.run(async (ctx) => ctx.db.get(cardId));
+    expect(row!.status).toBe("failed");
+
+    const audit = await t.run(async (ctx) =>
+      ctx.db
+        .query("financeAuditEvents")
+        .filter((q) => q.eq(q.field("action"), "card.provision_failed"))
+        .first(),
+    );
+    expect(JSON.parse(audit!.detailsJson!).message).toMatch(
+      /invite them in BILL Spend & Expense first/,
+    );
+  });
+
+  test("a cardholder with no Togather email fails on OUR side, before BILL", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t, { holderEmail: null });
+    await connect(t, f);
+
+    const cardId = await issueCard(t, f);
+
+    expect(bill.listBillUsers).not.toHaveBeenCalled();
+    const row = await t.run(async (ctx) => ctx.db.get(cardId));
+    expect(row!.status).toBe("failed");
+  });
+});
+
+// ============================================================================
+// The webhook — FETCH TO VERIFY
+// ============================================================================
+
+async function postWebhook(
+  t: ReturnType<typeof convexTest>,
+  payload: unknown,
+): Promise<Response> {
+  return await t.fetch(WEBHOOK_PATH, {
+    method: "POST",
+    body: JSON.stringify(payload),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** A notification as BILL sends it. Nothing in here is trusted but the two ids. */
+function notification(overrides: Record<string, unknown> = {}) {
+  return {
+    metadata: {
+      eventId: "evt_1",
+      eventType: "spend.transaction.updated",
+      spendCompanyUuid: "cmp_1",
+      version: "1",
+    },
+    transaction: { ...CLEARED_TXN, ...overrides },
+  };
+}
+
+describe("POST /card-provider-webhook/bill", () => {
+  async function connectedWithCard(t: ReturnType<typeof convexTest>) {
+    const f = await seed(t);
+    await connect(t, f);
+    await issueCard(t, f);
+    return f;
+  }
+
+  test("a clearing becomes exactly one expense and one ledger debit", async () => {
+    const t = convexTest(schema, modules);
+    const f = await connectedWithCard(t);
+    bill.getBillTransaction.mockResolvedValue(CLEARED_TXN);
+
+    const res = await postWebhook(t, notification());
+    expect(res.status).toBe(200);
+
+    // The route re-read the transaction rather than believing the body.
+    expect(bill.getBillTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      "txr_bill_1",
+    );
+
+    const expenses = await t.run(async (ctx) => ctx.db.query("expenses").collect());
+    expect(expenses).toHaveLength(1);
+    expect(expenses[0]).toMatchObject({
+      fundId: f.fundId,
+      amountCents: 4200,
+      kind: "card_charge",
+      description: "OFFICE SUPPLY CO",
+      increaseTransactionId: "txr_bill_1",
+    });
+    const ledger = await t.run(async (ctx) =>
+      ctx.db.query("ledgerEntries").collect(),
+    );
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0]).toMatchObject({ direction: "debit", amountCents: 4200 });
+  });
+
+  test("A PAYLOAD THAT LIES ABOUT THE AMOUNT BOOKS THE API'S NUMBER", async () => {
+    // THE test for this integration. BILL publishes no webhook signature, so
+    // this endpoint accepts anything a stranger sends. The defence is that the
+    // body only ROUTES: whatever it claims, what gets booked is what BILL's
+    // API returns for that uuid, fetched with the church's own token.
+    //
+    // If this ever fails, the handler has started trusting the payload and a
+    // stranger can write arbitrary expenses into a church's ledger.
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    bill.getBillTransaction.mockResolvedValue(CLEARED_TXN); // truth: $42.00
+
+    const res = await postWebhook(
+      t,
+      notification({
+        amount: 900_000,
+        merchantName: "ATTACKER LLC",
+        currencyData: {
+          exchangeRate: 1.0,
+          exponent: 2,
+          originalCurrencyAmount: "90000000",
+          originalCurrencyCode: "USD",
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const expenses = await t.run(async (ctx) => ctx.db.query("expenses").collect());
+    expect(expenses).toHaveLength(1);
+    expect(expenses[0].amountCents).toBe(4200);
+    expect(expenses[0].description).toBe("OFFICE SUPPLY CO");
+  });
+
+  test("a transaction BILL doesn't have writes NOTHING", async () => {
+    // What a wholly forged delivery looks like: a 404 on the re-fetch.
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    bill.getBillTransaction.mockResolvedValue(null);
+
+    const res = await postWebhook(t, notification({ uuid: "txr_invented" }));
+    expect(res.status).toBe(200);
+    expect(await countWrites(t)).toEqual({ expenses: 0, ledger: 0 });
+  });
+
+  test("a redelivery writes nothing further", async () => {
+    // `spend.transaction.updated` fires at AUTHORIZATION and AGAIN at CLEAR,
+    // and BILL retries on failure — idempotency on the transaction uuid is the
+    // entire defence, since there is no signature and therefore no replay
+    // window either.
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    bill.getBillTransaction.mockResolvedValue(CLEARED_TXN);
+
+    await postWebhook(t, notification());
+    await postWebhook(t, notification());
+    await postWebhook(t, notification());
+
+    expect(await countWrites(t)).toEqual({ expenses: 1, ledger: 1 });
+  });
+
+  test("the AUTHORIZATION delivery records nothing; its CLEAR does", async () => {
+    // BILL updates the SAME uuid rather than sending a second transaction, so
+    // recording the authorization would double-book it on settlement.
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+
+    bill.getBillTransaction.mockResolvedValue({
+      ...CLEARED_TXN,
+      transactionType: "AUTHORIZATION",
+      complete: false,
+    });
+    await postWebhook(t, notification());
+    expect(await countWrites(t)).toEqual({ expenses: 0, ledger: 0 });
+
+    bill.getBillTransaction.mockResolvedValue(CLEARED_TXN);
+    await postWebhook(t, notification());
+    expect(await countWrites(t)).toEqual({ expenses: 1, ledger: 1 });
+  });
+
+  test("a card we don't know is 200 with no writes, and no API call", async () => {
+    // Routine: the church has their own cards in this BILL account and the
+    // subscription covers the whole company's feed. Not fetching is also what
+    // keeps a stranger from using this endpoint to burn the church's rate limit.
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+
+    const res = await postWebhook(
+      t,
+      notification({ cardUuid: "crd_the_church_owns" }),
+    );
+    expect(res.status).toBe(200);
+    expect(bill.getBillTransaction).not.toHaveBeenCalled();
+    expect(await countWrites(t)).toEqual({ expenses: 0, ledger: 0 });
+  });
+
+  test("a payload with no ids is ignored without touching the database", async () => {
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    const res = await postWebhook(t, { metadata: { eventType: "spend.transaction.updated" } });
+    expect(res.status).toBe(200);
+    expect(bill.getBillTransaction).not.toHaveBeenCalled();
+  });
+
+  test("a failed re-fetch is 500 so BILL redelivers", async () => {
+    // Distinct from a 404: the transaction may well be real and we simply
+    // couldn't read it. The poll would catch it anyway, but a retry is cheaper.
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    bill.getBillTransaction.mockRejectedValue(new Error("failed (429): slow down"));
+
+    const res = await postWebhook(t, notification());
+    expect(res.status).toBe(500);
+    expect(await countWrites(t)).toEqual({ expenses: 0, ledger: 0 });
+  });
+
+  test("malformed JSON is 400", async () => {
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    const res = await t.fetch(WEBHOOK_PATH, { method: "POST", body: "{not json" });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ============================================================================
+// The hourly poll
+// ============================================================================
+
+describe("finance-card-txn-poll on BILL", () => {
+  async function connectedWithCard(t: ReturnType<typeof convexTest>) {
+    const f = await seed(t);
+    await connect(t, f);
+    await issueCard(t, f);
+    return f;
+  }
+
+  test("records clearings and advances the updatedTime cursor", async () => {
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    bill.listBillTransactions.mockResolvedValue({
+      results: [
+        CLEARED_TXN,
+        {
+          ...CLEARED_TXN,
+          uuid: "txr_bill_2",
+          amount: 9.0,
+          updatedTime: "2026-08-02T09:00:00.000+00:00",
+          currencyData: {
+            exchangeRate: 1.0,
+            exponent: 2,
+            originalCurrencyAmount: "900",
+            originalCurrencyCode: "USD",
+          },
+        },
+      ],
+      nextPage: null,
+    });
+
+    const result = await t.action(
+      internal.functions.finance.jobs.pollCardProviderTransactions,
+      {},
+    );
+    expect(result).toEqual({ polled: 1, recorded: 2 });
+
+    const row = await t.run(async (ctx) =>
+      ctx.db.query("cardProviderConnections").first(),
+    );
+    expect(row!.syncCursor).toBe("2026-08-02T09:00:00.000Z");
+    expect(row!.status).toBe("active");
+    expect(await countWrites(t)).toEqual({ expenses: 2, ledger: 2 });
+  });
+
+  test("DECLINES are read but not recorded (Phase 3 notifies)", async () => {
+    // `declineFeed: "poll"` made literal — this is the only place a BILL
+    // decline reaches Togather at all.
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    bill.listBillTransactions.mockResolvedValue({
+      results: [
+        {
+          ...CLEARED_TXN,
+          uuid: "txr_declined",
+          transactionType: "DECLINE",
+          declineReason: "Budget limit exceeded",
+        },
+      ],
+      nextPage: null,
+    });
+
+    const result = await t.action(
+      internal.functions.finance.jobs.pollCardProviderTransactions,
+      {},
+    );
+    expect(result.recorded).toBe(0);
+    expect(await countWrites(t)).toEqual({ expenses: 0, ledger: 0 });
+  });
+
+  test("a resumed poll filters from the stored cursor", async () => {
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    await t.run(async (ctx) => {
+      const row = await ctx.db.query("cardProviderConnections").first();
+      await ctx.db.patch(row!._id, { syncCursor: "2026-07-30T00:00:00.000Z" });
+    });
+
+    await t.action(internal.functions.finance.jobs.pollCardProviderTransactions, {});
+    const [, params] = bill.listBillTransactions.mock.calls[0] as any[];
+    expect(params.filters).toBe("updatedTime:gte:2026-07-30T00:00:00.000Z");
+    expect(params.sort).toBe("updatedTime:asc");
+  });
+
+  test("the poll and the webhook cannot double-book the same charge", async () => {
+    // What makes the poll a real backstop rather than a second, subtly
+    // different importer.
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    bill.getBillTransaction.mockResolvedValue(CLEARED_TXN);
+    await postWebhook(t, notification());
+
+    bill.listBillTransactions.mockResolvedValue({
+      results: [CLEARED_TXN],
+      nextPage: null,
+    });
+    await t.action(internal.functions.finance.jobs.pollCardProviderTransactions, {});
+
+    expect(await countWrites(t)).toEqual({ expenses: 1, ledger: 1 });
+  });
+
+  test("a revoked token flips the connection to error and keeps its cursor", async () => {
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    await t.run(async (ctx) => {
+      const row = await ctx.db.query("cardProviderConnections").first();
+      await ctx.db.patch(row!._id, { syncCursor: "2026-07-30T00:00:00.000Z" });
+    });
+    bill.listBillTransactions.mockRejectedValue(
+      new Error("BILL API GET /v3/spend/transactions failed (401): revoked"),
+    );
+
+    const result = await t.action(
+      internal.functions.finance.jobs.pollCardProviderTransactions,
+      {},
+    );
+    expect(result).toEqual({ polled: 1, recorded: 0 });
+
+    const row = await t.run(async (ctx) =>
+      ctx.db.query("cardProviderConnections").first(),
+    );
+    expect(row!.status).toBe("error");
+    expect(row!.lastError).toContain("401");
+    // Never rewound: the next successful poll re-reads from where we stopped.
+    expect(row!.syncCursor).toBe("2026-07-30T00:00:00.000Z");
+  });
+});
+
+// ============================================================================
+// Provider dispatch — the two churches must not cross wires
+// ============================================================================
+
+describe("a Privacy church and a BILL church in one fan-out", () => {
+  test("each is polled through its OWN adapter, with its own cursor", async () => {
+    // The fan-out has no provider switch of its own: each connection resolves
+    // to its community's adapter with its community's decrypted credential.
+    // This is the test that would fail if someone ever "simplified" that into a
+    // single client — and the failure mode it prevents is one church's charges
+    // landing in another church's fund.
+    const t = convexTest(schema, modules);
+
+    const billChurch = await seed(t, { fundName: "Youth Ministry" });
+    await connect(t, billChurch, "bill");
+    await issueCard(t, billChurch);
+
+    const privacyChurch = await seed(t, { fundName: "Building Fund" });
+    await connect(t, privacyChurch, "privacy");
+    const privacyCardId = await issueCard(t, privacyChurch);
+    expect(billChurch.communityId).not.toBe(privacyChurch.communityId);
+
+    bill.listBillTransactions.mockResolvedValue({
+      results: [CLEARED_TXN],
+      nextPage: null,
+    });
+    privacy.listPrivacyTransactions.mockResolvedValue({
+      data: [
+        {
+          token: "txn_privacy_1",
+          card_token: "card_privacy_1",
+          amount: 1500,
+          settled_amount: 1500,
+          status: "SETTLED",
+          result: "APPROVED",
+          created: "2026-08-03T10:00:00Z",
+          merchant: { descriptor: "HARDWARE STORE" },
+        },
+      ],
+      page: 1,
+      total_pages: 1,
+    } as any);
+
+    const result = await t.action(
+      internal.functions.finance.jobs.pollCardProviderTransactions,
+      {},
+    );
+    expect(result).toEqual({ polled: 2, recorded: 2 });
+
+    // Each provider client saw exactly its own church's poll — no double
+    // dispatch, and no adapter used for a community it doesn't belong to.
+    expect(bill.listBillTransactions).toHaveBeenCalledTimes(1);
+    expect(privacy.listPrivacyTransactions).toHaveBeenCalledTimes(1);
+
+    // And the money landed in the right fund on both sides.
+    const expenses = await t.run(async (ctx) =>
+      ctx.db.query("expenses").collect(),
+    );
+    const byFund = new Map(expenses.map((e) => [e.fundId, e]));
+    expect(byFund.get(billChurch.fundId)).toMatchObject({
+      amountCents: 4200,
+      description: "OFFICE SUPPLY CO",
+    });
+    expect(byFund.get(privacyChurch.fundId)).toMatchObject({
+      amountCents: 1500,
+      description: "HARDWARE STORE",
+    });
+
+    // Cursors are per connection and in each provider's own vocabulary.
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("cardProviderConnections").collect(),
+    );
+    const cursors = new Map(rows.map((r) => [r.provider, r.syncCursor]));
+    expect(cursors.get("bill")).toBe("2026-08-01T12:05:00.000Z");
+    expect(cursors.get("privacy")).toBe("2026-08-03T10:00:00.000Z");
+
+    // Sanity: the Privacy card really was created at Privacy, not at BILL.
+    const privacyCard = await t.run(async (ctx) => ctx.db.get(privacyCardId));
+    expect(privacyCard!.provider).toBe("privacy");
+  });
+
+  test("a BILL webhook cannot book against a Privacy church's card", async () => {
+    // The route looks up `(provider: "bill", providerCardId)`, so a payload
+    // naming another provider's card token resolves to nothing.
+    const t = convexTest(schema, modules);
+    const privacyChurch = await seed(t);
+    await connect(t, privacyChurch, "privacy");
+    await issueCard(t, privacyChurch);
+
+    const res = await postWebhook(t, notification({ cardUuid: "card_privacy_1" }));
+    expect(res.status).toBe(200);
+    expect(bill.getBillTransaction).not.toHaveBeenCalled();
+    expect(await countWrites(t)).toEqual({ expenses: 0, ledger: 0 });
+  });
+});

--- a/apps/convex/__tests__/finance-byoc-bill.test.ts
+++ b/apps/convex/__tests__/finance-byoc-bill.test.ts
@@ -29,6 +29,7 @@ import { modules } from "../test.setup";
 import type { Id } from "../_generated/dataModel";
 import { generateTokens } from "../lib/auth";
 import { decryptCredential } from "../lib/finance/credentialCrypto";
+import { BillApiError } from "../lib/finance/bill";
 
 process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
 /** 32 bytes, base64 — a valid AES-256 key for the envelope crypto. */
@@ -470,7 +471,9 @@ describe("issuing a BILL card", () => {
     // The legacy Increase column stays EMPTY — writing a BILL uuid into it
     // would put a foreign card on the Increase webhook's lookup index.
     expect(row!.increaseCardId).toBeUndefined();
-    expect(row!.status).toBe("ACTIVATED");
+    // The NORMALIZED state is what gets persisted, not BILL's `ACTIVATED` —
+    // `cards.status` speaks one vocabulary whatever the issuer calls it.
+    expect(row!.status).toBe("active");
     expect(row!.last4).toBe("9999");
   });
 
@@ -729,9 +732,39 @@ describe("finance-card-txn-poll on BILL", () => {
     return f;
   }
 
+  /**
+   * Connecting SEEDS the cursor at the connect moment, so a poll whose mocked
+   * feed predates that would legitimately advance nothing. Tests that assert
+   * advancement therefore rewind the cursor first, exactly as a connection a
+   * few days old would be.
+   */
+  async function rewindCursor(
+    t: ReturnType<typeof convexTest>,
+    to = "2026-07-30T00:00:00.000Z",
+  ) {
+    await t.run(async (ctx) => {
+      const row = await ctx.db.query("cardProviderConnections").first();
+      await ctx.db.patch(row!._id, { syncCursor: to });
+    });
+  }
+
+  test("connecting seeds a cursor so a failing first poll can't slide its horizon", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await connect(t, f);
+
+    const row = await t.run(async (ctx) =>
+      ctx.db.query("cardProviderConnections").first(),
+    );
+    // An ISO timestamp, which is what BILL's cursor is defined to be — the
+    // adapter's `updatedTime:gte` filter consumes it directly.
+    expect(row!.syncCursor).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
   test("records clearings and advances the updatedTime cursor", async () => {
     const t = convexTest(schema, modules);
     await connectedWithCard(t);
+    await rewindCursor(t);
     bill.listBillTransactions.mockResolvedValue({
       results: [
         CLEARED_TXN,
@@ -793,10 +826,7 @@ describe("finance-card-txn-poll on BILL", () => {
   test("a resumed poll filters from the stored cursor", async () => {
     const t = convexTest(schema, modules);
     await connectedWithCard(t);
-    await t.run(async (ctx) => {
-      const row = await ctx.db.query("cardProviderConnections").first();
-      await ctx.db.patch(row!._id, { syncCursor: "2026-07-30T00:00:00.000Z" });
-    });
+    await rewindCursor(t);
 
     await t.action(internal.functions.finance.jobs.pollCardProviderTransactions, {});
     const [, params] = bill.listBillTransactions.mock.calls[0] as any[];
@@ -821,15 +851,18 @@ describe("finance-card-txn-poll on BILL", () => {
     expect(await countWrites(t)).toEqual({ expenses: 1, ledger: 1 });
   });
 
-  test("a revoked token flips the connection to error and keeps its cursor", async () => {
+  test("a REVOKED token (401) deactivates the connection and keeps its cursor", async () => {
+    // The rejection is detected off `error.status`, so this asserts the join
+    // between BillApiError carrying the status and the poll acting on it — a
+    // client that threw a bare Error would silently stop deactivating.
     const t = convexTest(schema, modules);
     await connectedWithCard(t);
-    await t.run(async (ctx) => {
-      const row = await ctx.db.query("cardProviderConnections").first();
-      await ctx.db.patch(row!._id, { syncCursor: "2026-07-30T00:00:00.000Z" });
-    });
+    await rewindCursor(t);
     bill.listBillTransactions.mockRejectedValue(
-      new Error("BILL API GET /v3/spend/transactions failed (401): revoked"),
+      new BillApiError(
+        "BILL API GET /v3/spend/transactions failed (401): revoked",
+        401,
+      ),
     );
 
     const result = await t.action(
@@ -845,6 +878,81 @@ describe("finance-card-txn-poll on BILL", () => {
     expect(row!.lastError).toContain("401");
     // Never rewound: the next successful poll re-reads from where we stopped.
     expect(row!.syncCursor).toBe("2026-07-30T00:00:00.000Z");
+  });
+
+  test("a RATE LIMIT (429) records the error but keeps the connection live", async () => {
+    // Only a rejected credential deactivates. BILL allows 60 calls a minute
+    // per token and a busy church can brush it — flipping a working connection
+    // to "error" for that would send a finance admin to re-paste a token that
+    // was never the problem.
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    bill.listBillTransactions.mockRejectedValue(
+      new BillApiError("BILL API GET /v3/spend/transactions failed (429): slow down", 429),
+    );
+
+    await t.action(internal.functions.finance.jobs.pollCardProviderTransactions, {});
+
+    const row = await t.run(async (ctx) =>
+      ctx.db.query("cardProviderConnections").first(),
+    );
+    expect(row!.status).toBe("active");
+    expect(row!.lastError).toContain("429");
+  });
+
+  test("A TRUNCATED BACKLOG IS A VISIBLE ERROR, not a silent healthy poll", async () => {
+    // The adapter held its cursor because it couldn't read to the end of the
+    // feed. Without this the connection would look healthy forever while
+    // everything past the page budget never arrived.
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    await rewindCursor(t);
+    bill.listBillTransactions.mockResolvedValue({
+      results: [CLEARED_TXN],
+      nextPage: "always-more",
+    });
+
+    await t.action(internal.functions.finance.jobs.pollCardProviderTransactions, {});
+
+    const row = await t.run(async (ctx) =>
+      ctx.db.query("cardProviderConnections").first(),
+    );
+    expect(row!.lastError).toMatch(/backlog exceeds one poll/i);
+    // The credential is fine — the volume isn't — so the connection stays live.
+    expect(row!.status).toBe("active");
+    expect(row!.syncCursor).toBe("2026-07-30T00:00:00.000Z");
+  });
+
+  test("THE CURSOR HOLDS BELOW AN UNSETTLED AUTHORIZATION", async () => {
+    // End-to-end form of the adapter-level invariant: the authorization is not
+    // recorded, so the cursor must not step past it — otherwise a settlement
+    // that BILL fails to re-timestamp is imported by nothing at all.
+    const t = convexTest(schema, modules);
+    await connectedWithCard(t);
+    await rewindCursor(t);
+    bill.listBillTransactions.mockResolvedValue({
+      results: [
+        { ...CLEARED_TXN, uuid: "txr_settled", updatedTime: "2026-08-01T09:00:00.000+00:00" },
+        {
+          ...CLEARED_TXN,
+          uuid: "txr_pending",
+          transactionType: "AUTHORIZATION",
+          updatedTime: "2026-08-01T10:00:00.000+00:00",
+        },
+      ],
+      nextPage: null,
+    });
+
+    const result = await t.action(
+      internal.functions.finance.jobs.pollCardProviderTransactions,
+      {},
+    );
+    expect(result.recorded).toBe(1);
+
+    const row = await t.run(async (ctx) =>
+      ctx.db.query("cardProviderConnections").first(),
+    );
+    expect(row!.syncCursor).toBe("2026-08-01T09:00:00.000Z");
   });
 });
 
@@ -869,6 +977,14 @@ describe("a Privacy church and a BILL church in one fan-out", () => {
     await connect(t, privacyChurch, "privacy");
     const privacyCardId = await issueCard(t, privacyChurch);
     expect(billChurch.communityId).not.toBe(privacyChurch.communityId);
+
+    // Both connections seeded a cursor at connect; rewind both so the mocked
+    // feeds (which predate this run) are in range.
+    await t.run(async (ctx) => {
+      for (const row of await ctx.db.query("cardProviderConnections").collect()) {
+        await ctx.db.patch(row._id, { syncCursor: "2026-07-30T00:00:00.000Z" });
+      }
+    });
 
     bill.listBillTransactions.mockResolvedValue({
       results: [CLEARED_TXN],

--- a/apps/convex/__tests__/finance-community-roles.test.ts
+++ b/apps/convex/__tests__/finance-community-roles.test.ts
@@ -714,13 +714,22 @@ describe("getCardProvider", () => {
     ).resolves.toBe("none");
   });
 
-  test("a provider whose adapter isn't built yet fails loudly, not silently onto Increase", async () => {
+  /**
+   * The BILL adapter EXISTS now (ADR-033 Phase 2), so this case moved from
+   * "the code isn't there" to "the credential isn't there" — same as Privacy
+   * below, and for the same reason: the message decides whether an admin goes
+   * to paste a token or goes to ask an engineer about a deploy.
+   *
+   * What must NOT happen either way is the fall-through to Increase, which
+   * would issue a card at Togather's bank for a church that chose their own.
+   */
+  test("bill with no connection fails on the credential, not onto Increase", async () => {
     const t = convexTest(schema, modules);
     const f = await seed(t, { cardProvider: "bill" });
 
     await expect(
       t.run(async (ctx) => getCardProvider(ctx, f.communityId)),
-    ).rejects.toThrow(/isn't available yet/i);
+    ).rejects.toThrow(/BILL Spend & Expense account isn't connected/i);
   });
 
   /**

--- a/apps/convex/functions/finance/cardProviderConnections.ts
+++ b/apps/convex/functions/finance/cardProviderConnections.ts
@@ -50,11 +50,28 @@ import { createUnsavedProvider } from "../../lib/finance/cardProviders";
 /**
  * The providers a community can connect today.
  *
- * A union, not a bare string, so adding the second BYO issuer is a change
- * someone has to make deliberately in three places that must agree: here, the
- * schema, and the resolver.
+ * A union, not a bare string, so adding a BYO issuer is a change someone has to
+ * make deliberately in three places that must agree: here, the schema, and the
+ * resolver.
  */
-const byoProviderValidator = v.literal("privacy");
+const byoProviderValidator = v.union(v.literal("privacy"), v.literal("bill"));
+
+/**
+ * What to call each provider when talking to a human, and what its credential
+ * is called there.
+ *
+ * Exists because "Enter your Privacy.com API key" shown to a church connecting
+ * BILL is the kind of small wrongness that makes someone paste the wrong
+ * secret. BILL calls it an "API token" and it is self-served inside their
+ * product, which is a different thing to go looking for.
+ */
+const PROVIDER_LABELS: Record<
+  "privacy" | "bill",
+  { name: string; credential: string }
+> = {
+  privacy: { name: "Privacy.com", credential: "API key" },
+  bill: { name: "BILL Spend & Expense", credential: "API token" },
+};
 
 /**
  * Card statuses that mean "this card is DEAD and can be ignored when deciding
@@ -337,9 +354,10 @@ export const connectCardProvider = action({
       { token: args.token, communityId: args.communityId },
     );
 
+    const label = PROVIDER_LABELS[args.provider];
     const apiKey = args.apiKey.trim();
     if (!apiKey) {
-      throw new ConvexError("Enter your Privacy.com API key");
+      throw new ConvexError(`Enter your ${label.name} ${label.credential}`);
     }
 
     const provider = await createUnsavedProvider(args.provider, apiKey);
@@ -362,7 +380,7 @@ export const connectCardProvider = action({
       // in a message and the URL it builds carries no credential.
       const message = error instanceof Error ? error.message : String(error);
       throw new ConvexError(
-        `Couldn't reach ${args.provider} with that API key: ${message.slice(0, 300)}`,
+        `Couldn't reach ${label.name} with that ${label.credential}: ${message.slice(0, 300)}`,
       );
     }
 
@@ -385,9 +403,61 @@ export const connectCardProvider = action({
       },
     );
 
+    await registerProviderWebhook(provider, args.provider);
+
     return { accountLabel };
   },
 });
+
+/**
+ * Point the provider's notifications at this deployment, if it has an API for
+ * that. BEST EFFORT — a failure is a log line and nothing else.
+ *
+ * Three reasons that is the right severity, and not laziness:
+ *
+ * 1. **The poll is the backstop.** `finance-card-txn-poll` reads every BYO
+ *    connection hourly through the same recorder, so a connection with no
+ *    webhook still books every charge — later, not never.
+ * 2. **BILL's subscriptions are PRODUCTION-ONLY.** Their sandbox has a test
+ *    endpoint and no real deliveries, so in staging this call is EXPECTED to
+ *    fail. Making it fatal would make connecting a sandbox account impossible.
+ * 3. **The auth scheme is uncertain.** `/v3/subscriptions` is documented as
+ *    part of BILL's core v3 API (devKey + sessionId), and the Spend & Expense
+ *    apiToken may not satisfy it. Refusing the connection over that would block
+ *    a church whose cards would otherwise work perfectly.
+ *
+ * Runs AFTER the credential is stored, deliberately: the connection is the
+ * thing that matters and it is already durable by this point, so nothing here
+ * can lose it.
+ */
+async function registerProviderWebhook(
+  provider: { registerWebhook?: (url: string) => Promise<void> },
+  providerName: "privacy" | "bill",
+): Promise<void> {
+  if (!provider.registerWebhook) return;
+
+  // Convex sets this to the deployment's HTTP-actions origin; it is the same
+  // value http.ts's routes are served from, so deriving the URL means a
+  // staging connection never registers a production callback.
+  const siteUrl = process.env.CONVEX_SITE_URL;
+  if (!siteUrl) {
+    console.warn(
+      `[finance] CONVEX_SITE_URL is unset — not registering a ${providerName} webhook. The hourly poll still imports transactions.`,
+    );
+    return;
+  }
+
+  try {
+    await provider.registerWebhook(
+      `${siteUrl.replace(/\/$/, "")}/card-provider-webhook/${providerName}`,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `[finance] could not register the ${providerName} webhook (${message.slice(0, 300)}). Transactions will arrive on the hourly poll instead.`,
+    );
+  }
+}
 
 // ============================================================================
 // disconnectCardProvider

--- a/apps/convex/functions/finance/cardProviderConnections.ts
+++ b/apps/convex/functions/finance/cardProviderConnections.ts
@@ -621,8 +621,10 @@ async function countLiveCards(
  * AFTER a connection exists, so there is no Togather card whose spending could
  * predate this.
  *
- * FORMAT NOTE: an ISO timestamp, which is what today's one BYO adapter defines
- * its cursor to be (`syncCursor` is otherwise opaque and provider-defined). A
+ * FORMAT NOTE: an ISO timestamp, which is what BOTH of today's BYO adapters
+ * define their cursor to be (`syncCursor` is otherwise opaque and
+ * provider-defined) — Privacy's is a high-water mark over `created`, BILL's
+ * over `updatedTime`, and each feeds it straight back as a filter bound. A
  * future adapter that paginates by opaque token must seed its own — which is
  * why this is a named function rather than an inline `toISOString()`.
  */

--- a/apps/convex/functions/finance/cards.ts
+++ b/apps/convex/functions/finance/cards.ts
@@ -423,9 +423,16 @@ export const getCardForProvisioning = internalQuery({
     // Resolved here, in the query, because `provisionCard` is an ACTION and
     // has no `ctx.db` to resolve any of this with (ADR-033).
     const providerName = await resolveCardProviderName(ctx, fund.communityId);
+    // Read HERE, not in the action, for the same reason as everything else on
+    // this object: `provisionCard` has no `ctx.db`. An issuer with its own user
+    // directory (BILL matches cardholders by email) needs this, and one that
+    // treats a card as a bare instrument ignores it.
+    const holder = await ctx.db.get(card.holderUserId);
+
     return {
       card,
       fund,
+      holderEmail: holder?.email ?? null,
       onboardingStatus: finance?.onboardingStatus ?? null,
       providerName,
       /** Null when ready; otherwise the sentence explaining what's missing. */
@@ -573,8 +580,15 @@ export const provisionCard = internalAction({
       );
       return;
     }
-    const { card, fund, onboardingStatus, providerName, readiness, connection } =
-      loaded;
+    const {
+      card,
+      fund,
+      holderEmail,
+      onboardingStatus,
+      providerName,
+      readiness,
+      connection,
+    } = loaded;
 
     // Re-check every gate createFundCard checked, immediately before the
     // provider call. createFundCard's checks ran in a DIFFERENT transaction,
@@ -613,6 +627,15 @@ export const provisionCard = internalAction({
         // literal. `readiness` above already proved this is non-empty for the
         // providers that DO bind a card to an account.
         fundAccountRef: fund.increaseAccountId ?? "",
+        // The fund's name UNADORNED, alongside the composed description: an
+        // issuer that maps a fund to one of its own containers (BILL: one
+        // budget per fund, found by exact name) must not have to parse it back
+        // out of "<fund> — <card>".
+        fundName: fund.name,
+        // Null when the cardholder has no email. Only an issuer with its own
+        // user directory cares, and the one that does (BILL) turns it into a
+        // legible "invite them in BILL first" failure rather than a 400.
+        holderEmail,
         description: `${fund.name} — ${card.name ?? "Card"}`,
         idempotencyKey: `finance:card:${args.cardId}`,
         // The spend limit the finance_admin picked. Sent AT CREATION so there

--- a/apps/convex/functions/finance/jobs.ts
+++ b/apps/convex/functions/finance/jobs.ts
@@ -1726,11 +1726,23 @@ export const retryStuckReimbursements = internalAction({
  * Increase we have no `GET /events` feed to replay. So the poll is the
  * backstop that makes a missed delivery a delay instead of a hole in a
  * church's books. It is also, today, the only way a DECLINE reaches us at all
- * (`declineFeed: "poll"`).
+ * (`declineFeed: "poll"` on every BYO provider).
+ *
+ * For BILL Spend & Expense (ADR-033 Phase 2) it is more than a backstop: BILL's
+ * webhook subscriptions are PRODUCTION-ONLY, so on staging this poll is the
+ * entire settlement feed.
  *
  * Both paths book a charge through the same `recordProviderTransaction`, and
  * the settlement recorder is idempotent on the provider transaction id, so
  * "the webhook already handled this" costs one read and writes nothing.
+ *
+ * PER-PROVIDER DISPATCH IS THE ADAPTER'S JOB, not a switch here. Each
+ * connection resolves to its own community's adapter (`getCardProviderByName`
+ * in `pollOneConnection`) with its own decrypted credential and its own cursor
+ * semantics — an ISO `created` high-water mark at Privacy, an ISO `updatedTime`
+ * one at BILL. A Privacy church and a BILL church in the same fan-out never
+ * share a client, a cursor, or a credential, which is the property the
+ * cross-wiring test in finance-byoc-bill.test.ts pins.
  *
  * PER-COMMUNITY try/catch, deliberately: one church's revoked API key must not
  * stop every other church's charges from importing. A failure flips that one

--- a/apps/convex/functions/finance/webhooks.ts
+++ b/apps/convex/functions/finance/webhooks.ts
@@ -13,6 +13,12 @@
  *   anything else. Privacy signs with the COMMUNITY's API key, so that handler
  *   has to route the payload to a community first (read-only) and verify
  *   second.
+ * - `handleBillWebhookRequest` — `POST /card-provider-webhook/bill` (ADR-033
+ *   Phase 2), and a THIRD shape again: BILL publishes no webhook signature at
+ *   all, so there is nothing to verify. That handler uses the payload only to
+ *   route, then re-fetches the transaction from BILL with the community's own
+ *   token and records what the API says. Read its header before touching it —
+ *   "just book the payload" is exactly the change it exists to prevent.
  * - `handleFinanceStripeEvent` — called from the EXISTING `/stripe-webhook`
  *   route's switch (functions/ee/billing.ts's billing events already live
  *   there) for whatever billing's switch doesn't handle itself, i.e.
@@ -48,6 +54,7 @@ import {
 } from "../../lib/finance/cardProviders";
 import type { ProviderTxn } from "../../lib/finance/cardProviders";
 import { PRIVACY_HMAC_HEADER, type PrivacyTransaction } from "../../lib/finance/privacy";
+import type { BillWebhookNotification } from "../../lib/finance/bill";
 import { postLedgerEntry } from "../../lib/finance/ledger";
 import { now } from "../../lib/utils";
 import {
@@ -713,6 +720,143 @@ export async function handlePrivacyWebhookRequest(
     });
   } catch (error) {
     console.error("[PrivacyWebhook] Error processing transaction:", error);
+    return new Response("Webhook processing failed", { status: 500 });
+  }
+}
+
+// ============================================================================
+// handleBillWebhookRequest — POST /card-provider-webhook/bill
+// (http.ts mounts the path; all of the thinking is here).
+// ============================================================================
+
+/**
+ * BILL Spend & Expense transaction notification — the FETCH-TO-VERIFY handler.
+ *
+ * READ THIS BEFORE CHANGING ANYTHING HERE. Privacy's handler verifies an HMAC
+ * and then books the payload. BILL's cannot: their Spend & Expense notification
+ * documentation describes the payload in full and says nothing about a
+ * signature, header, or shared secret. There is no scheme to implement, so
+ * there is nothing to verify — which means an unauthenticated stranger can POST
+ * this endpoint any JSON they like.
+ *
+ * So the payload is treated as a HINT and never as evidence:
+ *
+ *   payload -> transaction uuid + card uuid   (routing ONLY)
+ *     -> our card -> fund -> community -> connection -> decrypted token
+ *       -> GET /v3/spend/transactions/{uuid} with THAT token
+ *         -> record whatever the API said
+ *
+ * A forged POST claiming a $9,000 clearing on someone's card therefore results
+ * in one of two things: BILL 404s (we write nothing) or BILL returns the real
+ * transaction (we write the REAL amount). The attacker controls which
+ * transaction we look at — all of which are transactions on this community's own
+ * cards, which we were going to import on the next poll anyway — and controls
+ * nothing about what we book. The worst they can do is make a settlement land
+ * an hour early.
+ *
+ * That is the whole security argument, and it is why "just trust the payload
+ * because it's over TLS" is not an acceptable simplification here.
+ *
+ * `spend.transaction.updated` fires at AUTHORIZATION and AGAIN at CLEAR, so
+ * most deliveries are the same uuid in an earlier state; `recordProviderTransaction`
+ * records only clearings and the settlement recorder is idempotent on the uuid,
+ * so the repeat costs one read and writes nothing.
+ *
+ * A card we don't know is a 200, not a 404: the church has their own cards in
+ * this BILL account and the subscription covers the whole company's feed.
+ */
+export async function handleBillWebhookRequest(
+  ctx: ActionCtx,
+  request: Request,
+): Promise<Response> {
+  const ok = (extra: Record<string, unknown> = {}) =>
+    new Response(JSON.stringify({ received: true, ...extra }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  let payload: BillWebhookNotification;
+  try {
+    payload = JSON.parse(await request.text());
+  } catch {
+    return new Response("Invalid JSON", { status: 400 });
+  }
+
+  // The ONLY two fields read from an unauthenticated body, and both are used
+  // to LOOK THINGS UP rather than to decide anything.
+  const transactionUuid = payload.transaction?.uuid;
+  const cardUuid = payload.transaction?.cardUuid;
+  if (!transactionUuid || !cardUuid) {
+    console.log(
+      "[BillWebhook] Payload has no transaction uuid / cardUuid — nothing to route on, ignoring",
+    );
+    return ok({ ignored: true });
+  }
+
+  const resolved = await ctx.runQuery(
+    internal.functions.finance.webhooks.resolveCardForProviderWebhook,
+    { provider: "bill", providerCardId: cardUuid },
+  );
+  if (!resolved) {
+    console.log(
+      `[BillWebhook] No Togather card (or no active connection) for card ${cardUuid} — ignoring`,
+    );
+    return ok({ ignored: true });
+  }
+
+  // Decrypts the community's token into the adapter. Any failure here is a
+  // deployment problem (missing master key, incomplete rotation), not a bad
+  // request — 500 so BILL retries once it's fixed.
+  let provider;
+  try {
+    provider = await getCardProviderByName("bill", resolved.connection);
+  } catch (error) {
+    console.error(
+      "[BillWebhook] Could not build the provider adapter (credential undecryptable?)",
+      error,
+    );
+    return new Response("Webhook not configured", { status: 500 });
+  }
+
+  if (!provider.fetchTransaction) {
+    // Structurally impossible while the BILL adapter is the only thing mounted
+    // here, and a hard failure rather than a fallback ON PURPOSE: the fallback
+    // would be "book the unauthenticated payload", which is the one behaviour
+    // this entire handler exists to prevent.
+    console.error(
+      "[BillWebhook] Adapter cannot re-fetch transactions — refusing to record an unverified payload",
+    );
+    return new Response("Webhook not configured", { status: 500 });
+  }
+
+  let txn: ProviderTxn | null;
+  try {
+    txn = await provider.fetchTransaction(transactionUuid);
+  } catch (error) {
+    // The fetch itself failed (rate limit, revoked token, BILL down). 500 so
+    // BILL redelivers; the hourly poll covers it either way.
+    console.error(
+      `[BillWebhook] Could not re-fetch transaction ${transactionUuid}:`,
+      error,
+    );
+    return new Response("Webhook processing failed", { status: 500 });
+  }
+
+  if (!txn) {
+    // BILL has no such transaction. Either a forged/garbage delivery or one
+    // for an object that no longer exists — both are "write nothing", and
+    // neither is worth a retry.
+    console.log(
+      `[BillWebhook] BILL has no transaction ${transactionUuid} — ignoring (payloads are hints, not evidence)`,
+    );
+    return ok({ ignored: true });
+  }
+
+  try {
+    await recordProviderTransaction(ctx, "bill", txn, "BillWebhook");
+    return ok();
+  } catch (error) {
+    console.error("[BillWebhook] Error processing transaction:", error);
     return new Response("Webhook processing failed", { status: 500 });
   }
 }

--- a/apps/convex/functions/finance/webhooks.ts
+++ b/apps/convex/functions/finance/webhooks.ts
@@ -617,6 +617,10 @@ interface PrivacyWebhookPayload {
  * be found via the payload's own card token). Quoting through `JSON.stringify`
  * escapes newlines and control characters, so a token cannot forge a second
  * log entry, and the length bound stops one request from flooding the log.
+ *
+ * The BILL route needs this MORE, not less: BILL publishes no signature at
+ * all, so every field it logs is attacker-supplied at every point in the
+ * handler, not merely before a check that eventually rejects.
  */
 function forLog(value: string): string {
   return JSON.stringify(value.length > 64 ? `${value.slice(0, 64)}…` : value);
@@ -799,7 +803,7 @@ export async function handleBillWebhookRequest(
   );
   if (!resolved) {
     console.log(
-      `[BillWebhook] No Togather card (or no active connection) for card ${cardUuid} — ignoring`,
+      `[BillWebhook] No Togather card (or no active connection) for card ${forLog(cardUuid)} — ignoring`,
     );
     return ok({ ignored: true });
   }
@@ -836,7 +840,7 @@ export async function handleBillWebhookRequest(
     // The fetch itself failed (rate limit, revoked token, BILL down). 500 so
     // BILL redelivers; the hourly poll covers it either way.
     console.error(
-      `[BillWebhook] Could not re-fetch transaction ${transactionUuid}:`,
+      `[BillWebhook] Could not re-fetch transaction ${forLog(transactionUuid)}:`,
       error,
     );
     return new Response("Webhook processing failed", { status: 500 });
@@ -847,7 +851,7 @@ export async function handleBillWebhookRequest(
     // for an object that no longer exists — both are "write nothing", and
     // neither is worth a retry.
     console.log(
-      `[BillWebhook] BILL has no transaction ${transactionUuid} — ignoring (payloads are hints, not evidence)`,
+      `[BillWebhook] BILL has no transaction ${forLog(transactionUuid)} — ignoring (payloads are hints, not evidence)`,
     );
     return ok({ ignored: true });
   }

--- a/apps/convex/http.ts
+++ b/apps/convex/http.ts
@@ -20,6 +20,7 @@ import { resolveLinkPreviewMeta } from "./functions/linkPreviewMeta";
 import { registerRoutes } from "@supa-media/dev-assistant";
 import "./functions/devAssistant/config"; // side-effect: sets config first
 import {
+  handleBillWebhookRequest,
   handleFinanceStripeEvent,
   handleIncreaseWebhookRequest,
   handlePrivacyWebhookRequest,
@@ -592,6 +593,29 @@ http.route({
   method: "POST",
   handler: httpAction(async (ctx, request) => {
     return await handlePrivacyWebhookRequest(ctx, request);
+  }),
+});
+
+/**
+ * POST /card-provider-webhook/bill
+ *
+ * Transaction receiver for communities that bring their own BILL Spend &
+ * Expense account (ADR-033 Phase 2). Unlike the Privacy route above, THIS
+ * ENDPOINT HAS NO SIGNATURE TO CHECK — BILL publishes none — so the handler
+ * treats every delivery as an unauthenticated hint and re-fetches the
+ * transaction from BILL before recording a cent. The reasoning is in
+ * `handleBillWebhookRequest`; this route is pure mounting.
+ *
+ * One URL for every community, matching the Privacy route. BILL's
+ * subscriptions ARE programmatic (`connectCardProvider` registers this URL on
+ * connect, best effort) and are production-only, so a staging deployment
+ * imports through the hourly poll alone.
+ */
+http.route({
+  path: "/card-provider-webhook/bill",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    return await handleBillWebhookRequest(ctx, request);
   }),
 });
 

--- a/apps/convex/lib/finance/bill.ts
+++ b/apps/convex/lib/finance/bill.ts
@@ -1,0 +1,663 @@
+/**
+ * Dependency-free BILL Spend & Expense API client (ADR-033 Phase 2 — the
+ * second "bring your own cards" issuer, formerly Divvy).
+ *
+ * Shaped like lib/finance/privacy.ts and lib/finance/increase.ts: plain
+ * `fetch`, no vendor SDK, because Convex actions/httpActions run in a
+ * restricted V8 isolate. And like Privacy — and unlike Increase — the
+ * credential belongs to the CHURCH, so every function takes an explicit
+ * `BillClient` rather than reading an env var. There is no ambient token to
+ * accidentally spend the wrong community's money with.
+ *
+ * FOUR THINGS ABOUT THIS VENDOR THAT DRIVE THE WHOLE FILE:
+ *
+ * 1. **Money is DOLLARS, not cents.** BILL sends `"amount": 53.03` and expects
+ *    the same on the way in. Togather is integer cents end to end, so every
+ *    boundary here converts, and `dollarsToCents` rounds rather than truncates
+ *    — `4.35 * 100` is `434.99999999999994` in IEEE754 and a truncating
+ *    conversion would quietly under-book a cent on ordinary amounts.
+ * 2. **Auth is a static `apiToken` HEADER**, self-served by an admin inside the
+ *    BILL product. Not OAuth, not Bearer, and long-lived with full-company
+ *    scope — which is why `checkConnection` is read-only and why the connect
+ *    flow's warning copy matters.
+ * 3. **Webhook deliveries carry no verifiable signature.** BILL's Spend &
+ *    Expense notification docs describe the payload and say nothing about a
+ *    signing scheme. So the payload is a HINT, never evidence — see
+ *    `getBillTransaction` and the webhook route's fetch-to-verify flow.
+ * 4. **60 calls per minute per token.** Every list here takes a page cap, and
+ *    the adapter's poll is budgeted against it.
+ *
+ * Endpoints, field names, enums and payload shapes below were confirmed
+ * against developer.bill.com on 2026-08-03 (docs/virtual-cards,
+ * docs/budgets-and-users, docs/transaction-management, reference/updatecard,
+ * reference/listbudgets, docs/spend-expense-transaction-notification-payloads).
+ * Anything NOT confirmable without a live account or sandbox is marked
+ * `UNVERIFIED:` inline, so a reviewer can find every guess by grepping one word.
+ */
+
+// ============================================================================
+// Client handle
+// ============================================================================
+
+/** Production gateway. `https://gateway.stage.bill.com/connect` is the sandbox twin. */
+const BILL_PRODUCTION_BASE_URL = "https://gateway.prod.bill.com/connect";
+
+/**
+ * The decrypted token plus the host to spend it at.
+ *
+ * `baseUrl` is resolved once, at the edge, for the same reason as Privacy's: a
+ * token is either a production token or a sandbox token, and a client that
+ * could change hosts mid-flight is a way to create a card in one environment
+ * and look for it in the other.
+ */
+export interface BillClient {
+  /** The community's own BILL Spend & Expense API token. Never logged, never returned. */
+  apiToken: string;
+  /** Defaults to production; `BILL_API_BASE_URL` overrides for dev/staging. */
+  baseUrl: string;
+}
+
+/**
+ * Build a client from a decrypted token.
+ *
+ * Host comes from `BILL_API_BASE_URL` when set (dev/staging point at
+ * `https://gateway.stage.bill.com/connect`), production otherwise — the same
+ * convention as `INCREASE_API_BASE_URL` / `PRIVACY_API_BASE_URL`, so an
+ * operator learns one rule. Deliberately NOT stored per connection: a
+ * deployment talks to one BILL environment, and a per-row host would let a
+ * staging row hold a production token.
+ */
+export function billClient(apiToken: string): BillClient {
+  return {
+    apiToken,
+    baseUrl: process.env.BILL_API_BASE_URL ?? BILL_PRODUCTION_BASE_URL,
+  };
+}
+
+// ============================================================================
+// Money
+// ============================================================================
+
+/**
+ * BILL dollars -> Togather cents.
+ *
+ * `Math.round`, not `Math.trunc` or `| 0`: `4.35 * 100 === 434.99999999999994`
+ * and `16.08 * 100 === 1607.9999999999998`. Truncating books $4.34 for a $4.35
+ * charge, and the error is invisible until a church reconciles a statement by
+ * hand.
+ */
+export function dollarsToCents(amount: number): number {
+  return Math.round(amount * 100);
+}
+
+/**
+ * Togather cents -> BILL dollars.
+ *
+ * The `Math.round(... ) / 100` shape (rather than `cents / 100`) keeps the
+ * result to two decimals for every integer input, so a limit never leaves as
+ * `500.0000000000001`.
+ */
+export function centsToDollars(cents: number): number {
+  return Math.round(cents) / 100;
+}
+
+/**
+ * The exact minor-unit amount from a transaction's `currencyData`, when it is
+ * safe to use — i.e. when the transaction really is USD at par.
+ *
+ * BILL gives BOTH a float `amount` (settled USD) and a
+ * `currencyData.originalCurrencyAmount` STRING in the original currency's
+ * minor units (`"5303"`, `exponent: 2`). For a domestic charge those describe
+ * the same money and the string is exact, so it is preferred. For a FOREIGN
+ * charge they do not: the string is euros-worth of cents and `amount` is what
+ * the church was actually billed, so the float (rounded) is the correct source
+ * and the string must be ignored.
+ *
+ * Returns `null` when the string can't be trusted, which pushes the caller onto
+ * `dollarsToCents(amount)`.
+ */
+export function exactUsdCents(
+  currencyData: BillCurrencyData | undefined | null,
+): number | null {
+  if (!currencyData) return null;
+  if (currencyData.originalCurrencyCode !== "USD") return null;
+  // An exchange rate other than 1 means the minor-unit string is not USD cents
+  // even if the code says USD; absent is treated as par, which is what a
+  // domestic payload looks like.
+  if (
+    currencyData.exchangeRate !== undefined &&
+    currencyData.exchangeRate !== null &&
+    currencyData.exchangeRate !== 1
+  ) {
+    return null;
+  }
+  if (currencyData.exponent !== undefined && currencyData.exponent !== 2) {
+    return null;
+  }
+  const raw = currencyData.originalCurrencyAmount;
+  if (typeof raw !== "string" || !/^-?\d+$/.test(raw)) return null;
+  return Number.parseInt(raw, 10);
+}
+
+// ============================================================================
+// Request plumbing
+// ============================================================================
+
+interface BillRequestOptions {
+  method: "GET" | "POST" | "PATCH" | "PUT";
+  body?: unknown;
+  /** Appended as a query string. Values are URI-encoded here, not by callers. */
+  query?: Record<string, string | number | undefined>;
+  /**
+   * Treat a 404 as "no such object" and return `null` instead of throwing.
+   * Used by the fetch-to-verify path, where "BILL doesn't have this
+   * transaction" is the ANSWER, not a failure.
+   */
+  nullOn404?: boolean;
+}
+
+/** Thrown for a non-2xx that isn't a tolerated 404. Carries the status for callers that branch on it. */
+export class BillApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "BillApiError";
+  }
+}
+
+/**
+ * One request.
+ *
+ * Auth is a bare `apiToken: <token>` header — BILL's own scheme for Spend &
+ * Expense, NOT `Authorization: Bearer` (docs/authentication-with-api-token).
+ * Getting this wrong produces a 401 that reads like a bad token, so it is
+ * worth the comment.
+ *
+ * Errors carry the status and the response body and deliberately never the
+ * token. The message reaches a finance admin through
+ * `recordCardProvisionFailed`, so it has to say what the vendor said.
+ */
+async function billRequest<T>(
+  client: BillClient,
+  path: string,
+  options: BillRequestOptions,
+): Promise<T | null> {
+  const query = options.query
+    ? Object.entries(options.query)
+        .filter(([, value]) => value !== undefined)
+        .map(
+          ([key, value]) =>
+            `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`,
+        )
+        .join("&")
+    : "";
+
+  const response = await fetch(
+    `${client.baseUrl}${path}${query ? `?${query}` : ""}`,
+    {
+      method: options.method,
+      headers: {
+        apiToken: client.apiToken,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body:
+        options.body !== undefined ? JSON.stringify(options.body) : undefined,
+    },
+  );
+
+  if (response.status === 404 && options.nullOn404) return null;
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new BillApiError(
+      `BILL API ${options.method} ${path} failed (${response.status}): ${text}`,
+      response.status,
+    );
+  }
+
+  // A 204 (or any empty body) is a success with nothing to parse — freeze and
+  // unfreeze are documented as returning the card, but an empty 200 must not
+  // become a JSON parse error on a call that actually worked.
+  const text = await response.text();
+  if (!text) return null;
+  return JSON.parse(text) as T;
+}
+
+/** `billRequest` for the calls where a null response is a bug, not an answer. */
+async function billRequestRequired<T>(
+  client: BillClient,
+  path: string,
+  options: BillRequestOptions,
+): Promise<T> {
+  const result = await billRequest<T>(client, path, options);
+  if (result === null) {
+    throw new BillApiError(
+      `BILL API ${options.method} ${path} returned an empty body where an object was expected`,
+      200,
+    );
+  }
+  return result;
+}
+
+/**
+ * BILL's list envelope. Token-based: `nextPage` is opaque and is handed back
+ * as the `nextPage` QUERY parameter on the following call.
+ */
+export interface BillPage<T> {
+  results?: T[];
+  nextPage?: string | null;
+  prevPage?: string | null;
+}
+
+/**
+ * Every BILL Spend & Expense list caps `max` at a small number and 60 calls a
+ * minute is the whole budget for a token. 50 is the documented ceiling for
+ * transactions; budgets allow 100 but there is no reason to ask for more pages
+ * than we will walk.
+ */
+export const BILL_MAX_PAGE_SIZE = 50;
+
+// ============================================================================
+// Identity — the `uuid` vs `id` trap
+// ============================================================================
+
+/**
+ * BILL objects carry BOTH `uuid` (the prefixed handle, `crd_…`/`bgt_…`/`usr_…`)
+ * and, on some responses, a numeric-ish `id`. Every WRITE path takes the uuid,
+ * including the create bodies whose fields are confusingly named `userId` and
+ * `budgetId`. Reading `id` and sending it as `budgetId` is the mistake this
+ * helper exists to make impossible to write by accident.
+ */
+export function billUuid(
+  object: { uuid?: string; id?: string } | null | undefined,
+): string | null {
+  return object?.uuid ?? object?.id ?? null;
+}
+
+// ============================================================================
+// Users — GET /v3/spend/users, GET /v3/spend/users/current
+// ============================================================================
+
+export interface BillUser {
+  uuid?: string;
+  id?: string;
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  /** `ADMIN` | `AUDITOR` | `BOOKKEEPER` | `MEMBER`. Open string — new roles must not break a read. */
+  role?: string;
+  retired?: boolean;
+}
+
+export interface BillCurrentUser extends BillUser {
+  /** UNVERIFIED: present on some responses; the connection label falls back to the email. */
+  companyName?: string;
+  company?: { name?: string; uuid?: string } | null;
+  companyUuid?: string;
+}
+
+/**
+ * The cheapest authenticated read BILL offers, and the connection probe.
+ *
+ * Read-only, so validating a token can never move money, and a revoked token
+ * fails HERE at connect time rather than later at card creation.
+ */
+export async function getBillCurrentUser(
+  client: BillClient,
+): Promise<BillCurrentUser> {
+  return await billRequestRequired<BillCurrentUser>(
+    client,
+    "/v3/spend/users/current",
+    { method: "GET" },
+  );
+}
+
+export async function listBillUsers(
+  client: BillClient,
+  params: { max?: number; nextPage?: string } = {},
+): Promise<BillPage<BillUser>> {
+  return (
+    (await billRequest<BillPage<BillUser>>(client, "/v3/spend/users", {
+      method: "GET",
+      query: { max: params.max ?? BILL_MAX_PAGE_SIZE, nextPage: params.nextPage },
+    })) ?? {}
+  );
+}
+
+// ============================================================================
+// Budgets — GET/POST /v3/spend/budgets
+// ============================================================================
+
+/** A budget's current window. `assigned` is what has been handed to cards; `spent` is what left. */
+export interface BillBudgetPeriod {
+  startDate?: string;
+  endDate?: string;
+  spent?: number;
+  assigned?: number;
+  limit?: number;
+}
+
+export interface BillBudget {
+  uuid?: string;
+  id?: string;
+  name?: string;
+  limit?: number;
+  recurringLimit?: number;
+  /** `MONTHLY` | `NONE` and friends. Open string on purpose. */
+  recurringInterval?: string;
+  retired?: boolean;
+  currentPeriod?: BillBudgetPeriod;
+}
+
+export interface BillCreateBudgetParams {
+  name: string;
+  /** User UUIDs. BILL requires at least one owner. */
+  owners: string[];
+  /** DOLLARS. */
+  limit: number;
+  /** DOLLARS — the limit each subsequent period gets. */
+  recurringLimit: number;
+  /** `MONTHLY` for a resetting budget, `NONE` for a one-off pot. */
+  recurringInterval: string;
+}
+
+export async function listBillBudgets(
+  client: BillClient,
+  params: { max?: number; nextPage?: string } = {},
+): Promise<BillPage<BillBudget>> {
+  return (
+    (await billRequest<BillPage<BillBudget>>(client, "/v3/spend/budgets", {
+      method: "GET",
+      query: { max: params.max ?? BILL_MAX_PAGE_SIZE, nextPage: params.nextPage },
+    })) ?? {}
+  );
+}
+
+export async function createBillBudget(
+  client: BillClient,
+  params: BillCreateBudgetParams,
+): Promise<BillBudget> {
+  return await billRequestRequired<BillBudget>(client, "/v3/spend/budgets", {
+    method: "POST",
+    body: params,
+  });
+}
+
+// ============================================================================
+// Cards — POST /v3/spend/cards, PATCH /v3/spend/cards/{uuid}, freeze/unfreeze
+// ============================================================================
+
+export interface BillCard {
+  uuid?: string;
+  id?: string;
+  name?: string;
+  /** `ACTIVATED` | `FROZEN` | … — BILL's own vocabulary, mapped by the adapter. */
+  status?: string;
+  lastFour?: string;
+  validThru?: string;
+  userUuid?: string;
+  budgetUuid?: string;
+  currentPeriod?: { limit?: number; spent?: number };
+}
+
+/**
+ * POST /v3/spend/cards body.
+ *
+ * NOTE the field NAMES: `userId` and `budgetId` both take UUIDs (see
+ * `billUuid`). `limit` is DOLLARS.
+ *
+ * DELIBERATELY ABSENT: anything to do with the PAN. BILL exposes card numbers
+ * through a separate two-step JWT flow (`GET /v3/spend/cards/{uuid}/pan-jwt`)
+ * which this integration does not implement and should not: Togather is not a
+ * card-display surface, cardholders read their numbers in BILL's own app, and
+ * a type with no PAN field is a type no future edit can accidentally persist
+ * one through.
+ */
+export interface BillCreateCardParams {
+  name: string;
+  /** BILL user UUID of the cardholder. Resolved from their email — see the adapter. */
+  userId: string;
+  /** BILL budget UUID this card draws from. */
+  budgetId: string;
+  /** DOLLARS. The card's own cap — Togather's enforcement lever. */
+  limit?: number;
+  /**
+   * `false` for every Togather card. `true` would let the card spend the whole
+   * budget, which throws away the only per-card control BILL gives us.
+   */
+  shareBudgetFunds?: boolean;
+}
+
+/** PATCH /v3/spend/cards/{cardId} body (reference/updatecard). All fields nullable/optional. */
+export interface BillUpdateCardParams {
+  name?: string;
+  budgetId?: string;
+  /** DOLLARS available in the CURRENT period. */
+  availableFunds?: number;
+  /** DOLLARS granted in each FUTURE period. */
+  recurringLimit?: number;
+  shareBudgetFunds?: boolean;
+  recurring?: boolean;
+}
+
+export async function createBillCard(
+  client: BillClient,
+  params: BillCreateCardParams,
+): Promise<BillCard> {
+  return await billRequestRequired<BillCard>(client, "/v3/spend/cards", {
+    method: "POST",
+    body: params,
+  });
+}
+
+export async function updateBillCard(
+  client: BillClient,
+  cardUuid: string,
+  params: BillUpdateCardParams,
+): Promise<BillCard> {
+  return await billRequestRequired<BillCard>(
+    client,
+    `/v3/spend/cards/${encodeURIComponent(cardUuid)}`,
+    { method: "PATCH", body: params },
+  );
+}
+
+/**
+ * POST /v3/spend/cards/{uuid}/freeze — "frozen cards cannot be used for
+ * payments". Reversible, which is the whole reason `cardCloseReversible` is
+ * TRUE for this provider and false for Privacy.
+ */
+export async function freezeBillCard(
+  client: BillClient,
+  cardUuid: string,
+): Promise<BillCard | null> {
+  return await billRequest<BillCard>(
+    client,
+    `/v3/spend/cards/${encodeURIComponent(cardUuid)}/freeze`,
+    { method: "POST" },
+  );
+}
+
+/** POST /v3/spend/cards/{uuid}/unfreeze — restores the pre-freeze status. */
+export async function unfreezeBillCard(
+  client: BillClient,
+  cardUuid: string,
+): Promise<BillCard | null> {
+  return await billRequest<BillCard>(
+    client,
+    `/v3/spend/cards/${encodeURIComponent(cardUuid)}/unfreeze`,
+    { method: "POST" },
+  );
+}
+
+// ============================================================================
+// Transactions — GET /v3/spend/transactions, GET /v3/spend/transactions/{uuid}
+// ============================================================================
+
+export interface BillCurrencyData {
+  exchangeRate?: number;
+  exponent?: number;
+  /** Minor units of the ORIGINAL currency, as a string. See `exactUsdCents`. */
+  originalCurrencyAmount?: string;
+  originalCurrencyCode?: string;
+  symbol?: string;
+}
+
+/**
+ * One Spend & Expense transaction.
+ *
+ * `transactionType` is the lifecycle: a purchase arrives as `AUTHORIZATION`
+ * (or `DECLINE`) and the SAME uuid is updated to `CLEAR` on settlement. A
+ * reversal is a negative amount ending at `AUTHORIZATION`; a refund is a
+ * negative amount ending at `CLEAR`. So "did money move" is
+ * `transactionType === "CLEAR"`, and sign carries direction — which is exactly
+ * the shape `ProviderTxn` already documents.
+ */
+export interface BillTransaction {
+  uuid?: string;
+  cardUuid?: string;
+  budgetUuid?: string;
+  userUuid?: string;
+  companyUuid?: string;
+  /** DOLLARS, signed. */
+  amount?: number;
+  fees?: number;
+  merchantName?: string;
+  rawMerchantName?: string;
+  merchantCategoryCode?: string;
+  /** `AUTHORIZATION` | `CLEAR` | `DECLINE` | `OTHER`. */
+  transactionType?: string;
+  occurredTime?: string;
+  updatedTime?: string;
+  authorizedTime?: string | null;
+  complete?: boolean;
+  declineReason?: string | null;
+  currencyData?: BillCurrencyData;
+}
+
+export interface BillListTransactionsParams {
+  /**
+   * BILL's filter syntax: `{field}:{operator}:{value}`, e.g.
+   * `updatedTime:gte:2026-08-01T00:00:00.000Z`. Multiple filters are repeated
+   * occurrences of the parameter; the poll needs exactly one.
+   */
+  filters?: string;
+  /** `{field}:{asc|desc}`. The poll sorts by `updatedTime` ascending so a truncated walk is resumable. */
+  sort?: string;
+  /** 1–50. */
+  max?: number;
+  /** Opaque token from the previous page's `nextPage`. */
+  nextPage?: string;
+}
+
+export async function listBillTransactions(
+  client: BillClient,
+  params: BillListTransactionsParams,
+): Promise<BillPage<BillTransaction>> {
+  return (
+    (await billRequest<BillPage<BillTransaction>>(
+      client,
+      "/v3/spend/transactions",
+      {
+        method: "GET",
+        query: {
+          filters: params.filters,
+          sort: params.sort,
+          max: params.max ?? BILL_MAX_PAGE_SIZE,
+          nextPage: params.nextPage,
+        },
+      },
+    )) ?? {}
+  );
+}
+
+/**
+ * Fetch ONE transaction by uuid. Returns `null` for a 404.
+ *
+ * THIS IS THE SECURITY BOUNDARY for the webhook route. BILL's Spend & Expense
+ * notifications carry no signature we can verify, so a delivery is only ever a
+ * hint that something happened; what gets BOOKED is whatever this call returns,
+ * fetched with the community's own stored token. A forged POST claiming a
+ * $9,000 charge results in either a 404 (nothing written) or the real
+ * transaction (the real amount written) — never the attacker's number.
+ */
+export async function getBillTransaction(
+  client: BillClient,
+  transactionUuid: string,
+): Promise<BillTransaction | null> {
+  return await billRequest<BillTransaction>(
+    client,
+    `/v3/spend/transactions/${encodeURIComponent(transactionUuid)}`,
+    { method: "GET", nullOn404: true },
+  );
+}
+
+// ============================================================================
+// Webhook subscriptions — POST /v3/subscriptions
+// ============================================================================
+
+/** The Spend & Expense transaction event. Fires at AUTHORIZATION and AGAIN at CLEAR. */
+export const BILL_TRANSACTION_UPDATED_EVENT = "spend.transaction.updated";
+
+export interface BillSubscription {
+  id?: string;
+  uuid?: string;
+  notificationUrl?: string;
+}
+
+/**
+ * Register a notification URL, best effort.
+ *
+ * PRODUCTION ONLY — BILL's sandbox exposes a test endpoint and no real
+ * subscriptions, so in staging this call is expected to fail and the poll is
+ * the entire feed.
+ *
+ * UNVERIFIED: `/v3/subscriptions` is documented as part of BILL's CORE v3 API,
+ * whose auth is `devKey` + `sessionId` rather than the Spend & Expense
+ * `apiToken` this client holds. It may therefore reject our token outright.
+ * That is survivable and deliberately not fatal: the caller logs and moves on,
+ * because the hourly poll is the source of truth in staging and the backstop in
+ * production. If it turns out a separate credential is required, THIS is the
+ * function that grows a second argument — nothing else changes.
+ */
+export async function createBillWebhookSubscription(
+  client: BillClient,
+  params: { name: string; notificationUrl: string; events?: string[] },
+): Promise<BillSubscription | null> {
+  const events = params.events ?? [BILL_TRANSACTION_UPDATED_EVENT];
+  return await billRequest<BillSubscription>(client, "/v3/subscriptions", {
+    method: "POST",
+    body: {
+      name: params.name,
+      status: { enabled: true },
+      events: events.map((type) => ({ type, version: "1" })),
+      notificationUrl: params.notificationUrl,
+    },
+  });
+}
+
+/**
+ * The shape of an inbound Spend & Expense notification, in the fields the
+ * route reads BEFORE it throws the rest away.
+ *
+ * Only `transaction.uuid` (what to fetch) and `transaction.cardUuid` (who to
+ * route to) are ever used. Every other field — amount included, especially
+ * amount — is ignored by design.
+ */
+export interface BillWebhookNotification {
+  metadata?: {
+    eventId?: string;
+    subscriptionId?: string;
+    spendCompanyUuid?: string;
+    eventType?: string;
+    version?: string;
+  };
+  transaction?: {
+    uuid?: string;
+    cardUuid?: string;
+    [key: string]: unknown;
+  };
+}

--- a/apps/convex/lib/finance/bill.ts
+++ b/apps/convex/lib/finance/bill.ts
@@ -298,11 +298,23 @@ export const BILL_MAX_PAGE_SIZE = 50;
  * including the create bodies whose fields are confusingly named `userId` and
  * `budgetId`. Reading `id` and sending it as `budgetId` is the mistake this
  * helper exists to make impossible to write by accident.
+ *
+ * WHICH IS WHY IT DOES NOT FALL BACK TO `id`. It used to, and that quietly
+ * granted exactly the thing the paragraph above forbids: a response carrying
+ * only the numeric-ish `id` would have been accepted as a user, budget or card
+ * uuid and sent straight back into a write. The card case is the worst of the
+ * three and is not even loud — a `cards.providerCardId` holding an `id` never
+ * matches the `cardUuid` on a webhook, so that card's settlements route to
+ * nothing, forever, with no error anywhere.
+ *
+ * `null` instead runs the explicit refusals the callers already have ("BILL
+ * created a card but returned no uuid — refusing to record a card Togather
+ * could never control again"), which fail where a human can see them.
  */
 export function billUuid(
   object: { uuid?: string; id?: string } | null | undefined,
 ): string | null {
-  return object?.uuid ?? object?.id ?? null;
+  return object?.uuid ?? null;
 }
 
 // ============================================================================

--- a/apps/convex/lib/finance/bill.ts
+++ b/apps/convex/lib/finance/bill.ts
@@ -156,7 +156,16 @@ interface BillRequestOptions {
   nullOn404?: boolean;
 }
 
-/** Thrown for a non-2xx that isn't a tolerated 404. Carries the status for callers that branch on it. */
+/**
+ * Thrown for a non-2xx that isn't a tolerated 404.
+ *
+ * `status` is not decoration: `pollCardProviderTransactions` reads it to decide
+ * whether a failure DEACTIVATES the connection (401/403 — the credential was
+ * refused) or merely records an error and retries next hour (429, 5xx — the
+ * credential is fine, the moment isn't). A client that threw a bare `Error`
+ * would silently stop deactivating revoked tokens, and a church would keep a
+ * dead connection showing green.
+ */
 export class BillApiError extends Error {
   constructor(
     message: string,
@@ -165,6 +174,25 @@ export class BillApiError extends Error {
     super(message);
     this.name = "BillApiError";
   }
+}
+
+/**
+ * Remove the API token from text that is about to be shown, logged, or stored.
+ *
+ * Mirrors `redactApiKey` in lib/finance/privacy.ts, and for the same reason: an
+ * error body is vendor text headed for a finance admin's screen via
+ * `recordCardProvisionFailed`, and a provider that echoes the credential it
+ * rejected would put a live spending token in a place we deliberately never
+ * write one.
+ *
+ * A plain `split`/`join` rather than a regex — the token is arbitrary text and
+ * would need escaping to be a safe pattern. Short values are ignored: nothing
+ * under 8 characters is a real BILL token, and blindly replacing a 3-character
+ * string would mangle unrelated error text.
+ */
+export function redactApiToken(text: string, apiToken: string): string {
+  if (apiToken.length < 8) return text;
+  return text.split(apiToken).join("[redacted]");
 }
 
 /**
@@ -211,7 +239,7 @@ async function billRequest<T>(
   if (response.status === 404 && options.nullOn404) return null;
 
   if (!response.ok) {
-    const text = await response.text();
+    const text = redactApiToken(await response.text(), client.apiToken);
     throw new BillApiError(
       `BILL API ${options.method} ${path} failed (${response.status}): ${text}`,
       response.status,

--- a/apps/convex/lib/finance/cardProviders/bill.ts
+++ b/apps/convex/lib/finance/cardProviders/bill.ts
@@ -23,6 +23,17 @@
  *    logged loudly (`[BillAdapter] created budget …`) precisely so the support
  *    answer is "someone renamed it, rename it back or accept the split".
  *
+ *    A SECOND, NARROWER WAY TO SPLIT THE SAME HISTORY: two cards provisioned
+ *    for the SAME fund concurrently both miss the lookup and both create a
+ *    budget, because there is no `fundId -> budgetUuid` row to take a lock on
+ *    and BILL does not reject a duplicate budget name. Every later card then
+ *    resolves to whichever one the list returns first. Same blast radius as the
+ *    rename (split history, no misdirected money) and the same loud log names
+ *    it. The real fix is the persisted mapping a later phase's schema change
+ *    brings, which closes both at once — not a retry loop here, which would
+ *    still race. The THIRD way, a lookup that gave up mid-list, is refused
+ *    outright in `findOrCreateBudget` rather than allowed to split silently.
+ *
  * 3. **Cards carry their OWN limit; `shareBudgetFunds` is always false.** The
  *    card limit is the only per-card control BILL offers, so it is Togather's
  *    enforcement lever. Sharing budget funds would let one card spend the whole
@@ -649,7 +660,7 @@ export async function findOrCreateBudget(
   limit: NormalizedLimit | null,
 ): Promise<string> {
   const wanted = billBudgetName(fundName);
-  const existing = await findBudgetByName(client, wanted);
+  const { budget: existing, exhausted } = await findBudgetByName(client, wanted);
 
   if (existing) {
     const uuid = billUuid(existing);
@@ -660,6 +671,22 @@ export async function findOrCreateBudget(
     }
     warnIfBudgetTooSmall(existing, wanted, limit);
     return uuid;
+  }
+
+  // "No match" and "stopped looking" are NOT the same answer, and treating them
+  // the same is how a history split happens for a reason nobody can diagnose.
+  // If the walk hit `BILL_BUDGET_MAX_PAGES` with more pages still to come, the
+  // fund's budget may well exist on page 11 — creating a second one here would
+  // permanently split that fund's spending across two BILL budgets, and the
+  // "someone renamed it" log below would send support down the wrong path.
+  //
+  // Refusing is the recoverable direction: no card is issued, nothing is
+  // created, and the message names the actual fix. A duplicate budget cannot be
+  // merged in BILL, so the asymmetry is not close.
+  if (!exhausted) {
+    throw new Error(
+      `Togather could not read all of your BILL budgets (stopped after ${BILL_BUDGET_MAX_PAGES * BILL_MAX_PAGE_SIZE}) and so cannot tell whether "${wanted}" already exists. Refusing to create a second budget for this fund — retire the budgets you no longer use in BILL Spend & Expense, then issue this card.`,
+    );
   }
 
   // Budgets need an owner, and the only BILL user we are certain exists is the
@@ -696,11 +723,19 @@ export async function findOrCreateBudget(
   return uuid;
 }
 
-/** Walk the budget list looking for an exact (trimmed, case-insensitive) name match. */
+/**
+ * Walk the budget list looking for an exact (trimmed, case-insensitive) name
+ * match.
+ *
+ * `exhausted` reports whether the walk actually reached the END of the list, and
+ * it is the half of the answer that matters when `budget` is null: only a
+ * complete walk licenses the caller to conclude "this fund has no budget yet".
+ * See the refusal in `findOrCreateBudget`.
+ */
 async function findBudgetByName(
   client: BillClient,
   wanted: string,
-): Promise<BillBudget | null> {
+): Promise<{ budget: BillBudget | null; exhausted: boolean }> {
   const target = wanted.trim().toLowerCase();
   let nextPage: string | undefined;
 
@@ -715,12 +750,14 @@ async function findBudgetByName(
       // create makes a live one with the same name, which is the recoverable
       // direction.
       if (budget.retired) continue;
-      if ((budget.name ?? "").trim().toLowerCase() === target) return budget;
+      if ((budget.name ?? "").trim().toLowerCase() === target) {
+        return { budget, exhausted: true };
+      }
     }
     nextPage = result.nextPage ?? undefined;
-    if (!nextPage) break;
+    if (!nextPage) return { budget: null, exhausted: true };
   }
-  return null;
+  return { budget: null, exhausted: false };
 }
 
 function warnIfBudgetTooSmall(
@@ -764,6 +801,13 @@ export async function resolveBillUserByEmail(
     );
   }
 
+  // THREE failures hide behind "we didn't return a uuid", and they have three
+  // different fixes. Telling an admin to "invite them in BILL" when the person
+  // is already there — deactivated, or simply past the page cap — gets a SECOND
+  // BILL user created for the same human, and a duplicate identity at a bank is
+  // the expensive kind of wrong. So each case is tracked and answered on its own.
+  let retiredMatch = false;
+  let exhausted = false;
   let nextPage: string | undefined;
   for (let page = 0; page < BILL_USER_MAX_PAGES; page++) {
     const result = await listBillUsers(client, {
@@ -771,15 +815,33 @@ export async function resolveBillUserByEmail(
       nextPage,
     });
     for (const user of result.results ?? []) {
-      // A retired BILL user cannot hold a card; matching one would produce a
-      // card creation that fails with a message about the wrong thing.
-      if (user.retired) continue;
       if ((user.email ?? "").trim().toLowerCase() !== wanted) continue;
+      // A retired BILL user cannot hold a card; matching one would produce a
+      // card creation that fails with a message about the wrong thing. Noted
+      // rather than ignored, so the error below can name the real fix.
+      if (user.retired) {
+        retiredMatch = true;
+        continue;
+      }
       const uuid = billUuid(user);
       if (uuid) return uuid;
     }
     nextPage = result.nextPage ?? undefined;
-    if (!nextPage) break;
+    if (!nextPage) {
+      exhausted = true;
+      break;
+    }
+  }
+
+  if (retiredMatch) {
+    throw new Error(
+      `${wanted} exists in your BILL Spend & Expense account but is DEACTIVATED, and a deactivated user cannot hold a card. Reactivate them in BILL — don't invite them again, a second BILL user for the same person is worse than no card.`,
+    );
+  }
+  if (!exhausted) {
+    throw new Error(
+      `Togather could not read all of your BILL users (stopped after ${BILL_USER_MAX_PAGES * BILL_MAX_PAGE_SIZE}) and so cannot tell whether ${wanted} is among them. Not inviting anyone on that basis — retire the BILL users you no longer need, then issue this card.`,
+    );
   }
 
   throw new Error(

--- a/apps/convex/lib/finance/cardProviders/bill.ts
+++ b/apps/convex/lib/finance/cardProviders/bill.ts
@@ -364,6 +364,8 @@ export const BILL_UNVERIFIED_BEHAVIOURS = [
   "The exact status string a freshly created card comes back with (ACTIVATED is documented; a card awaiting activation may differ).",
   "Whether GET /v3/spend/users/current returns a company name we can use as the connection label.",
   "Whether GET /v3/spend/budgets' filters support name equality, which would replace the paged client-side match in findOrCreateBudget.",
+  "Whether POST /v3/spend/cards has any recurrence field at all. It documents none, which is why a monthly card is created and then PATCHed to renew; if a create field exists, that follow-up call collapses into the create.",
+  "Whether POST /v3/spend/cards accepts an idempotency header under any name. It documents none, so a lost response leaves an orphan card (see createCard).",
 ] as const;
 
 // ============================================================================
@@ -396,7 +398,20 @@ export function createBillCardProvider(apiToken: string): CardProviderAdapter {
         input.limit,
       );
 
-      const { limit, shareBudgetFunds } = toBillCardLimit(input.limit);
+      // `input.idempotencyKey` IS DROPPED, exactly as it is in the Privacy
+      // adapter and for the same reason: BILL documents no idempotency header
+      // for POST /v3/spend/cards, so there is nowhere to put it. The residual
+      // risk is bounded and identical to Privacy's — if the POST succeeds and
+      // the response is lost, BILL holds a live card Togather records as
+      // failed: an orphan on the church's own account, visible in their
+      // dashboard under the name below. It cannot become a DOUBLE issue today,
+      // because nothing retries this call — `createFundCard` schedules
+      // `provisionCard` exactly once and a failure is recorded and stays
+      // recorded (functions/finance/cards.ts).
+      // TODO: before any retry is added there, reconcile first — list the
+      // account's cards and match on name — or a lost response becomes two
+      // spending instruments instead of one orphan.
+      const { limit, shareBudgetFunds, recurring } = toBillCardLimit(input.limit);
       const card = await createBillCard(client, {
         // The name a church admin sees in THEIR BILL dashboard. Already carries
         // the fund and the card's own name (cards.ts builds it) — they have
@@ -416,6 +431,41 @@ export function createBillCardProvider(apiToken: string): CardProviderAdapter {
           "BILL created a card but returned no uuid — refusing to record a card Togather could never control again",
         );
       }
+
+      // THE CREATE BODY HAS NO RECURRENCE FIELD, so a monthly card is not
+      // monthly yet. `POST /v3/spend/cards` takes `limit` and
+      // `shareBudgetFunds` and nothing about periods (docs/virtual-cards); only
+      // `PATCH .../{uuid}` has `recurring` / `recurringLimit`
+      // (reference/updatecard). Left alone, a "$500 a month" card would spend
+      // $500 once and then stop for good — the failure mode nobody reports as a
+      // bug because a dead card just looks declined.
+      //
+      // So the recurrence is applied as a follow-up PATCH, with exactly the
+      // body `setSpendLimit` sends, rather than by guessing a create field the
+      // vendor doesn't document. Only for a recurring limit: a `week`/`charge`
+      // card is DELIBERATELY a flat non-resetting cap (see toBillCardLimit) and
+      // already correct as created.
+      //
+      // BEST EFFORT, and a warn rather than a throw: the card exists and is
+      // spendable for this period either way, so failing the provisioning now
+      // would record "failed" over a live card and orphan it — the one outcome
+      // the idempotency note above is about. A finance admin re-saving the
+      // limit issues this same PATCH.
+      if (recurring && limit !== undefined) {
+        try {
+          await updateBillCard(client, providerCard.providerCardId, {
+            recurring: true,
+            availableFunds: limit,
+            recurringLimit: limit,
+          });
+        } catch (error) {
+          console.warn(
+            `[BillAdapter] card ${providerCard.providerCardId} was created with a $${limit} limit but could not be set to RENEW each month — it will spend $${limit} once and then stop. Re-save the card's limit in Togather to retry:`,
+            error,
+          );
+        }
+      }
+
       return providerCard;
     },
 
@@ -431,7 +481,26 @@ export function createBillCardProvider(apiToken: string): CardProviderAdapter {
      */
     async setCardState(providerCardId, state) {
       const card = await applyBillCardState(client, providerCardId, state);
-      const providerCard = toProviderCard(card ?? {}, providerCardId);
+
+      if (!card) {
+        // A 204 / empty body on freeze or unfreeze. `billRequest` treats that as
+        // the SUCCESS it is rather than a parse error — but an empty object run
+        // through `toProviderCard` has no status, and an unknown status is
+        // `failed`. That would persist `cards.status = "failed"` for a pause
+        // BILL actually applied, and the card would read as broken in Togather
+        // while working perfectly at the bank.
+        //
+        // The request succeeded, so the card is in the state we asked for; say
+        // that. `providerStatus` stays empty on purpose — BILL told us no word,
+        // and inventing one would put a string in the "the vendor's own word,
+        // unedited" field that the vendor never said.
+        // `CardStateRequest` is a subset of `CardState`, so the requested state
+        // IS the resulting state — including `closed`, which needs no override
+        // here because nothing came back to be overridden.
+        return { providerCardId, state, providerStatus: "" };
+      }
+
+      const providerCard = toProviderCard(card, providerCardId);
 
       if (state !== "closed") return providerCard;
 

--- a/apps/convex/lib/finance/cardProviders/bill.ts
+++ b/apps/convex/lib/finance/cardProviders/bill.ts
@@ -335,6 +335,18 @@ export const BILL_CAPABILITIES: ProviderCapabilities = {
   // TRUE, and the word is doing work: there IS no close at BILL. "Closed" is
   // freeze + rename, and a freeze is reversible — so the honest answer is true
   // and the UI must not promise an irreversible destruction it cannot perform.
+  //
+  // TODO: THE UI DOES NOT HONOUR THIS YET, and it is a promise to a user rather
+  // than a detail. `capabilities` is server-side only — no client query exposes
+  // it — so `CardDetailView`'s cancel confirmation still says "This permanently
+  // disables … This can't be undone" for every provider, and a cancelled card
+  // offers no way back. For BILL both halves are false: an admin can unfreeze
+  // the card in BILL while Togather goes on showing it cancelled. Not yet
+  // reachable by anyone (no community is on BILL until one connects it), which
+  // is why it is a TODO and not a blocker — but it must land with, or before,
+  // the first church on this provider. The fix is a slice, not a copy edit:
+  // surface `cardCloseReversible` on the card query, then make the confirmation
+  // copy and the un-cancel affordance conditional on it.
   cardCloseReversible: true,
   cardFreezeReversible: true,
   // Subscriptions are PRODUCTION-ONLY (sandbox offers a test endpoint and no

--- a/apps/convex/lib/finance/cardProviders/bill.ts
+++ b/apps/convex/lib/finance/cardProviders/bill.ts
@@ -1,0 +1,782 @@
+/**
+ * The BILL Spend & Expense card-provider adapter (ADR-033 Phase 2) — the
+ * second BRING-YOUR-OWN issuer, and the first one whose model does not line up
+ * with ours field for field.
+ *
+ * Privacy.com was a flat account: create a card, give it a limit, done. BILL
+ * has a middle layer — a BUDGET — that every card must live inside, and that
+ * layer is where the mapping decisions are. All five are here, at the top,
+ * because each one is a trade a reviewer should be able to disagree with:
+ *
+ * 1. **ONE BUDGET PER FUND**, named `"<fund> · Togather"`. A fund is the unit
+ *    of money in Togather and a budget is the unit of money in BILL, so this is
+ *    the only mapping where a church's BILL dashboard tells the same story as
+ *    their Togather one.
+ *
+ * 2. **The budget is found BY NAME, and created if missing.** There is nowhere
+ *    to persist a `fundId -> budgetUuid` map without a schema change, and
+ *    ADR-033's phase discipline says no schema change here. The cost is a real
+ *    hazard, stated plainly: IF A CHURCH RENAMES THE BUDGET IN BILL, the lookup
+ *    misses and we create a second one. Nothing breaks and no money moves
+ *    wrongly — new cards simply land in a fresh budget while old cards keep
+ *    spending from the old one, splitting that fund's history in BILL. It is
+ *    logged loudly (`[BillAdapter] created budget …`) precisely so the support
+ *    answer is "someone renamed it, rename it back or accept the split".
+ *
+ * 3. **Cards carry their OWN limit; `shareBudgetFunds` is always false.** The
+ *    card limit is the only per-card control BILL offers, so it is Togather's
+ *    enforcement lever. Sharing budget funds would let one card spend the whole
+ *    fund, which is precisely the control the finance admin thought they set.
+ *
+ * 4. **"Closed" is a freeze plus a rename.** BILL has NO close/terminate
+ *    endpoint (docs/virtual-cards documents freeze and unfreeze and nothing
+ *    else). So `closed` means: freeze the card, and rename it with a
+ *    `" · closed"` suffix so the church's own BILL dashboard says what
+ *    happened. `cardCloseReversible` is TRUE and honest about it — this is a
+ *    strong freeze, not a destruction, and the UI copy must not promise
+ *    otherwise.
+ *
+ * 5. **Cardholders are matched to BILL users BY EMAIL, never created.**
+ *    Creating a BILL user takes personal details (and, for some roles, a date
+ *    of birth) that Togather has no business collecting on someone's behalf.
+ *    No match is a legible error telling the finance admin to invite that
+ *    person in BILL first.
+ *
+ * TWO MORE FACTS THAT SHAPE EVERYTHING BELOW:
+ *
+ * - **BILL cards are a CHARGE CARD against the org's shared credit line.**
+ *   There is no per-fund pot of money at the bank, so `hardFundIsolation` is
+ *   false — the same posture as Privacy, for a different reason. Repayment and
+ *   bank accounts are not in the API at all (`repaymentVisibility:
+ *   "in_product"`).
+ * - **Webhooks carry no verifiable signature.** `verifyWebhook` is therefore
+ *   NOT implemented; `fetchTransaction` is, and the route uses it to re-read
+ *   every notification from the API before booking a cent. See
+ *   lib/finance/bill.ts's `getBillTransaction`.
+ *
+ * Every API fact was confirmed against developer.bill.com on 2026-08-03. What
+ * a live sandbox or the founder's church token would still settle is listed on
+ * `BILL_UNVERIFIED_BEHAVIOURS` at the bottom of this file.
+ */
+
+import {
+  BILL_MAX_PAGE_SIZE,
+  billClient,
+  billUuid,
+  centsToDollars,
+  createBillBudget,
+  createBillCard,
+  createBillWebhookSubscription,
+  dollarsToCents,
+  exactUsdCents,
+  freezeBillCard,
+  getBillCurrentUser,
+  getBillTransaction,
+  listBillBudgets,
+  listBillTransactions,
+  listBillUsers,
+  unfreezeBillCard,
+  updateBillCard,
+  type BillBudget,
+  type BillCard,
+  type BillClient,
+  type BillTransaction,
+} from "../bill";
+import type {
+  CardProviderAdapter,
+  CardState,
+  CardStateRequest,
+  NormalizedLimit,
+  ProviderCapabilities,
+  ProviderCard,
+  ProviderTxn,
+  ProviderTxnPage,
+} from "./types";
+
+// ============================================================================
+// Budgets
+// ============================================================================
+
+/** The suffix that marks a budget as ours inside the church's own BILL account. */
+export const BILL_BUDGET_SUFFIX = " · Togather";
+
+/**
+ * The budget name for a fund. This string IS the mapping key (decision 2
+ * above), so it is a function rather than an inline template — one definition,
+ * used by both the lookup and the create.
+ */
+export function billBudgetName(fundName: string): string {
+  return `${fundName.trim()}${BILL_BUDGET_SUFFIX}`;
+}
+
+/** The rename suffix that stands in for a close (decision 4 above). */
+export const BILL_CLOSED_SUFFIX = " · closed";
+
+/**
+ * Pages of budgets walked when looking one up. 10 x 50 = 500 budgets, which is
+ * far past any church's fund count and well inside the 60-calls-per-minute
+ * token budget.
+ */
+const BILL_BUDGET_MAX_PAGES = 10;
+
+/** Same reasoning, for the user directory. */
+const BILL_USER_MAX_PAGES = 20;
+
+// ============================================================================
+// Limits
+// ============================================================================
+
+/**
+ * Our normalized limit -> BILL's card fields.
+ *
+ * BILL card limits are a plain AMOUNT plus an optional recurrence; there is no
+ * per-week and no per-transaction window (the budget owns the period, and it
+ * is per-budget, not per-card). So:
+ *
+ * - `month`  -> a recurring limit, which is the one period that maps cleanly
+ *               onto the MONTHLY budget interval we create budgets with.
+ * - `week`   -> the same NUMBER as a NON-recurring cap. Stricter than asked,
+ *               never looser: the card stops at a week's worth of spend and
+ *               stays stopped until someone tops it up, rather than silently
+ *               being handed four weeks of runway. `weeklyLimits: false` is
+ *               what the UI reads to disclose this.
+ * - `charge` -> likewise. BILL cannot cap a single authorization, so a
+ *               "$200 per charge" card becomes a $200 card. Same direction of
+ *               error, same disclosure.
+ *
+ * `null` (no limit) becomes `shareBudgetFunds: true` — the card draws the whole
+ * budget, which is BILL's only expression of "uncapped". Stated EXPLICITLY
+ * rather than by omission, because omitting fields on a PATCH leaves whatever
+ * the card already had.
+ */
+export function toBillCardLimit(limit: NormalizedLimit | null): {
+  limit?: number;
+  shareBudgetFunds: boolean;
+  recurring: boolean;
+} {
+  if (!limit) {
+    return { shareBudgetFunds: true, recurring: false };
+  }
+  return {
+    limit: centsToDollars(limit.limitCents),
+    shareBudgetFunds: false,
+    recurring: limit.period === "month",
+  };
+}
+
+/** True when the requested period cannot be expressed natively — the caller may want to disclose it. */
+export function isDegradedBillLimitPeriod(
+  period: NormalizedLimit["period"],
+): boolean {
+  return period !== "month";
+}
+
+// ============================================================================
+// States
+// ============================================================================
+
+/**
+ * BILL's card `status` -> our vocabulary.
+ *
+ * An UNRECOGNIZED status maps to `failed`, matching both other adapters and for
+ * the same reason: guessing "active" is the dangerous direction.
+ */
+export function billStatusToCardState(status: string): CardState {
+  switch (status.toUpperCase()) {
+    case "ACTIVATED":
+    case "ACTIVE":
+      return "active";
+    case "FROZEN":
+      return "paused";
+    case "TERMINATED":
+    case "CLOSED":
+    case "CANCELED":
+    case "CANCELLED":
+      return "closed";
+    case "PENDING":
+    case "REQUESTED":
+      return "pending";
+    default:
+      return "failed";
+  }
+}
+
+function toProviderCard(card: BillCard, fallbackId?: string): ProviderCard {
+  const id = billUuid(card) ?? fallbackId ?? "";
+  const status = card.status ?? "";
+  return {
+    providerCardId: id,
+    // BILL spells it `lastFour`, not `last_four` — reading the wrong one gets
+    // `undefined` and a card that renders as "Groceries •••• ".
+    last4: card.lastFour,
+    state: billStatusToCardState(status),
+    providerStatus: status,
+  };
+}
+
+// ============================================================================
+// Transactions
+// ============================================================================
+
+/**
+ * BILL transaction -> our `ProviderTxn`.
+ *
+ * **Only `CLEAR` is settled.** BILL updates the SAME uuid from `AUTHORIZATION`
+ * to `CLEAR` on settlement, so an authorization is genuinely the same object
+ * in an earlier state — recording it would double-book the moment it clears.
+ * `DECLINE` is `declined`; anything else (`OTHER`, or a type BILL adds later)
+ * is `pending`, because booking money on a status we don't understand is the
+ * one failure with no cheap recovery.
+ *
+ * **Sign is carried, not stripped.** A reversal or refund arrives as a negative
+ * amount, which is exactly `ProviderTxn`'s stated convention ("positive cents
+ * SPENT, a refund/credit is negative"). Phase 1's recorder deliberately skips
+ * negatives — reversing an expense is real work owned by the expense module —
+ * so normalizing it correctly now means that day this function doesn't move.
+ *
+ * **Amount comes from the exact minor-unit string when it can.** See
+ * `exactUsdCents`: BILL's float dollars are lossy at the cent, and a foreign
+ * charge's minor-unit string is not USD. This picks whichever is right.
+ */
+export function normalizeBillTransaction(txn: BillTransaction): ProviderTxn {
+  const exact = exactUsdCents(txn.currencyData);
+  const amountCents = exact ?? dollarsToCents(txn.amount ?? 0);
+
+  // `occurredTime` is when the swipe happened, which is the date a church
+  // recognizes on a receipt. `updatedTime` is our cursor field, not our date.
+  const occurredAtMs = Date.parse(txn.occurredTime ?? txn.updatedTime ?? "");
+
+  return {
+    providerTxnId: txn.uuid ?? "",
+    providerCardId: txn.cardUuid ?? "",
+    amountCents,
+    // `merchantName` is BILL's cleaned-up name ("Amazon"); `rawMerchantName`
+    // is the network descriptor ("AMZN Mktp US"). Prefer the readable one and
+    // fall back, because a blank description on an expense is useless.
+    merchantName: txn.merchantName ?? txn.rawMerchantName ?? null,
+    // A decline reason is the one piece of free text worth carrying: it is what
+    // makes a declined-card notification actionable in Phase 3.
+    description: txn.declineReason ?? null,
+    occurredAtMs: Number.isNaN(occurredAtMs) ? Date.now() : occurredAtMs,
+    state: billTxnState(txn.transactionType ?? ""),
+  };
+}
+
+function billTxnState(transactionType: string): ProviderTxn["state"] {
+  switch (transactionType.toUpperCase()) {
+    case "CLEAR":
+      return "settled";
+    case "DECLINE":
+      return "declined";
+    case "AUTHORIZATION":
+      return "pending";
+    default:
+      return "pending";
+  }
+}
+
+/**
+ * How far back a FIRST poll looks when the connection has no cursor yet.
+ *
+ * Seven days, matching the Privacy adapter and for the same reason: a freshly
+ * connected BILL account may hold years of the church's own pre-Togather
+ * spending, none of which belongs to a card this app issued.
+ */
+export const BILL_INITIAL_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Pages walked per poll. 20 x 50 = 1,000 transactions an hour.
+ *
+ * The cap is a RATE-LIMIT budget as much as a work budget: BILL allows 60 calls
+ * per minute per token, and this poll must leave room for the card operations a
+ * finance admin is doing at the same time.
+ */
+const BILL_TXN_MAX_PAGES = 20;
+
+// ============================================================================
+// Capabilities
+// ============================================================================
+
+/**
+ * BILL Spend & Expense's capability profile. Every value is a claim about the
+ * vendor, checked against their docs (2026-08-03), not assumed.
+ */
+export const BILL_CAPABILITIES: ProviderCapabilities = {
+  // Cards are a charge card against the ORGANIZATION's shared credit line.
+  // A budget is a spending policy, not a segregated pot — so the bank cannot
+  // enforce a fund boundary and the ledger has to.
+  hardFundIsolation: false,
+  // Card limits are a plain amount; only the BUDGET has a period, and it is
+  // per-budget rather than per-card. See toBillCardLimit.
+  weeklyLimits: false,
+  // TRUE, and the word is doing work: there IS no close at BILL. "Closed" is
+  // freeze + rename, and a freeze is reversible — so the honest answer is true
+  // and the UI must not promise an irreversible destruction it cannot perform.
+  cardCloseReversible: true,
+  cardFreezeReversible: true,
+  // Subscriptions are PRODUCTION-ONLY (sandbox offers a test endpoint and no
+  // real deliveries), so a staging deployment is poll-only. "partial" is also
+  // the truthful answer for production: the transaction event pushes, card
+  // status changes do not.
+  webhooks: "partial",
+  // A DECLINE is a transaction row like any other; nothing distinct pushes for
+  // it, and the poll is where we see them.
+  declineFeed: "poll",
+  // No documented per-month card cap.
+  maxCardsPerMonth: null,
+  // A charge card billed on a cycle. Repayment, bank accounts and the credit
+  // line are IN-PRODUCT ONLY — not in the API, so Togather can neither show nor
+  // reconcile them.
+  repaymentVisibility: "in_product",
+};
+
+/**
+ * What a live BILL sandbox (or the founder's church token) would settle that
+ * reading the docs cannot. Kept as data, next to the code it qualifies, so it
+ * survives being copied into a PR description.
+ */
+export const BILL_UNVERIFIED_BEHAVIOURS = [
+  "Whether POST /v3/subscriptions accepts the Spend & Expense apiToken, or requires the core API's devKey + sessionId (registration is best-effort for exactly this reason).",
+  "Whether PATCH /v3/spend/cards/{uuid} accepts availableFunds on a card created with an explicit limit, or only on shareBudgetFunds cards.",
+  "The exact status string a freshly created card comes back with (ACTIVATED is documented; a card awaiting activation may differ).",
+  "Whether GET /v3/spend/users/current returns a company name we can use as the connection label.",
+  "Whether GET /v3/spend/budgets' filters support name equality, which would replace the paged client-side match in findOrCreateBudget.",
+] as const;
+
+// ============================================================================
+// The adapter
+// ============================================================================
+
+/**
+ * Build an adapter bound to ONE community's BILL Spend & Expense token.
+ *
+ * A factory, not a singleton: the credential is the church's, decrypted per
+ * call by the resolver (lib/finance/cardProviders/index.ts) and held only for
+ * the life of this object. Nothing here writes it anywhere, and nothing here
+ * puts it in an error message.
+ */
+export function createBillCardProvider(apiToken: string): CardProviderAdapter {
+  const client = billClient(apiToken);
+
+  return {
+    name: "bill",
+    capabilities: BILL_CAPABILITIES,
+
+    async createCard(input) {
+      // Order matters: resolve the HUMAN first. A missing BILL user is the one
+      // failure a finance admin can act on, and finding it out before we have
+      // created a budget means a failed attempt leaves nothing behind.
+      const userUuid = await resolveBillUserByEmail(client, input.holderEmail);
+      const budgetUuid = await findOrCreateBudget(
+        client,
+        input.fundName,
+        input.limit,
+      );
+
+      const { limit, shareBudgetFunds } = toBillCardLimit(input.limit);
+      const card = await createBillCard(client, {
+        // The name a church admin sees in THEIR BILL dashboard. Already carries
+        // the fund and the card's own name (cards.ts builds it) — they have
+        // their own cards in this account and must tell ours apart at a glance.
+        name: input.description,
+        userId: userUuid,
+        budgetId: budgetUuid,
+        ...(limit !== undefined ? { limit } : {}),
+        shareBudgetFunds,
+      });
+
+      const providerCard = toProviderCard(card);
+      if (!providerCard.providerCardId) {
+        // Without an id we cannot ever freeze, re-limit, or reconcile this
+        // card, and a card row pointing at nothing is worse than a failure.
+        throw new Error(
+          "BILL created a card but returned no uuid — refusing to record a card Togather could never control again",
+        );
+      }
+      return providerCard;
+    },
+
+    /**
+     * Move a card to `state`.
+     *
+     * `closed` is the interesting one, and it is decision 4 in this file's
+     * header: BILL has no close endpoint, so a close is a freeze plus a rename
+     * that says so in the church's own dashboard. The rename is best-effort —
+     * a card that is frozen but not renamed is cosmetically wrong, and failing
+     * the whole close over cosmetics would leave a card LIVE that a finance
+     * admin believes they just killed.
+     */
+    async setCardState(providerCardId, state) {
+      const card = await applyBillCardState(client, providerCardId, state);
+      const providerCard = toProviderCard(card ?? {}, providerCardId);
+
+      if (state !== "closed") return providerCard;
+
+      // THE ONE PLACE THIS ADAPTER DOES NOT PASS BILL'S STRING THROUGH
+      // VERBATIM, and it is load-bearing rather than tidy.
+      //
+      // A closed BILL card and a paused one are both `FROZEN` at the vendor —
+      // BILL has no word for what we just did. But `cards.status` stores this
+      // string, and real readers branch on it: `countLiveProviderCards`
+      // (functions/finance/cardProviderConnections.ts) refuses to disconnect a
+      // provider while cards are alive, and it decides "alive" from exactly
+      // this value. Passing `FROZEN` through would mean a church that closed
+      // every card could never disconnect BILL without `force`.
+      //
+      // So a close reports `CLOSED`: already in that module's dead set, already
+      // the vocabulary Privacy uses, and TRUE about what Togather did. What it
+      // must not be read as is a claim that the card is destroyed at the bank —
+      // `capabilities.cardCloseReversible: true` is the field that says
+      // otherwise, and the UI copy hangs off that, not off this string.
+      return { ...providerCard, state: "closed", providerStatus: "CLOSED" };
+    },
+
+    /**
+     * Replace the card's spend limit.
+     *
+     * `availableFunds` is the CURRENT period's cap and `recurringLimit` is what
+     * each future period gets; both are sent so a limit change is not silently
+     * a one-period change. `null` means "no limit", which at BILL is
+     * `shareBudgetFunds: true` — the card draws the budget. Sent explicitly,
+     * because omission on a PATCH means "leave it alone".
+     */
+    async setSpendLimit(providerCardId, limit) {
+      const { limit: dollars, shareBudgetFunds, recurring } =
+        toBillCardLimit(limit);
+      const card = await updateBillCard(client, providerCardId, {
+        shareBudgetFunds,
+        recurring,
+        ...(dollars !== undefined
+          ? { availableFunds: dollars, recurringLimit: dollars }
+          : {}),
+      });
+      return toProviderCard(card, providerCardId);
+    },
+
+    /**
+     * Pull transactions since `cursor`.
+     *
+     * THE CURSOR IS AN ISO `updatedTime`, not a page token. BILL's `nextPage`
+     * tokens are valid within one walk and meaningless between polls, so each
+     * run filters `updatedTime:gte:<cursor>`, sorts ASCENDING, and returns the
+     * newest `updatedTime` it saw.
+     *
+     * `gte` is inclusive, so the boundary transaction is re-fetched every run.
+     * Intended: `recordCardSettlement` is idempotent on the transaction uuid,
+     * and one duplicate read beats a one-millisecond gap that drops a charge.
+     *
+     * `updatedTime` rather than `occurredTime` is what makes this a settlement
+     * feed at all — a purchase that authorized last week and CLEARS today is
+     * updated today, and an occurredTime cursor would have walked past it.
+     *
+     * IF THE BACKLOG EXCEEDS `BILL_TXN_MAX_PAGES`, the cursor does NOT advance.
+     * The next poll re-reads the same window rather than skipping ahead — a
+     * stall an operator notices, instead of a hole in a church's books that
+     * nobody does. Everything fetched is still returned and recorded.
+     */
+    async listTransactions(cursor: string | null): Promise<ProviderTxnPage> {
+      const since =
+        cursor ?? new Date(Date.now() - BILL_INITIAL_LOOKBACK_MS).toISOString();
+
+      const collected: BillTransaction[] = [];
+      let nextPage: string | undefined;
+      let exhausted = false;
+
+      for (let page = 0; page < BILL_TXN_MAX_PAGES; page++) {
+        const result = await listBillTransactions(client, {
+          filters: `updatedTime:gte:${since}`,
+          sort: "updatedTime:asc",
+          max: BILL_MAX_PAGE_SIZE,
+          nextPage,
+        });
+        collected.push(...(result.results ?? []));
+        nextPage = result.nextPage ?? undefined;
+        if (!nextPage) {
+          exhausted = true;
+          break;
+        }
+      }
+
+      const transactions = collected
+        .map(normalizeBillTransaction)
+        // A transaction with no uuid or no card cannot be recorded or routed;
+        // dropping it here keeps the recorder from logging a mystery.
+        .filter((txn) => txn.providerTxnId !== "" && txn.providerCardId !== "");
+
+      // Only advance past what we know we've seen ALL of.
+      let nextCursor = cursor;
+      if (exhausted) {
+        for (const txn of collected) {
+          const parsed = Date.parse(txn.updatedTime ?? "");
+          if (Number.isNaN(parsed)) continue;
+          if (nextCursor === null || parsed > Date.parse(nextCursor)) {
+            nextCursor = new Date(parsed).toISOString();
+          }
+        }
+      }
+
+      return { transactions, nextCursor };
+    },
+
+    /**
+     * Re-read one transaction from BILL. The fetch half of fetch-to-verify.
+     *
+     * Returns `null` for a transaction BILL doesn't have, which is what a
+     * forged or stale notification looks like — and the route writes nothing.
+     */
+    async fetchTransaction(providerTxnId: string): Promise<ProviderTxn | null> {
+      const txn = await getBillTransaction(client, providerTxnId);
+      if (!txn) return null;
+      const normalized = normalizeBillTransaction(txn);
+      // BILL echoing back a transaction with no uuid would make the settlement
+      // recorder's idempotency key empty, which is how one charge becomes many.
+      if (!normalized.providerTxnId) return null;
+      return normalized;
+    },
+
+    /**
+     * Validate the credential and name the account.
+     *
+     * `GET /v3/spend/users/current` is the probe: authenticated, read-only and
+     * cheap, so checking a token can never move money. The label is the
+     * company name when BILL gives one, the authenticated user's email
+     * otherwise — the point is that a finance admin can tell WHICH BILL account
+     * they just connected.
+     */
+    async checkConnection() {
+      const user = await getBillCurrentUser(client);
+      const label =
+        user.companyName?.trim() ||
+        user.company?.name?.trim() ||
+        user.email?.trim() ||
+        null;
+      return { accountLabel: label ?? null };
+    },
+
+    /**
+     * Register this deployment's webhook URL, best effort.
+     *
+     * Deliberately swallows nothing — it throws, and the CALLER decides that a
+     * failure is a log rather than an error (see connectCardProvider). The
+     * adapter's job is to say what happened; the connect flow's job is to know
+     * that the poll makes this optional.
+     */
+    async registerWebhook(notificationUrl: string) {
+      await createBillWebhookSubscription(client, {
+        name: "Togather card transactions",
+        notificationUrl,
+      });
+    },
+
+    // NO `verifyWebhook`. BILL's Spend & Expense notifications carry no
+    // documented signature, and an adapter that returned `true` here would be
+    // claiming a guarantee that does not exist — the most expensive kind of
+    // lie a security boundary can tell. The route uses `fetchTransaction`
+    // instead: the payload routes, the API decides.
+  };
+}
+
+// ============================================================================
+// Budget resolution
+// ============================================================================
+
+/**
+ * The fund's budget, found by name or created.
+ *
+ * This is decision 2 from the file header made literal, and the rename hazard
+ * lives here. The lookup walks the budget list and matches the EXACT name
+ * (trimmed, case-insensitive — a church that fixes the capitalization of a
+ * fund name should not get a second budget for it). A miss creates the budget
+ * and logs loudly.
+ *
+ * The new budget's limit is seeded from the card being created, because that is
+ * the only number available at this point, and its interval is MONTHLY so the
+ * budget refreshes rather than draining to a permanent stop. When the budget
+ * ALREADY exists and its period limit is below what this card is asking for, we
+ * warn rather than fail: the church owns that number in BILL, the card is still
+ * created, and if the budget really is the binding constraint the decline feed
+ * will say so with BILL's own reason attached.
+ */
+export async function findOrCreateBudget(
+  client: BillClient,
+  fundName: string,
+  limit: NormalizedLimit | null,
+): Promise<string> {
+  const wanted = billBudgetName(fundName);
+  const existing = await findBudgetByName(client, wanted);
+
+  if (existing) {
+    const uuid = billUuid(existing);
+    if (!uuid) {
+      throw new Error(
+        `BILL returned a budget named "${wanted}" with no uuid — cannot attach a card to it`,
+      );
+    }
+    warnIfBudgetTooSmall(existing, wanted, limit);
+    return uuid;
+  }
+
+  // Budgets need an owner, and the only BILL user we are certain exists is the
+  // one whose token we are holding — the admin who connected the account.
+  const currentUser = await getBillCurrentUser(client);
+  const ownerUuid = billUuid(currentUser);
+  if (!ownerUuid) {
+    throw new Error(
+      "BILL did not identify the authenticated user, so there is no one to own a new budget — reconnect the BILL account in Community Settings → Finance",
+    );
+  }
+
+  const seedDollars = limit ? centsToDollars(limit.limitCents) : 0;
+  const budget = await createBillBudget(client, {
+    name: wanted,
+    owners: [ownerUuid],
+    limit: seedDollars,
+    recurringLimit: seedDollars,
+    recurringInterval: "MONTHLY",
+  });
+  const uuid = billUuid(budget);
+  if (!uuid) {
+    throw new Error(
+      `BILL created the budget "${wanted}" but returned no uuid — refusing to issue a card into a budget we cannot reference`,
+    );
+  }
+
+  // LOUD on purpose. On the first card for a fund this line is routine; seeing
+  // it a second time for the same fund name is the rename hazard happening, and
+  // this log is the only place that shows up.
+  console.log(
+    `[BillAdapter] created budget "${wanted}" (${uuid}). If this fund already had a Togather budget in BILL, it was renamed there and its history is now split — rename it back to "${wanted}" to re-link.`,
+  );
+  return uuid;
+}
+
+/** Walk the budget list looking for an exact (trimmed, case-insensitive) name match. */
+async function findBudgetByName(
+  client: BillClient,
+  wanted: string,
+): Promise<BillBudget | null> {
+  const target = wanted.trim().toLowerCase();
+  let nextPage: string | undefined;
+
+  for (let page = 0; page < BILL_BUDGET_MAX_PAGES; page++) {
+    const result = await listBillBudgets(client, {
+      max: BILL_MAX_PAGE_SIZE,
+      nextPage,
+    });
+    for (const budget of result.results ?? []) {
+      // A retired budget cannot take new cards, and matching one would send
+      // every future card into a dead container. Skipping it means the next
+      // create makes a live one with the same name, which is the recoverable
+      // direction.
+      if (budget.retired) continue;
+      if ((budget.name ?? "").trim().toLowerCase() === target) return budget;
+    }
+    nextPage = result.nextPage ?? undefined;
+    if (!nextPage) break;
+  }
+  return null;
+}
+
+function warnIfBudgetTooSmall(
+  budget: BillBudget,
+  name: string,
+  limit: NormalizedLimit | null,
+): void {
+  if (!limit) return;
+  const budgetDollars = budget.currentPeriod?.limit ?? budget.limit;
+  if (typeof budgetDollars !== "number") return;
+  const cardDollars = centsToDollars(limit.limitCents);
+  if (budgetDollars >= cardDollars) return;
+  console.warn(
+    `[BillAdapter] budget "${name}" allows $${budgetDollars} this period but the new card asks for $${cardDollars}. The card is being created anyway — BILL will decline past the BUDGET's limit, so raise it in BILL if these cards should all be able to spend.`,
+  );
+}
+
+// ============================================================================
+// User resolution
+// ============================================================================
+
+/**
+ * The cardholder's BILL user uuid, matched by email.
+ *
+ * Decision 5 from the file header: we match, we never create. `POST
+ * /v3/spend/users` exists, but creating a person at a bank on their behalf —
+ * with the personal details BILL wants — is not a thing Togather should do
+ * silently from a card-issuing flow.
+ *
+ * The no-match error is written for the finance admin who will read it in the
+ * card row's failure message, and names the exact next action.
+ */
+export async function resolveBillUserByEmail(
+  client: BillClient,
+  email: string | null,
+): Promise<string> {
+  const wanted = email?.trim().toLowerCase();
+  if (!wanted) {
+    throw new Error(
+      "This cardholder has no email address on their Togather profile, and BILL identifies cardholders by email. Add their email in Togather, then issue the card.",
+    );
+  }
+
+  let nextPage: string | undefined;
+  for (let page = 0; page < BILL_USER_MAX_PAGES; page++) {
+    const result = await listBillUsers(client, {
+      max: BILL_MAX_PAGE_SIZE,
+      nextPage,
+    });
+    for (const user of result.results ?? []) {
+      // A retired BILL user cannot hold a card; matching one would produce a
+      // card creation that fails with a message about the wrong thing.
+      if (user.retired) continue;
+      if ((user.email ?? "").trim().toLowerCase() !== wanted) continue;
+      const uuid = billUuid(user);
+      if (uuid) return uuid;
+    }
+    nextPage = result.nextPage ?? undefined;
+    if (!nextPage) break;
+  }
+
+  throw new Error(
+    `No BILL user has the email ${wanted}. BILL issues cards to people who already exist in your BILL account, and Togather won't create one on their behalf — invite them in BILL Spend & Expense first, then issue this card.`,
+  );
+}
+
+// ============================================================================
+// Card state
+// ============================================================================
+
+/**
+ * Freeze / unfreeze / pseudo-close, split out of the adapter so the "closed is
+ * a freeze plus a rename" decision reads as one thing.
+ */
+async function applyBillCardState(
+  client: BillClient,
+  cardUuid: string,
+  state: CardStateRequest,
+): Promise<BillCard | null> {
+  if (state === "active") {
+    return await unfreezeBillCard(client, cardUuid);
+  }
+
+  const frozen = await freezeBillCard(client, cardUuid);
+  if (state === "paused") return frozen;
+
+  // state === "closed": the card is already frozen and can no longer spend,
+  // which is the part that matters. The rename is the part that tells the
+  // church's own dashboard why — best-effort, because a cosmetic failure must
+  // never leave a "closed" card looking merely paused to us while it is
+  // actually stopped at the bank.
+  const currentName = frozen?.name ?? "";
+  if (currentName.endsWith(BILL_CLOSED_SUFFIX)) return frozen;
+  try {
+    return await updateBillCard(client, cardUuid, {
+      name: `${currentName}${BILL_CLOSED_SUFFIX}`.slice(0, 200),
+    });
+  } catch (error) {
+    console.warn(
+      `[BillAdapter] froze card ${cardUuid} but could not rename it to mark it closed:`,
+      error,
+    );
+    return frozen;
+  }
+}

--- a/apps/convex/lib/finance/cardProviders/bill.ts
+++ b/apps/convex/lib/finance/cardProviders/bill.ts
@@ -148,6 +148,18 @@ const BILL_USER_MAX_PAGES = 20;
  * budget, which is BILL's only expression of "uncapped". Stated EXPLICITLY
  * rather than by omission, because omitting fields on a PATCH leaves whatever
  * the card already had.
+ *
+ * UNREACHABLE FROM THE APP, exactly as Privacy's equivalent branch is: BILL has
+ * no hard fund isolation, so `requiresSpendLimit("bill")` is true and
+ * `createFundCard` / `setCardLimit` refuse to make an uncapped card. This
+ * branch is the adapter honouring its own contract ("no limit must be stated
+ * explicitly"), not a path anything takes.
+ *
+ * Likewise `week`: `supportsWeeklyLimits("bill")` is false, so the gate refuses
+ * a weekly limit before it reaches here rather than letting a card say
+ * "/ week" while capping a flat amount. The mapping below stays because the
+ * adapter must still answer honestly if it is ever handed one — the refusal
+ * lives at the gate, not in two divergent copies.
  */
 export function toBillCardLimit(limit: NormalizedLimit | null): {
   limit?: number;
@@ -412,23 +424,26 @@ export function createBillCardProvider(apiToken: string): CardProviderAdapter {
 
       if (state !== "closed") return providerCard;
 
-      // THE ONE PLACE THIS ADAPTER DOES NOT PASS BILL'S STRING THROUGH
-      // VERBATIM, and it is load-bearing rather than tidy.
+      // OVERRIDE THE NORMALIZED STATE, AND ONLY THAT. It is load-bearing
+      // rather than tidy.
       //
       // A closed BILL card and a paused one are both `FROZEN` at the vendor —
-      // BILL has no word for what we just did. But `cards.status` stores this
-      // string, and real readers branch on it: `countLiveProviderCards`
-      // (functions/finance/cardProviderConnections.ts) refuses to disconnect a
-      // provider while cards are alive, and it decides "alive" from exactly
-      // this value. Passing `FROZEN` through would mean a church that closed
+      // BILL has no word for what we just did, so `billStatusToCardState`
+      // reads the response as `paused`. But `state` is what
+      // `cardStateToStoredStatus` turns into `cards.status` at the write, and
+      // `countLiveProviderCards` decides whether a card is still spending from
+      // exactly that. Leaving it `paused` would store "disabled" — a live card
+      // as far as the disconnect guard is concerned — and a church that closed
       // every card could never disconnect BILL without `force`.
       //
-      // So a close reports `CLOSED`: already in that module's dead set, already
-      // the vocabulary Privacy uses, and TRUE about what Togather did. What it
-      // must not be read as is a claim that the card is destroyed at the bank —
-      // `capabilities.cardCloseReversible: true` is the field that says
-      // otherwise, and the UI copy hangs off that, not off this string.
-      return { ...providerCard, state: "closed", providerStatus: "CLOSED" };
+      // `providerStatus` is deliberately NOT touched: it stays BILL's own
+      // `FROZEN`, verbatim, because that is literally what the card is at the
+      // bank and the field's whole contract is to carry the vendor's word
+      // unedited. The two together say the true thing — Togather considers
+      // this card closed, BILL has it frozen — and
+      // `capabilities.cardCloseReversible: true` is what stops the UI from
+      // promising a destruction that never happened.
+      return { ...providerCard, state: "closed" };
     },
 
     /**
@@ -469,10 +484,26 @@ export function createBillCardProvider(apiToken: string): CardProviderAdapter {
      * feed at all — a purchase that authorized last week and CLEARS today is
      * updated today, and an occurredTime cursor would have walked past it.
      *
-     * IF THE BACKLOG EXCEEDS `BILL_TXN_MAX_PAGES`, the cursor does NOT advance.
-     * The next poll re-reads the same window rather than skipping ahead — a
-     * stall an operator notices, instead of a hole in a church's books that
-     * nobody does. Everything fetched is still returned and recorded.
+     * IF THE BACKLOG EXCEEDS `BILL_TXN_MAX_PAGES`, the cursor does NOT advance
+     * and the page comes back `truncated: true`. The next poll re-reads the
+     * same window rather than skipping ahead, and `pollOneConnection` records
+     * the stall as a visible error — an operator notices, instead of a hole in
+     * a church's books that nobody does. Everything fetched is still recorded.
+     *
+     * THE CURSOR ALSO STOPS BELOW THE OLDEST STILL-CHANGEABLE TRANSACTION, the
+     * same invariant the Privacy adapter holds. The reasoning transfers even
+     * though the mechanism differs: an `AUTHORIZATION` is one we deliberately
+     * did not record, and BILL turns it into a `CLEAR` by UPDATING THE SAME
+     * uuid. In principle that bumps `updatedTime` and a plain high-water mark
+     * would still catch it — but "BILL always bumps `updatedTime` on
+     * settlement" is precisely the sort of vendor claim this integration lists
+     * as unverified, and if it is ever false the settled charge is imported by
+     * nothing at all. Holding below the oldest pending row costs one re-read
+     * per poll and removes the assumption entirely.
+     *
+     * Held on `updatedTime`, NOT `occurredTime`: the cursor is a high-water
+     * mark over `updatedTime`, and holding one field back while advancing on
+     * another would leave exactly the gap this is meant to close.
      */
     async listTransactions(cursor: string | null): Promise<ProviderTxnPage> {
       const since =
@@ -503,19 +534,34 @@ export function createBillCardProvider(apiToken: string): CardProviderAdapter {
         // dropping it here keeps the recorder from logging a mystery.
         .filter((txn) => txn.providerTxnId !== "" && txn.providerCardId !== "");
 
-      // Only advance past what we know we've seen ALL of.
+      // The oldest `updatedTime` that can still change state. Terminal rows
+      // (settled, declined) are safe to pass: settled is already recorded, and
+      // a later refund on it is work the recorder skips either way.
+      let holdBackFrom: number | null = null;
+      for (const row of collected) {
+        if (billTxnState(row.transactionType ?? "") !== "pending") continue;
+        const parsed = Date.parse(row.updatedTime ?? "");
+        if (Number.isNaN(parsed)) continue;
+        if (holdBackFrom === null || parsed < holdBackFrom) {
+          holdBackFrom = parsed;
+        }
+      }
+
+      // Only advance past what we know we've seen ALL of, and never past
+      // something still in flight.
       let nextCursor = cursor;
       if (exhausted) {
-        for (const txn of collected) {
-          const parsed = Date.parse(txn.updatedTime ?? "");
+        for (const row of collected) {
+          const parsed = Date.parse(row.updatedTime ?? "");
           if (Number.isNaN(parsed)) continue;
+          if (holdBackFrom !== null && parsed >= holdBackFrom) continue;
           if (nextCursor === null || parsed > Date.parse(nextCursor)) {
             nextCursor = new Date(parsed).toISOString();
           }
         }
       }
 
-      return { transactions, nextCursor };
+      return { transactions, nextCursor, truncated: !exhausted };
     },
 
     /**

--- a/apps/convex/lib/finance/cardProviders/index.ts
+++ b/apps/convex/lib/finance/cardProviders/index.ts
@@ -193,14 +193,24 @@ export async function getCardProviderByName(
         }),
       );
     }
-    case "bill":
-      // A later phase lands this adapter. Until then a community cannot be put
-      // on it, so reaching this is a hand-edited row — say so plainly rather
-      // than falling back to Increase, which would issue a card at the wrong
-      // bank.
-      throw new ConvexError(
-        `The "${name}" card provider isn't available yet — this community's card provider setting is ahead of the code`,
+    case "bill": {
+      if (!connection) {
+        // Same real state as Privacy's: they disconnected, or the token stopped
+        // working and the connection went to "error". Say which thing to do,
+        // since the person reading this is the finance admin who has to do it.
+        throw new ConvexError(
+          "This community's BILL Spend & Expense account isn't connected — reconnect it in Community Settings → Finance before issuing or changing cards",
+        );
+      }
+      const { createBillCardProvider } = await import("./bill");
+      return createBillCardProvider(
+        await decryptCredential(connection.credential, {
+          communityId: connection.communityId,
+          provider: connection.provider,
+          purpose: "apiKey",
+        }),
       );
+    }
     case "none":
       throw new ConvexError(
         "No card provider is configured for this community — finish finance setup before issuing cards",
@@ -226,9 +236,8 @@ export async function createUnsavedProvider(
     const { createPrivacyCardProvider } = await import("./privacy");
     return createPrivacyCardProvider(apiKey);
   }
-  throw new ConvexError(
-    `The "${name}" card provider isn't available yet — nothing can be connected to it`,
-  );
+  const { createBillCardProvider } = await import("./bill");
+  return createBillCardProvider(apiKey);
 }
 
 /**

--- a/apps/convex/lib/finance/cardProviders/index.ts
+++ b/apps/convex/lib/finance/cardProviders/index.ts
@@ -255,9 +255,15 @@ export async function createUnsavedProvider(
  * still says "/ week" with a Monday reset, so the cardholder learns the truth
  * by being declined for three weeks. An honest refusal at the gate beats a
  * safe number under a false label.
+ *
+ * BILL is the same answer for a slightly different shape (ADR-033 Phase 2): a
+ * BILL card limit is a plain AMOUNT with an optional recurrence, and the only
+ * period in the model belongs to the BUDGET, not the card. So "$100/week"
+ * degrades to a $100 cap that does not reset weekly — same false label, same
+ * three weeks of unexplained declines, same refusal.
  */
 export function supportsWeeklyLimits(name: CardProviderName): boolean {
-  return name !== "privacy";
+  return name !== "privacy" && name !== "bill";
 }
 
 /**
@@ -272,14 +278,22 @@ export function supportsWeeklyLimits(name: CardProviderName): boolean {
  * promises the opposite, and no pooled-balance authorization control exists
  * yet (ADR-033 Phase 2).
  *
+ * BILL is the same answer and, if anything, a starker version of it (ADR-033
+ * Phase 2). Its cards are a CHARGE CARD against the organization's shared
+ * credit line — there is no per-fund pot at the bank at all, and a budget is a
+ * spending policy rather than segregated money. An uncapped BILL card
+ * (`shareBudgetFunds: true`) draws the whole budget, and the budget is
+ * whatever the church set it to. So the card limit is again the only boundary
+ * Togather controls, and it must exist.
+ *
  * So the limit stops being a preference and becomes the only boundary there
  * is. Same shape as `supportsWeeklyLimits` and for the same reason: keyed on
  * the NAME, because the mutations that gate a limit have no credential to
- * build an adapter from. MUST agree with `capabilities.hardFundIsolation`; a
- * test pins that the two cannot drift.
+ * build an adapter from. MUST agree with `capabilities.hardFundIsolation` FOR
+ * EVERY PROVIDER; a test pins that the two cannot drift.
  */
 export function requiresSpendLimit(name: CardProviderName): boolean {
-  return name === "privacy";
+  return name === "privacy" || name === "bill";
 }
 
 /** Does this provider bring its own, community-held credential? */

--- a/apps/convex/lib/finance/cardProviders/types.ts
+++ b/apps/convex/lib/finance/cardProviders/types.ts
@@ -121,11 +121,16 @@ export interface ProviderCapabilities {
 
   /**
    * How the provider's balance is funded and repaid.
-   * - `"n/a"`       — the card spends a real deposit balance we already hold (Increase).
-   * - `"prefund"`   — we push money to the provider before it can be spent.
-   * - `"statement"` — a charge card billed on a cycle; repayment is out-of-band.
+   * - `"n/a"`        — the card spends a real deposit balance we already hold (Increase).
+   * - `"prefund"`    — we push money to the provider before it can be spent.
+   * - `"statement"`  — a charge card billed on a cycle; repayment is out-of-band.
+   * - `"in_product"` — a charge card whose credit line, repayment and bank
+   *   accounts are not in the API AT ALL (BILL Spend & Expense). Distinct from
+   *   `"statement"` on purpose: with a statement we could at least fetch the
+   *   cycle, whereas here Togather can neither show a balance nor reconcile a
+   *   repayment, and any UI that implies otherwise is lying.
    */
-  repaymentVisibility: "n/a" | "prefund" | "statement";
+  repaymentVisibility: "n/a" | "prefund" | "statement" | "in_product";
 }
 
 // ============================================================================
@@ -233,6 +238,25 @@ export interface CardProviderAdapter {
    */
   createCard(input: {
     fundAccountRef: string;
+    /**
+     * The FUND's own name, unadorned.
+     *
+     * Distinct from `description` (which is "<fund> — <card>") because some
+     * issuers need the fund as an IDENTITY, not as display text: the BILL
+     * adapter maps one fund to one BILL budget and finds that budget by exact
+     * name, so parsing it back out of a composed string would make a fund
+     * called "Youth — Camp" resolve to the wrong container.
+     */
+    fundName: string;
+    /**
+     * The cardholder's email, or `null` if their Togather profile has none.
+     *
+     * Present because an issuer may have its OWN user directory that a card
+     * must be attached to — BILL issues cards to people who already exist in
+     * the church's BILL account, matched by email. Providers that treat a card
+     * as a bare instrument (Increase, Privacy) ignore it.
+     */
+    holderEmail: string | null;
     description: string;
     idempotencyKey: string;
     limit: NormalizedLimit | null;
@@ -264,6 +288,40 @@ export interface CardProviderAdapter {
    * as `nextCursor` is what gets stored and handed back next time.
    */
   listTransactions?(cursor: string | null): Promise<ProviderTxnPage>;
+
+  /**
+   * Re-read ONE transaction from the provider, by its provider id.
+   *
+   * Exists for a specific and unpleasant class of issuer: one whose webhook
+   * deliveries carry no signature we can verify. BILL Spend & Expense is the
+   * first — its notification docs describe the payload and say nothing about a
+   * signing scheme — so a delivery can only be treated as a HINT that
+   * something happened, never as evidence of WHAT happened.
+   *
+   * The webhook route therefore uses the payload to route (which community,
+   * which transaction id) and then calls this to fetch the transaction with the
+   * community's own stored credential, booking only what the API returns. A
+   * forged POST claiming a $9,000 charge yields either `null` (nothing written)
+   * or the real transaction (the real amount written) — never the attacker's
+   * number. See functions/finance/webhooks.ts's `handleBillWebhookRequest`.
+   *
+   * `null` means "the provider has no such transaction", which is an ANSWER —
+   * the caller writes nothing and returns 200. A network/auth failure throws.
+   */
+  fetchTransaction?(providerTxnId: string): Promise<ProviderTxn | null>;
+
+  /**
+   * Ask the provider to POST future events to `notificationUrl`.
+   *
+   * Present only on issuers with a programmatic webhook API. Privacy's endpoint
+   * is typed into their dashboard by a human, so its adapter has nothing to
+   * implement; BILL's is an API call, so its adapter does.
+   *
+   * Throws on failure. The CALLER decides how much that matters — for a
+   * provider whose transactions are also polled, a failed registration is a log
+   * line, not a failed connection (see `connectCardProvider`).
+   */
+  registerWebhook?(notificationUrl: string): Promise<void>;
 
   /**
    * Prove the stored credential still works, and say whose account it is.


### PR DESCRIPTION
## Summary

Phase 2 of ADR-033 — the adapter the pilot church (the founder's) will actually use. Rebased over #752's nine review rounds with each moved invariant re-derived for BILL's own semantics:

- **Adapter** (`lib/finance/cardProviders/bill.ts` + dependency-free client): one BILL **budget per fund** (found by exact-name match, created if missing; rename hazard logged loudly with the rename-back instruction), cards issued inside the fund's budget with explicit limits (`shareBudgetFunds` false — the card limit is the enforcement lever). Holder mapped to a BILL user **by email**; no match → legible "invite them in BILL first" (never auto-creates users). **Amounts are dollars at BILL** — every boundary converts with explicit rounding (`4.35×100 === 434.999…`).
- **Fetch-to-verify webhooks**: BILL's signatures are under-documented, so payloads are routing hints only — the transaction is re-fetched with the church's own token before anything is recorded; a lying payload is corrected by construction; 404 → no write; unknown card short-circuits before the fetch (can't burn a church's 60/min rate budget). Webhook subscription registered programmatically on connect, best-effort (prod-only per BILL; polling is the staging source of truth and the prod backstop).
- **Pseudo-close** (BILL has no close endpoint): freeze + rename; `cards.status` reads closed (so disconnect isn't blocked forever) while `providerStatus` stays BILL's verbatim FROZEN — both true things said separately.
- **Invariant alignment with #752's review**: uncapped and weekly limits refused (from BILL's starker premise — a charge card draws the shared credit line); poll cursor holds below non-terminal transactions and reports truncation; only 401/403 deactivates a connection (429 pinned as must-NOT); attacker-controlled log fields wrapped; API token redacted from error text that reaches admins.

## Evidence
```
BILL tests: 102 (63 adapter + 29 e2e + cursor-holdback/truncation/redaction/gate-drift)
Full finance suite: 682 passed / 20 files · full convex tsc: 0 errors
```

### Unverified without live access (carried as code-adjacent data, BILL_UNVERIFIED_BEHAVIOURS)
Sandbox would settle: PATCH card limit field semantics, fresh-card status string, budget name filters. Only the pilot church's prod token settles: whether POST /v3/subscriptions accepts the S&E apiToken, and users/current's company label.

### Deploy note
Function logic only; no schema changes. Merge deploys staging.

Phase 3 (UI, community-administers gates, managed lifetime limits on privacy, receipt forwarding) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcamCRXMUU1DhocRpr59YD