### PR TITLE
feat(finance-ui): the Community Finance home — overview, per-group enablement, modal fix

### DIFF
--- a/apps/convex/__tests__/finance-card-failure.test.ts
+++ b/apps/convex/__tests__/finance-card-failure.test.ts
@@ -1,0 +1,297 @@
+/**
+ * `getCardDetail.failureMessage` — reading back why a card was never issued.
+ *
+ * A refused provisioning stores the provider's own sentence in a
+ * `financeAuditEvents` row (`recordCardProvisionFailed`) or ours
+ * (`recordCardProvisionRefused`), patches the card to `failed`, and nothing
+ * ever read it. On staging that meant Privacy's "Insufficient privileges to
+ * create UNLOCKED cards" — an account-plan problem the admin could have fixed
+ * in a minute — surfaced as "Something went wrong. Contact support."
+ *
+ * The reason is community-finance information: it names the issuer, which
+ * group-level card surfaces are anonymous about on purpose (ADR-033 §1), and
+ * describes a fix only a financial-controls holder can carry out. So these
+ * tests pin BOTH directions — the holder gets it, the group leader doesn't.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/finance-card-failure.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../schema";
+import { api } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+import { generateTokens } from "../lib/auth";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+const PRIVACY_REFUSAL =
+  "Insufficient privileges to create UNLOCKED cards — this Privacy account may not have general-purpose cards enabled; check the plan.";
+
+interface Fixture {
+  communityId: Id<"communities">;
+  fundId: Id<"funds">;
+  cardId: Id<"cards">;
+  primaryAdminUserId: Id<"users">; // holds financial controls implicitly
+  leaderUserId: Id<"users">; // group leader, no financial controls
+}
+
+async function seed(t: ReturnType<typeof convexTest>): Promise<Fixture> {
+  return await t.run(async (ctx) => {
+    await ctx.db.insert("featureFlags", {
+      key: "group-giving",
+      enabled: true,
+      updatedAt: Date.now(),
+    });
+    const timestamp = Date.now();
+    const suffix = Math.floor(Math.random() * 1_000_000);
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Test Church",
+      slug: `test-church-${suffix}`,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    const mkUser = async (name: string) =>
+      ctx.db.insert("users", {
+        firstName: name,
+        lastName: "User",
+        phone: `+1555000${Math.floor(Math.random() * 9000 + 1000)}`,
+        isActive: true,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+    const primaryAdminUserId = await mkUser("Primary");
+    const leaderUserId = await mkUser("Leader");
+
+    await ctx.db.insert("userCommunities", {
+      userId: primaryAdminUserId,
+      communityId,
+      roles: 4, // PRIMARY_ADMIN — implicit financial controls
+      status: 1,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    await ctx.db.insert("userCommunities", {
+      userId: leaderUserId,
+      communityId,
+      roles: 1, // MEMBER
+      status: 1,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Group",
+      slug: `small-group-${suffix}`,
+      isActive: true,
+      createdAt: timestamp,
+      displayOrder: 1,
+    });
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Worship Team",
+      isArchived: false,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    await ctx.db.insert("groupMembers", {
+      groupId,
+      userId: leaderUserId,
+      role: "leader",
+      joinedAt: timestamp,
+      notificationsEnabled: true,
+    });
+
+    await ctx.db.insert("communityFinance", {
+      communityId,
+      stripeConnectedAccountId: "acct_test",
+      cardProvider: "privacy",
+      onboardingStatus: "live",
+      legalName: "Test Church",
+      ein: "12-3456789",
+      address: {
+        addressLine1: "1 Main St",
+        city: "Austin",
+        state: "TX",
+        zipCode: "78701",
+      },
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    const fundId = await ctx.db.insert("funds", {
+      communityId,
+      groupId,
+      name: "Worship Team Fund",
+      type: "group",
+      status: "active",
+      balanceCents: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    // The card the provider refused: `failed`, and with no last4 — it never
+    // existed at the issuer, so there are no digits to show.
+    const cardId = await ctx.db.insert("cards", {
+      fundId,
+      holderUserId: leaderUserId,
+      name: "Groceries",
+      provider: "privacy",
+      status: "failed",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    return { communityId, fundId, cardId, primaryAdminUserId, leaderUserId };
+  });
+}
+
+async function tokenFor(userId: Id<"users">): Promise<string> {
+  const { accessToken } = await generateTokens(userId);
+  return accessToken;
+}
+
+async function logFailure(
+  t: ReturnType<typeof convexTest>,
+  f: Fixture,
+  opts: { action: string; details: Record<string, unknown>; createdAt?: number },
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("financeAuditEvents", {
+      communityId: f.communityId,
+      fundId: f.fundId,
+      action: opts.action,
+      detailsJson: JSON.stringify(opts.details),
+      createdAt: opts.createdAt ?? Date.now(),
+    });
+  });
+}
+
+function detail(
+  t: ReturnType<typeof convexTest>,
+  f: Fixture,
+  userId: Id<"users">,
+) {
+  return tokenFor(userId).then((token) =>
+    t.query(api.functions.finance.cards.getCardDetail, {
+      token,
+      cardId: f.cardId,
+    }),
+  );
+}
+
+describe("getCardDetail — a card that failed to issue", () => {
+  test("hands the provider's reason to a financial-controls holder", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await logFailure(t, f, {
+      action: "card.provision_failed",
+      details: { cardId: f.cardId, message: PRIVACY_REFUSAL },
+    });
+
+    const result = await detail(t, f, f.primaryAdminUserId);
+
+    expect(result.status).toBe("failed");
+    expect(result.last4).toBeNull();
+    expect(result.failureMessage).toBe(PRIVACY_REFUSAL);
+  });
+
+  test("withholds it from a group leader, who can neither verify nor fix it", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await logFailure(t, f, {
+      action: "card.provision_failed",
+      details: { cardId: f.cardId, message: PRIVACY_REFUSAL },
+    });
+
+    const result = await detail(t, f, f.leaderUserId);
+
+    // The leader still sees the card — just not the vendor's account detail.
+    expect(result.status).toBe("failed");
+    expect(result.failureMessage).toBeNull();
+  });
+
+  test("reads our own preflight refusal too, which uses a different key", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await logFailure(t, f, {
+      action: "card.provision_refused",
+      details: { cardId: f.cardId, reason: 'fund status is "frozen"' },
+    });
+
+    const result = await detail(t, f, f.primaryAdminUserId);
+    expect(result.failureMessage).toBe('fund status is "frozen"');
+  });
+
+  test("takes the most recent attempt, not the first", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    const nowMs = Date.now();
+    await logFailure(t, f, {
+      action: "card.provision_failed",
+      details: { cardId: f.cardId, message: "an older, already-fixed problem" },
+      createdAt: nowMs - 60_000,
+    });
+    await logFailure(t, f, {
+      action: "card.provision_failed",
+      details: { cardId: f.cardId, message: PRIVACY_REFUSAL },
+      createdAt: nowMs,
+    });
+
+    const result = await detail(t, f, f.primaryAdminUserId);
+    expect(result.failureMessage).toBe(PRIVACY_REFUSAL);
+  });
+
+  test("ignores another card's failure on the same fund", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await logFailure(t, f, {
+      action: "card.provision_failed",
+      details: { cardId: "some-other-card", message: "not this card's problem" },
+    });
+
+    const result = await detail(t, f, f.primaryAdminUserId);
+    expect(result.failureMessage).toBeNull();
+  });
+
+  test("falls back to null when nothing was recorded", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+
+    const result = await detail(t, f, f.primaryAdminUserId);
+    expect(result.failureMessage).toBeNull();
+  });
+
+  test("a healthy card never carries one, holder or not", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await logFailure(t, f, {
+      action: "card.provision_failed",
+      details: { cardId: f.cardId, message: PRIVACY_REFUSAL },
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(f.cardId, { status: "active", last4: "4921" });
+    });
+
+    const result = await detail(t, f, f.primaryAdminUserId);
+    expect(result.failureMessage).toBeNull();
+    expect(result.last4).toBe("4921");
+  });
+
+  test("truncates a runaway provider message", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await logFailure(t, f, {
+      action: "card.provision_failed",
+      details: { cardId: f.cardId, message: "x".repeat(500) },
+    });
+
+    const result = await detail(t, f, f.primaryAdminUserId);
+    expect(result.failureMessage).toHaveLength(300);
+  });
+});

--- a/apps/convex/__tests__/finance-community-overview.test.ts
+++ b/apps/convex/__tests__/finance-community-overview.test.ts
@@ -1,0 +1,547 @@
+/**
+ * `giving.getCommunityFinanceOverview` — the community Finance home's one
+ * round trip (ADR-032/033).
+ *
+ * The screen is a list of rows whose SUBTITLES are these numbers, so what
+ * matters here is the arithmetic and the window: a donation from last month
+ * must not appear in "this month", a card that was canceled must not be
+ * counted as a card the fund has, and fees/refunds must not be read as spend
+ * (they aren't spend, and `getFundOverview` already says so per-fund — the two
+ * screens have to agree).
+ *
+ * Plus the gate: ADR-033 moved community-level finance off "plain community
+ * admin", so a plain admin must be REFUSED here and a granted one must pass.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/finance-community-overview.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../schema";
+import { api } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+import { generateTokens } from "../lib/auth";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+const ADDRESS = {
+  addressLine1: "1 Main St",
+  city: "Austin",
+  state: "TX",
+  zipCode: "78701",
+};
+
+interface Fixture {
+  communityId: Id<"communities">;
+  primaryAdminUserId: Id<"users">; // roles === 4 — implicit finance access
+  plainAdminUserId: Id<"users">; // roles === 3, no grant — must be denied
+  grantedAdminUserId: Id<"users">; // roles === 3 + a communityFinanceRoles row
+  fundedGroupId: Id<"groups">;
+  unfundedGroupId: Id<"groups">;
+  archivedGroupId: Id<"groups">;
+  fundId: Id<"funds">;
+  generalFundId: Id<"funds">;
+}
+
+function startOfMonthUTC(ms: number): number {
+  const d = new Date(ms);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1);
+}
+
+async function seed(
+  t: ReturnType<typeof convexTest>,
+  opts: { onboardingStatus?: string; groupGiving?: boolean } = {},
+): Promise<Fixture> {
+  return await t.run(async (ctx) => {
+    await ctx.db.insert("featureFlags", {
+      key: "group-giving",
+      enabled: opts.groupGiving ?? true,
+      updatedAt: Date.now(),
+    });
+    const timestamp = Date.now();
+    const suffix = Math.floor(Math.random() * 1_000_000);
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Test Church",
+      slug: `test-church-${suffix}`,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    const mkUser = async (name: string) =>
+      ctx.db.insert("users", {
+        firstName: name,
+        lastName: "User",
+        phone: `+1555000${Math.floor(Math.random() * 9000 + 1000)}`,
+        isActive: true,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+
+    const primaryAdminUserId = await mkUser("Primary");
+    const plainAdminUserId = await mkUser("PlainAdmin");
+    const grantedAdminUserId = await mkUser("GrantedAdmin");
+
+    const membership = async (userId: Id<"users">, roles: number) =>
+      ctx.db.insert("userCommunities", {
+        userId,
+        communityId,
+        roles,
+        status: 1,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+    await membership(primaryAdminUserId, 4);
+    await membership(plainAdminUserId, 3);
+    await membership(grantedAdminUserId, 3);
+
+    await ctx.db.insert("communityFinanceRoles", {
+      communityId,
+      userId: grantedAdminUserId,
+      role: "finance_admin",
+      grantedBy: primaryAdminUserId,
+      grantedAt: timestamp,
+    });
+
+    await ctx.db.insert("communityFinance", {
+      communityId,
+      stripeConnectedAccountId: "acct_test",
+      increaseEntityId: "entity_test",
+      increaseReceivingAccountId: "increase_account_receiving_test",
+      cardProvider: "privacy",
+      onboardingStatus: (opts.onboardingStatus ?? "live") as any,
+      legalName: "Test Church",
+      ein: "12-3456789",
+      address: ADDRESS,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Group",
+      slug: `small-group-${suffix}`,
+      isActive: true,
+      createdAt: timestamp,
+      displayOrder: 1,
+    });
+    const mkGroup = async (name: string, isArchived = false) =>
+      ctx.db.insert("groups", {
+        communityId,
+        groupTypeId,
+        name,
+        isArchived,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+    // Deliberately inserted out of alphabetical order — the query sorts.
+    const unfundedGroupId = await mkGroup("Youth");
+    const fundedGroupId = await mkGroup("Worship Team");
+    const archivedGroupId = await mkGroup("Alumni", true);
+
+    const generalFundId = await ctx.db.insert("funds", {
+      communityId,
+      name: "General Fund",
+      type: "general",
+      status: "active",
+      balanceCents: 100_00,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    const fundId = await ctx.db.insert("funds", {
+      communityId,
+      groupId: fundedGroupId,
+      name: "Worship Team Fund",
+      type: "group",
+      status: "active",
+      balanceCents: 250_00,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    return {
+      communityId,
+      primaryAdminUserId,
+      plainAdminUserId,
+      grantedAdminUserId,
+      fundedGroupId,
+      unfundedGroupId,
+      archivedGroupId,
+      fundId,
+      generalFundId,
+    };
+  });
+}
+
+async function tokenFor(userId: Id<"users">): Promise<string> {
+  const { accessToken } = await generateTokens(userId);
+  return accessToken;
+}
+
+function overview(t: ReturnType<typeof convexTest>, f: Fixture, userId: Id<"users">) {
+  return tokenFor(userId).then((token) =>
+    t.query(api.functions.finance.giving.getCommunityFinanceOverview, {
+      token,
+      communityId: f.communityId,
+    }),
+  );
+}
+
+// ============================================================================
+// The gate
+// ============================================================================
+
+describe("getCommunityFinanceOverview — access", () => {
+  test("the primary admin sees it", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    const result = await overview(t, f, f.primaryAdminUserId);
+    expect(result.funds).toHaveLength(2);
+  });
+
+  test("a community admin WITH a financial-controls grant sees it", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    const result = await overview(t, f, f.grantedAdminUserId);
+    expect(result.funds).toHaveLength(2);
+  });
+
+  test("a plain community admin is refused (ADR-033 §5)", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await expect(overview(t, f, f.plainAdminUserId)).rejects.toThrow(
+      /financial-controls access/i,
+    );
+  });
+
+  test("the whole surface is behind the group-giving flag", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t, { groupGiving: false });
+    await expect(overview(t, f, f.primaryAdminUserId)).rejects.toThrow();
+  });
+});
+
+// ============================================================================
+// getMyCommunityFinanceAccess — the non-throwing "may I offer this?" answer
+// ============================================================================
+
+describe("getMyCommunityFinanceAccess", () => {
+  const ask = (
+    t: ReturnType<typeof convexTest>,
+    f: Fixture,
+    userId: Id<"users">,
+  ) =>
+    tokenFor(userId).then((token) =>
+      t.query(api.functions.finance.communityRoles.getMyCommunityFinanceAccess, {
+        token,
+        communityId: f.communityId,
+      }),
+    );
+
+  test("says yes to the primary admin, with the precondition they need", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    expect(await ask(t, f, f.primaryAdminUserId)).toEqual({
+      canManage: true,
+      onboardingStatus: "live",
+      canEnableGiving: true,
+    });
+  });
+
+  test("says yes to a granted admin", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    expect((await ask(t, f, f.grantedAdminUserId)).canManage).toBe(true);
+  });
+
+  // The whole point: it ANSWERS for a non-holder instead of throwing, so the
+  // group Giving hub can pick an empty state rather than crash into a boundary.
+  test("says no to a plain admin without throwing", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    expect(await ask(t, f, f.plainAdminUserId)).toEqual({
+      canManage: false,
+      onboardingStatus: null,
+      canEnableGiving: false,
+    });
+  });
+
+  test("a holder learns giving isn't live yet, so the row can say why", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t, { onboardingStatus: "verifying" });
+    const result = await ask(t, f, f.primaryAdminUserId);
+    expect(result.canManage).toBe(true);
+    expect(result.canEnableGiving).toBe(false);
+    expect(result.onboardingStatus).toBe("verifying");
+  });
+});
+
+// ============================================================================
+// The month window and the arithmetic
+// ============================================================================
+
+describe("getCommunityFinanceOverview — aggregation", () => {
+  test("counts this month's donations and spend, and no earlier ones", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+
+    const nowMs = Date.now();
+    const thisMonth = nowMs - 1_000;
+    const lastMonth = startOfMonthUTC(nowMs) - 24 * 60 * 60 * 1000;
+
+    await t.run(async (ctx) => {
+      const entry = (
+        direction: "credit" | "debit",
+        amountCents: number,
+        kind: string,
+        createdAt: number,
+        key: string,
+      ) =>
+        ctx.db.insert("ledgerEntries", {
+          fundId: f.fundId,
+          communityId: f.communityId,
+          direction,
+          amountCents,
+          kind: kind as any,
+          idempotencyKey: key,
+          createdAt,
+        });
+
+      await entry("credit", 5_000, "donation", thisMonth, "d1");
+      await entry("credit", 2_500, "donation", thisMonth, "d2");
+      await entry("debit", 1_200, "card_capture", thisMonth, "s1");
+      await entry("debit", 800, "reimbursement", thisMonth, "s2");
+      // Fees and refunds are NOT spend — same rule as getFundOverview.
+      await entry("debit", 150, "fee", thisMonth, "f1");
+      await entry("debit", 900, "refund", thisMonth, "r1");
+      // Last month — must be outside the window entirely.
+      await entry("credit", 90_000, "donation", lastMonth, "d-old");
+      await entry("debit", 40_000, "card_capture", lastMonth, "s-old");
+    });
+
+    const result = await overview(t, f, f.primaryAdminUserId);
+    const worship = result.funds.find((row) => row.fundId === f.fundId)!;
+
+    expect(worship.monthDonatedCents).toBe(7_500);
+    expect(worship.monthSpentCents).toBe(2_000);
+    expect(worship.balanceCents).toBe(250_00);
+    expect(worship.groupName).toBe("Worship Team");
+    expect(worship.groupId).toBe(f.fundedGroupId);
+  });
+
+  test("community totals sum every fund, general included", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+
+    const thisMonth = Date.now() - 1_000;
+    await t.run(async (ctx) => {
+      await ctx.db.insert("ledgerEntries", {
+        fundId: f.fundId,
+        communityId: f.communityId,
+        direction: "credit",
+        amountCents: 4_000,
+        kind: "donation",
+        idempotencyKey: "t-d1",
+        createdAt: thisMonth,
+      });
+      await ctx.db.insert("ledgerEntries", {
+        fundId: f.generalFundId,
+        communityId: f.communityId,
+        direction: "credit",
+        amountCents: 1_000,
+        kind: "donation",
+        idempotencyKey: "t-d2",
+        createdAt: thisMonth,
+      });
+      await ctx.db.insert("ledgerEntries", {
+        fundId: f.generalFundId,
+        communityId: f.communityId,
+        direction: "debit",
+        amountCents: 600,
+        kind: "card_capture",
+        idempotencyKey: "t-s1",
+        createdAt: thisMonth,
+      });
+    });
+
+    const result = await overview(t, f, f.primaryAdminUserId);
+
+    expect(result.totals.balanceCents).toBe(350_00);
+    expect(result.totals.monthDonatedCents).toBe(5_000);
+    expect(result.totals.monthSpentCents).toBe(600);
+    expect(result.totals.fundCount).toBe(2);
+  });
+
+  test("counts live cards only — a canceled card isn't a card the fund has", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+
+    await t.run(async (ctx) => {
+      const timestamp = Date.now();
+      const holderUserId = f.primaryAdminUserId;
+      const mkCard = (status: string, key: string) =>
+        ctx.db.insert("cards", {
+          fundId: f.fundId,
+          holderUserId,
+          provider: "privacy",
+          providerCardId: key,
+          status,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        });
+      await mkCard("active", "c1");
+      await mkCard("pending", "c2"); // about to exist — alive
+      await mkCard("canceled", "c3");
+      await mkCard("failed", "c4");
+    });
+
+    const result = await overview(t, f, f.primaryAdminUserId);
+    const worship = result.funds.find((row) => row.fundId === f.fundId)!;
+
+    expect(worship.cardCount).toBe(2);
+    expect(result.totals.cardCount).toBe(2);
+  });
+
+  test("the general fund sorts first and carries no group", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    const result = await overview(t, f, f.primaryAdminUserId);
+
+    expect(result.funds[0].type).toBe("general");
+    expect(result.funds[0].groupId).toBeNull();
+    expect(result.funds[0].groupName).toBeNull();
+  });
+});
+
+// ============================================================================
+// Groups that have no fund yet — the "Enable giving" rows
+// ============================================================================
+
+describe("getCommunityFinanceOverview — groups without funds", () => {
+  test("lists un-funded groups and excludes funded and archived ones", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    const result = await overview(t, f, f.primaryAdminUserId);
+
+    expect(result.groupsWithoutFunds).toEqual([
+      { groupId: f.unfundedGroupId, groupName: "Youth" },
+    ]);
+  });
+
+  test("canEnableGiving is true only once the community's giving is live", async () => {
+    const t = convexTest(schema, modules);
+    const live = await seed(t);
+    expect((await overview(t, live, live.primaryAdminUserId)).canEnableGiving).toBe(
+      true,
+    );
+
+    const t2 = convexTest(schema, modules);
+    const pending = await seed(t2, { onboardingStatus: "verifying" });
+    const result = await overview(t2, pending, pending.primaryAdminUserId);
+    expect(result.canEnableGiving).toBe(false);
+    expect(result.onboardingStatus).toBe("verifying");
+  });
+});
+
+// ============================================================================
+// The plumbing rows
+// ============================================================================
+
+describe("getCommunityFinanceOverview — plumbing rows", () => {
+  test("reports the provider and whether it is connected", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+
+    const disconnected = await overview(t, f, f.primaryAdminUserId);
+    expect(disconnected.provider.name).toBe("privacy");
+    expect(disconnected.provider.connected).toBe(false);
+    expect(disconnected.provider.accountLabel).toBeNull();
+
+    await t.run(async (ctx) => {
+      const timestamp = Date.now();
+      await ctx.db.insert("cardProviderConnections", {
+        communityId: f.communityId,
+        provider: "privacy",
+        credentialCiphertext: "x",
+        credentialIv: "y",
+        keyVersion: 1,
+        accountLabel: "Grace Church Ops",
+        status: "active",
+        connectedById: f.primaryAdminUserId,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+    });
+
+    const connected = await overview(t, f, f.primaryAdminUserId);
+    expect(connected.provider.connected).toBe(true);
+    expect(connected.provider.accountLabel).toBe("Grace Church Ops");
+    expect(connected.provider.status).toBe("active");
+  });
+
+  test("counts active financial-controls grants, not revoked ones", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+
+    expect((await overview(t, f, f.primaryAdminUserId)).financeGrantCount).toBe(1);
+
+    await t.run(async (ctx) => {
+      const row = await ctx.db
+        .query("communityFinanceRoles")
+        .withIndex("by_community", (q) => q.eq("communityId", f.communityId))
+        .first();
+      await ctx.db.patch(row!._id, { revokedAt: Date.now() });
+    });
+
+    expect((await overview(t, f, f.primaryAdminUserId)).financeGrantCount).toBe(0);
+  });
+});
+
+// ============================================================================
+// Empty states
+// ============================================================================
+
+describe("getCommunityFinanceOverview — empty states", () => {
+  test("a community with no funds returns zeroed totals, not nulls", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.delete(f.fundId);
+      await ctx.db.delete(f.generalFundId);
+    });
+
+    const result = await overview(t, f, f.primaryAdminUserId);
+
+    expect(result.funds).toEqual([]);
+    expect(result.totals).toEqual({
+      balanceCents: 0,
+      monthDonatedCents: 0,
+      monthSpentCents: 0,
+      cardCount: 0,
+      fundCount: 0,
+    });
+    // Both live groups are now enable-able.
+    expect(result.groupsWithoutFunds.map((g) => g.groupName)).toEqual([
+      "Worship Team",
+      "Youth",
+    ]);
+  });
+
+  test("a community that never started onboarding still answers", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await t.run(async (ctx) => {
+      const row = await ctx.db
+        .query("communityFinance")
+        .withIndex("by_community", (q) => q.eq("communityId", f.communityId))
+        .first();
+      await ctx.db.delete(row!._id);
+    });
+
+    const result = await overview(t, f, f.primaryAdminUserId);
+    expect(result.onboardingStatus).toBeNull();
+    expect(result.canEnableGiving).toBe(false);
+    expect(result.provider.name).toBe("none");
+  });
+});

--- a/apps/convex/__tests__/finance-community-overview.test.ts
+++ b/apps/convex/__tests__/finance-community-overview.test.ts
@@ -275,6 +275,23 @@ describe("getMyCommunityFinanceAccess", () => {
     expect(result.canEnableGiving).toBe(false);
     expect(result.onboardingStatus).toBe("verifying");
   });
+
+  // The gap between this non-throwing wrapper and the throwing one:
+  // `requireCommunityFinanceAccess` refuses an ARCHIVED community, and
+  // `enableGroupGiving` goes through it. If `canEnableGiving` ignored that,
+  // the hub would offer a button the mutation always refuses.
+  test("an archived community can't have giving enabled, live or not", async () => {
+    const t = convexTest(schema, modules);
+    const f = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(f.communityId, { isArchived: true });
+    });
+
+    const result = await ask(t, f, f.primaryAdminUserId);
+    expect(result.canManage).toBe(true);
+    expect(result.onboardingStatus).toBe("live");
+    expect(result.canEnableGiving).toBe(false);
+  });
 });
 
 // ============================================================================

--- a/apps/convex/functions/finance/cardProviderConnections.ts
+++ b/apps/convex/functions/finance/cardProviderConnections.ts
@@ -101,8 +101,13 @@ const DEAD_CARD_STATUSES = new Set(["CLOSED", "canceled", "closed", "failed"]);
  * Returns the LATEST row rather than the active one: an admin looking at this
  * screen after a key was revoked needs to see "disconnected", not an empty
  * state that implies they never connected at all.
+ *
+ * Exported for `giving.getCommunityFinanceOverview`, which shows the same
+ * "«provider» · Connected" line inline on the Finance home. One reader of the
+ * "which row counts" rule, not two — a second copy would drift the moment
+ * this one learns about another status.
  */
-async function loadConnectionRow(
+export async function loadConnectionRow(
   ctx: { db: any },
   communityId: Id<"communities">,
 ) {

--- a/apps/convex/functions/finance/cards.ts
+++ b/apps/convex/functions/finance/cards.ts
@@ -389,7 +389,17 @@ function assertLimitRequired(
  * about to exist at the issuer, and letting a second one through in that window
  * is precisely how a fund ends up with two lifetime caps.
  */
-const DEAD_CARD_STATUSES = new Set(["canceled", "closed", "CLOSED", "failed"]);
+export const DEAD_CARD_STATUSES = new Set([
+  "canceled",
+  "closed",
+  "CLOSED",
+  "failed",
+]);
+
+/** `true` when this card still occupies its fund's slot and is worth counting. */
+export function isLiveCardStatus(status: string): boolean {
+  return !DEAD_CARD_STATUSES.has(status);
+}
 
 /** Cents -> "$1,234.56", for the copy a finance admin reads on a refusal. */
 function usd(cents: number): string {
@@ -1726,6 +1736,63 @@ export const listManagedCards = internalQuery({
 const ACTIVITY_LIMIT = 20;
 
 /**
+ * Both ways a card row ends up `failed`. They write different detail keys
+ * (`message` from the provider, `reason` from our own preflight), and a
+ * screen that only knew about one would show the generic apology for the
+ * other — which is the whole failure this reads back to avoid.
+ */
+const CARD_FAILURE_ACTIONS = new Set([
+  "card.provision_failed",
+  "card.provision_refused",
+]);
+
+/**
+ * How far back to look for it. `financeAuditEvents` has no index on `action`
+ * and the card id lives inside a JSON string, so the only indexed path is the
+ * fund's own log newest-first. A failed card's failure is by construction one
+ * of the most recent things that happened to that fund's card slot, so a
+ * bounded scan finds it or it isn't worth finding — and the alternative,
+ * walking a busy fund's whole audit history for a subtitle, is not.
+ */
+const CARD_FAILURE_SCAN_LIMIT = 200;
+/** Provider text is already capped at 500 on write; a strip is not 500 chars. */
+const CARD_FAILURE_MESSAGE_MAX = 300;
+
+/**
+ * The stored reason a card was never issued, or null if it wasn't recorded.
+ *
+ * Only ever called for a `failed` card being read by someone with the
+ * community's financial controls — see `getCardDetail` for why both halves of
+ * that matter.
+ */
+async function findCardFailureMessage(
+  ctx: { db: any },
+  fundId: Id<"funds">,
+  cardId: Id<"cards">,
+): Promise<string | null> {
+  const events = await ctx.db
+    .query("financeAuditEvents")
+    .withIndex("by_fund", (q: any) => q.eq("fundId", fundId))
+    .order("desc")
+    .take(CARD_FAILURE_SCAN_LIMIT);
+
+  for (const event of events) {
+    if (!CARD_FAILURE_ACTIONS.has(event.action) || !event.detailsJson) continue;
+    let details: any;
+    try {
+      details = JSON.parse(event.detailsJson);
+    } catch {
+      continue; // A malformed row is not a reason to fail the whole screen.
+    }
+    if (String(details?.cardId) !== String(cardId)) continue;
+    const raw = details.message ?? details.reason;
+    if (typeof raw !== "string" || raw.trim() === "") return null;
+    return raw.trim().slice(0, CARD_FAILURE_MESSAGE_MAX);
+  }
+  return null;
+}
+
+/**
  * A single card's detail plus its recent `card_charge` activity. Same viewer
  * gate as `listFundCards`, resolved via the card's fund.
  */
@@ -1774,6 +1841,26 @@ export const getCardDetail = query({
       ? await resolveCardProviderName(ctx, fund.communityId)
       : "none";
 
+    // WHY THE FAILURE REASON IS READ BACK AT ALL. A card that never got issued
+    // showed "Something went wrong issuing this card. Contact support." while
+    // the audit row held the actual, actionable sentence — e.g. Privacy's
+    // "Insufficient privileges to create UNLOCKED cards", which means the
+    // community's own account plan, not a Togather fault. Support was being
+    // asked to relay a message the admin could already have acted on.
+    //
+    // ONLY FOR FINANCE HOLDERS. `getCardDetail`'s gate is deliberately wider
+    // than that (any cardholder or group leader on the fund), and this text is
+    // vendor ACCOUNT detail: it names the provider — which every group-level
+    // card surface is anonymous about on purpose, ADR-033 §1 — and describes a
+    // fix only someone with financial controls can carry out.
+    const viewerCanManageCommunityFinance = fund
+      ? await canManageCommunityFinance(ctx, userId, fund.communityId)
+      : false;
+    const failureMessage =
+      card.status === "failed" && viewerCanManageCommunityFinance && fund
+        ? await findCardFailureMessage(ctx, fund._id, card._id)
+        : null;
+
     return {
       ...toCardSummary(
         card,
@@ -1784,6 +1871,12 @@ export const getCardDetail = query({
       viewerCanFreeze: viewerIsFinanceAdmin || viewerIsHolder,
       viewerCanUnfreeze: viewerIsFinanceAdmin,
       viewerCanCancel: viewerIsFinanceAdmin,
+      /**
+       * The provider's own words for why this card was never issued, or null.
+       * PROVIDER TEXT — untrusted; already truncated at the write, truncated
+       * again here, and rendered as text only.
+       */
+      failureMessage,
       /**
        * Provider capabilities, provider-ANONYMOUS (see `listFundCards`).
        *

--- a/apps/convex/functions/finance/communityRoles.ts
+++ b/apps/convex/functions/finance/communityRoles.ts
@@ -73,6 +73,57 @@ async function requirePrimaryAdminForFinance(
 }
 
 // ============================================================================
+// getMyCommunityFinanceAccess
+// ============================================================================
+
+/**
+ * Does the CALLER hold this community's financial controls — answered without
+ * throwing.
+ *
+ * Every other community-level finance query is gated and raises for anyone
+ * else, which is right for the surfaces that show finance DATA but useless for
+ * a surface that merely needs to decide whether to offer a finance ACTION. The
+ * group Giving hub is exactly that: with no fund yet there is no `fundId`, so
+ * `getMyFundRole` can't run, and the hub was falling back to "ask a community
+ * admin" for the admins themselves — a dead end pointing at a screen the
+ * viewer was already entitled to use.
+ *
+ * Answering it non-throwingly leaks nothing: the caller learns one bit about
+ * their OWN standing, which they can already establish by opening any of the
+ * gated screens.
+ *
+ * `onboardingStatus` rides along because the same rows have to explain WHY
+ * "Enable giving" is unavailable when the community's own giving isn't live —
+ * `enableGroupGiving`'s first precondition. Non-holders get `null` for it:
+ * they have no action to explain, and it is finance information.
+ */
+export const getMyCommunityFinanceAccess = query({
+  args: { token: v.string(), communityId: v.id("communities") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    const canManage = await canManageCommunityFinance(
+      ctx,
+      userId,
+      args.communityId,
+    );
+    if (!canManage) {
+      return { canManage: false, onboardingStatus: null, canEnableGiving: false };
+    }
+
+    const finance = await ctx.db
+      .query("communityFinance")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .first();
+    const onboardingStatus = finance?.onboardingStatus ?? null;
+    return {
+      canManage: true,
+      onboardingStatus,
+      canEnableGiving: onboardingStatus === "live",
+    };
+  },
+});
+
+// ============================================================================
 // listCommunityFinanceRoles
 // ============================================================================
 

--- a/apps/convex/functions/finance/communityRoles.ts
+++ b/apps/convex/functions/finance/communityRoles.ts
@@ -96,6 +96,15 @@ async function requirePrimaryAdminForFinance(
  * "Enable giving" is unavailable when the community's own giving isn't live —
  * `enableGroupGiving`'s first precondition. Non-holders get `null` for it:
  * they have no action to explain, and it is finance information.
+ *
+ * ONE PREDICATE, TWO WRAPPERS. `canManage` is `canManageCommunityFinance`
+ * itself — the same function `requireCommunityFinanceAccess` throws on — so
+ * the two can never disagree about who holds the controls. The throwing
+ * wrapper adds one thing this one can't (it refuses an ARCHIVED community),
+ * and `canEnableGiving` carries that clause too: otherwise an archived
+ * community's finance holder would be offered an "Enable giving" button that
+ * `enableGroupGiving` — which goes through the throwing wrapper — always
+ * refuses.
  */
 export const getMyCommunityFinanceAccess = query({
   args: { token: v.string(), communityId: v.id("communities") },
@@ -115,10 +124,11 @@ export const getMyCommunityFinanceAccess = query({
       .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
       .first();
     const onboardingStatus = finance?.onboardingStatus ?? null;
+    const community = await ctx.db.get(args.communityId);
     return {
       canManage: true,
       onboardingStatus,
-      canEnableGiving: onboardingStatus === "live",
+      canEnableGiving: onboardingStatus === "live" && !community?.isArchived,
     };
   },
 });

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -59,6 +59,12 @@ import { computeCoverFeesCents, COVER_FEE_TOLERANCE_CENTS } from "../../lib/fina
 // Pure helper, no cycle: webhooks.ts reaches giving.ts through the generated
 // `internal` API, never by importing this module.
 import { splitDonationAmounts } from "./webhooks";
+// Same story for these three: plain functions, and none of those modules
+// imports this one back.
+import { requireCommunityFinanceAccess } from "../../lib/finance/communityFinanceAccess";
+import { loadConnectionRow } from "./cardProviderConnections";
+import { isLiveCardStatus } from "./cards";
+import { resolveCardProviderName } from "../../lib/finance/cardProviders";
 import { getResendClient } from "../../lib/resend";
 import { now, getDisplayName } from "../../lib/utils";
 import {
@@ -386,6 +392,168 @@ export const getFundOverview = query({
       yearToDate: summarizePeriod(yearEntries),
       activity,
       viewerCanSeeDonorNames,
+    };
+  },
+});
+
+// ============================================================================
+// getCommunityFinanceOverview — the Finance home
+// ============================================================================
+
+/**
+ * Everything the community-level Finance home renders in one round trip: each
+ * fund's balance and month, the groups that have no fund yet, the card-provider
+ * connection, and how many people hold financial controls.
+ *
+ * WHY ONE QUERY. The screen is a list of rows whose SUBTITLES are the data —
+ * "«group» — $balance · $spent this month · N cards". Fetching those per row
+ * would mean one subscription per group, each with its own auth round trip,
+ * for a screen whose whole job is the overview.
+ *
+ * COST. Convex has no `["communityId", "createdAt"]` index on `ledgerEntries`
+ * (only `by_community` on the id alone), so a single community-wide month
+ * window is not expressible as one range scan. Rather than add an index for
+ * one screen, this fans out over the community's funds and uses the SAME
+ * `by_fund` range `getFundOverview` uses — an indexed read bounded by the
+ * month, not by the fund's history. That is 2 indexed reads per fund (ledger
+ * window + card list) plus 3 fixed ones, i.e. O(funds), and a fund only exists
+ * where an admin turned giving on. If a community ever has enough funds for
+ * that to hurt, the fix is the compound index and a single scan — not
+ * pagination of a summary.
+ *
+ * The balance is `funds.balanceCents` — the ledger-maintained cache every
+ * other surface reads, so this screen can't disagree with the fund screen.
+ */
+export const getCommunityFinanceOverview = query({
+  args: { token: v.string(), communityId: v.id("communities") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireCommunityFinanceAccess(ctx, userId, args.communityId);
+    await requireGroupGivingEnabled(ctx);
+
+    const finance = await ctx.db
+      .query("communityFinance")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .first();
+    const onboardingStatus = finance?.onboardingStatus ?? null;
+    // The one precondition `enableGroupGiving` checks that this screen can
+    // answer without attempting the mutation. Sent as a flag AND a reason so
+    // the row can explain itself rather than just being disabled.
+    const canEnableGiving = onboardingStatus === "live";
+
+    const connection = await loadConnectionRow(ctx, args.communityId);
+    const providerName = await resolveCardProviderName(ctx, args.communityId);
+
+    const funds = await ctx.db
+      .query("funds")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+
+    const groups = await ctx.db
+      .query("groups")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    const groupById = new Map(groups.map((group) => [group._id, group]));
+
+    const monthStart = startOfMonthUTC(now());
+
+    const fundRows = await Promise.all(
+      funds.map(async (fund) => {
+        const monthEntries = await ctx.db
+          .query("ledgerEntries")
+          .withIndex("by_fund", (q) =>
+            q.eq("fundId", fund._id).gte("createdAt", monthStart),
+          )
+          .collect();
+        const month = summarizePeriod(monthEntries);
+
+        // Live cards only: a canceled or failed card is not a card this fund
+        // has, and counting one would tell an admin their fund is covered
+        // when it isn't. Same denylist `createFundCard` enforces the
+        // one-card-per-fund rule with.
+        const cards = await ctx.db
+          .query("cards")
+          .withIndex("by_fund", (q) => q.eq("fundId", fund._id))
+          .collect();
+        const cardCount = cards.filter((card) =>
+          isLiveCardStatus(card.status),
+        ).length;
+
+        const group = fund.groupId ? (groupById.get(fund.groupId) ?? null) : null;
+
+        return {
+          fundId: fund._id,
+          groupId: fund.groupId ?? null,
+          // Null for the community's general fund, which belongs to no group.
+          groupName: group?.name ?? null,
+          fundName: fund.name,
+          type: fund.type,
+          status: fund.status,
+          balanceCents: fund.balanceCents,
+          monthDonatedCents: month.donationsCents,
+          monthSpentCents: month.spentCents,
+          cardCount,
+        };
+      }),
+    );
+
+    // General fund first (it's the community's own money), then group funds
+    // by the name the admin will scan for.
+    fundRows.sort((a, b) => {
+      if (a.type !== b.type) return a.type === "general" ? -1 : 1;
+      return (a.groupName ?? a.fundName).localeCompare(b.groupName ?? b.fundName);
+    });
+
+    const fundedGroupIds = new Set(
+      funds.map((fund) => fund.groupId).filter(Boolean),
+    );
+    const groupsWithoutFunds = groups
+      // Archived groups are excluded rather than shown disabled: enabling
+      // giving on one would create a fund the archive job immediately freezes.
+      .filter((group) => !group.isArchived && !fundedGroupIds.has(group._id))
+      .map((group) => ({ groupId: group._id, groupName: group.name }))
+      .sort((a, b) => a.groupName.localeCompare(b.groupName));
+
+    // Active grants only. The primary admin holds financial controls with no
+    // row at all (see `canManageCommunityFinance`), so this is deliberately
+    // "how many people it was GIVEN to" — the same population the Financial
+    // controls screen lists, and the count has to agree with that screen.
+    const financeRoles = await ctx.db
+      .query("communityFinanceRoles")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    const financeGrantCount = financeRoles.filter(
+      (role) => role.revokedAt === undefined,
+    ).length;
+
+    return {
+      onboardingStatus,
+      canEnableGiving,
+      provider: {
+        /** The community's effective issuer: "increase" | "privacy" | "bill" | "none". */
+        name: providerName,
+        connected: connection?.status === "active",
+        // Provider-supplied display text — untrusted, escape at render.
+        accountLabel: connection?.accountLabel ?? null,
+        status: (connection?.status ?? null) as
+          | "active"
+          | "error"
+          | "revoked"
+          | null,
+      },
+      totals: {
+        balanceCents: fundRows.reduce((sum, f) => sum + f.balanceCents, 0),
+        monthDonatedCents: fundRows.reduce(
+          (sum, f) => sum + f.monthDonatedCents,
+          0,
+        ),
+        monthSpentCents: fundRows.reduce((sum, f) => sum + f.monthSpentCents, 0),
+        cardCount: fundRows.reduce((sum, f) => sum + f.cardCount, 0),
+        fundCount: fundRows.length,
+      },
+      funds: fundRows,
+      groupsWithoutFunds,
+      financeGrantCount,
     };
   },
 });

--- a/apps/convex/functions/finance/giving.ts
+++ b/apps/convex/functions/finance/giving.ts
@@ -416,10 +416,15 @@ export const getFundOverview = query({
  * one screen, this fans out over the community's funds and uses the SAME
  * `by_fund` range `getFundOverview` uses — an indexed read bounded by the
  * month, not by the fund's history. That is 2 indexed reads per fund (ledger
- * window + card list) plus 3 fixed ones, i.e. O(funds), and a fund only exists
- * where an admin turned giving on. If a community ever has enough funds for
- * that to hurt, the fix is the compound index and a single scan — not
- * pagination of a summary.
+ * window + card list), and a fund only exists where an admin turned giving on.
+ *
+ * The rest is six indexed reads that don't scale with the ledger: the finance
+ * row, the provider connection, the provider name, the fund list, the group
+ * list, and the finance-role grants. Two of those (`groups`, `funds`) are
+ * whole-community collects, so the query is O(groups + funds) — the same
+ * order the screen it feeds is, since it draws a row for each. If a community
+ * ever has enough of either for that to hurt, the fix is the compound index
+ * and a single scan, plus paginating the LIST — not paginating a summary.
  *
  * The balance is `funds.balanceCents` — the ledger-maintained cache every
  * other surface reads, so this screen can't disagree with the fund screen.

--- a/apps/mobile/app/finance-setup/index.tsx
+++ b/apps/mobile/app/finance-setup/index.tsx
@@ -1,3 +1,14 @@
-import { FinanceOnboardingStatusScreen } from "@features/finance/leader/FinanceOnboardingStatusScreen";
+import { CommunityFinanceHomeScreen } from "@features/finance/leader/CommunityFinanceHomeScreen";
 
-export default FinanceOnboardingStatusScreen;
+/**
+ * `/finance-setup` — the community's Finance home.
+ *
+ * This route used to be the onboarding checklist and only that, which meant a
+ * community whose setup was finished opened it to four ticked boxes and no way
+ * onward. The home ABSORBS that checklist (it still takes the screen over
+ * while giving isn't live, so the setup flow and Stripe's return URL are
+ * unchanged) and becomes the parent of `/finance-setup/card-provider` and
+ * `/finance-setup/financial-controls` — both of which keep their own routes,
+ * so existing deep links still land.
+ */
+export default CommunityFinanceHomeScreen;

--- a/apps/mobile/features/admin/components/SettingsContent.tsx
+++ b/apps/mobile/features/admin/components/SettingsContent.tsx
@@ -453,8 +453,21 @@ export function SettingsContent() {
               EIN, address, Stripe identity verification) lives outside any
               one group, so it's a top-level leader-tools route rather than
               nested under a specific group's giving screens. */}
+          {/* ONE row, not three. Card provider and Financial controls used to
+              sit here beside this one; they are now sections of the Finance
+              home, which is their PARENT rather than their sibling — and which
+              also answers the question none of the three flat rows did ("how
+              much money does this community have, and which groups can receive
+              it?"). Their own routes are unchanged, so existing deep links
+              still land.
+
+              Shown to any community admin, not only to people who hold
+              financial controls: "primary admin OR an active grant" has no
+              cheap client-side signal, and the destination opens on an
+              explicit "you need financial-controls access — ask your primary
+              admin" state, which is a better answer than a row that silently
+              isn't there. */}
           {groupGivingEnabled ? (
-          <>
           <TouchableOpacity
             style={[styles.quickLinkItem, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
             onPress={() => pushOutOfModal("/finance-setup")}
@@ -463,57 +476,13 @@ export function SettingsContent() {
               <Ionicons name="wallet-outline" size={20} color={themePrimaryColor} />
             </View>
             <View style={styles.quickLinkInfo}>
-              <Text style={[styles.quickLinkName, { color: colors.text }]}>Community Finance</Text>
+              <Text style={[styles.quickLinkName, { color: colors.text }]}>Finance</Text>
               <Text style={[styles.quickLinkDescription, { color: colors.textSecondary }]}>
-                Set up giving, spending, and reimbursements
+                Balances, group funds, cards, and who can spend
               </Text>
             </View>
             <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
           </TouchableOpacity>
-          {/* ADR-033 Phase 3: the two community-level finance surfaces sit
-              beside the onboarding one rather than in the You tab's Admin
-              group, so every entry point into community finance is in one
-              place — and so they work in BOTH shells (this component renders
-              inside the legacy AdminScreen as well as /(user)/you/admin/community,
-              and a `you/admin` route redirects flag-off admins away).
-
-              Both rows are shown to any community admin, not only to people
-              who hold financial controls: "primary admin OR an active grant"
-              has no cheap client-side signal, and each destination opens on an
-              explicit "you need financial-controls access — ask your primary
-              admin" state, which is a better answer than a row that silently
-              isn't there. */}
-          <TouchableOpacity
-            style={[styles.quickLinkItem, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
-            onPress={() => pushOutOfModal("/finance-setup/card-provider")}
-          >
-            <View style={[styles.quickLinkIcon, { backgroundColor: colors.surface }]}>
-              <Ionicons name="card-outline" size={20} color={themePrimaryColor} />
-            </View>
-            <View style={styles.quickLinkInfo}>
-              <Text style={[styles.quickLinkName, { color: colors.text }]}>Card provider</Text>
-              <Text style={[styles.quickLinkDescription, { color: colors.textSecondary }]}>
-                Issue group-fund cards on your own card account
-              </Text>
-            </View>
-            <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.quickLinkItem, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
-            onPress={() => pushOutOfModal("/finance-setup/financial-controls")}
-          >
-            <View style={[styles.quickLinkIcon, { backgroundColor: colors.surface }]}>
-              <Ionicons name="key-outline" size={20} color={themePrimaryColor} />
-            </View>
-            <View style={styles.quickLinkInfo}>
-              <Text style={[styles.quickLinkName, { color: colors.text }]}>Financial controls</Text>
-              <Text style={[styles.quickLinkDescription, { color: colors.textSecondary }]}>
-                Who can connect providers and issue cards
-              </Text>
-            </View>
-            <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
-          </TouchableOpacity>
-          </>
           ) : null}
           {settings?.churchFeatures?.prayerEnabled ? (
             <TouchableOpacity

--- a/apps/mobile/features/admin/components/SettingsContent.tsx
+++ b/apps/mobile/features/admin/components/SettingsContent.tsx
@@ -318,6 +318,32 @@ export function SettingsContent() {
     }
   };
 
+  /**
+   * `SettingsContent` renders in BOTH shells, and in the WhatsApp one it sits
+   * inside `/(user)/you/admin/community` — i.e. inside the `(user)` route
+   * group, which `app/_layout.tsx` declares `presentation: "modal"`. A native
+   * modal sits above EVERY navigator screen, so pushing a ROOT-stack route
+   * (`/finance-setup/...`) from here lands the destination *behind* the still-
+   * open settings modal on iOS: the admin taps "Card provider" and nothing
+   * appears to happen. Dismiss the modal stack first, then push.
+   *
+   * Same pattern (and same comment) as `CommunityPageScreen`'s
+   * `pushOutOfModal`, `useStartDirectMessage`, `NotificationFeedScreen` and
+   * `NativeRunSheetView`.
+   *
+   * In the legacy shell this component renders in `/(tabs)/admin`, where there
+   * is no modal to dismiss — `canDismiss()` is false there and this degrades
+   * to a plain push, which is why one call site works for both shells.
+   *
+   * Destinations that stay INSIDE `(user)` (`/(user)/admin/*`,
+   * `/leader-tools/*`) must NOT go through this — they belong to the modal's
+   * own stack.
+   */
+  const pushOutOfModal = (path: string) => {
+    if (router.canDismiss?.()) router.dismissAll();
+    router.push(path as never);
+  };
+
   const toggleExploreGroupType = (groupTypeId: string) => {
     setExploreGroupTypes((prev) =>
       prev.includes(groupTypeId)
@@ -431,7 +457,7 @@ export function SettingsContent() {
           <>
           <TouchableOpacity
             style={[styles.quickLinkItem, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
-            onPress={() => router.push("/finance-setup")}
+            onPress={() => pushOutOfModal("/finance-setup")}
           >
             <View style={[styles.quickLinkIcon, { backgroundColor: colors.surface }]}>
               <Ionicons name="wallet-outline" size={20} color={themePrimaryColor} />
@@ -459,7 +485,7 @@ export function SettingsContent() {
               isn't there. */}
           <TouchableOpacity
             style={[styles.quickLinkItem, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
-            onPress={() => router.push("/finance-setup/card-provider")}
+            onPress={() => pushOutOfModal("/finance-setup/card-provider")}
           >
             <View style={[styles.quickLinkIcon, { backgroundColor: colors.surface }]}>
               <Ionicons name="card-outline" size={20} color={themePrimaryColor} />
@@ -474,7 +500,7 @@ export function SettingsContent() {
           </TouchableOpacity>
           <TouchableOpacity
             style={[styles.quickLinkItem, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
-            onPress={() => router.push("/finance-setup/financial-controls")}
+            onPress={() => pushOutOfModal("/finance-setup/financial-controls")}
           >
             <View style={[styles.quickLinkIcon, { backgroundColor: colors.surface }]}>
               <Ionicons name="key-outline" size={20} color={themePrimaryColor} />

--- a/apps/mobile/features/admin/components/__tests__/SettingsContent.test.tsx
+++ b/apps/mobile/features/admin/components/__tests__/SettingsContent.test.tsx
@@ -160,14 +160,19 @@ describe("SettingsContent — leaves the (user) settings modal before pushing", 
     );
   };
 
-  it.each([
-    ["Community Finance", "/finance-setup"],
-    ["Card provider", "/finance-setup/card-provider"],
-    ["Financial controls", "/finance-setup/financial-controls"],
-  ])("dismisses before opening %s", (label, path) => {
+  it("dismisses before opening Finance", () => {
     const { getByText } = render(<SettingsContent />);
-    fireEvent.press(getByText(label));
-    expectDismissedThenPushed(path);
+    fireEvent.press(getByText("Finance"));
+    expectDismissedThenPushed("/finance-setup");
+  });
+
+  // Card provider and Financial controls are sections of the Finance home now,
+  // not rows here — the home is their parent. Their routes still exist for
+  // deep links; this asserts Settings has stopped duplicating them.
+  it("no longer lists the finance sub-surfaces beside it", () => {
+    const { queryByText } = render(<SettingsContent />);
+    expect(queryByText("Card provider")).toBeNull();
+    expect(queryByText("Financial controls")).toBeNull();
   });
 
   it("keeps in-(user) destinations a plain push", () => {
@@ -181,8 +186,8 @@ describe("SettingsContent — leaves the (user) settings modal before pushing", 
     // `/(tabs)/admin` renders this same component with nothing to dismiss.
     mockCanDismiss.mockReturnValue(false);
     const { getByText } = render(<SettingsContent />);
-    fireEvent.press(getByText("Card provider"));
+    fireEvent.press(getByText("Finance"));
     expect(mockDismissAll).not.toHaveBeenCalled();
-    expect(mockPush).toHaveBeenCalledWith("/finance-setup/card-provider");
+    expect(mockPush).toHaveBeenCalledWith("/finance-setup");
   });
 });

--- a/apps/mobile/features/admin/components/__tests__/SettingsContent.test.tsx
+++ b/apps/mobile/features/admin/components/__tests__/SettingsContent.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * SettingsContent — navigation out of the `(user)` settings modal.
+ *
+ * `SettingsContent` renders in both shells. In the WhatsApp one it sits inside
+ * `/(user)/you/admin/community`, i.e. inside the `(user)` route group that
+ * `app/_layout.tsx` declares `presentation: "modal"`. A native modal sits above
+ * EVERY navigator screen, so a plain `router.push` to a ROOT-stack route lands
+ * the destination *behind* the still-open settings modal on iOS — the founder's
+ * report: "when clicking card provider, community finance and financial
+ * controls the page opens up behind the modal".
+ *
+ * These tests pin the fix: every `/finance-setup/*` quick link dismisses the
+ * modal stack BEFORE pushing, while destinations that stay inside `(user)`
+ * keep their plain push (dismissing those would tear down the stack they
+ * belong to).
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import { SettingsContent } from "../SettingsContent";
+
+const mockPush = jest.fn();
+const mockDismissAll = jest.fn();
+const mockCanDismiss = jest.fn(() => true);
+jest.mock("expo-router", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: jest.fn(),
+    canGoBack: () => true,
+    canDismiss: mockCanDismiss,
+    dismissAll: mockDismissAll,
+  }),
+}));
+
+jest.mock("@services/api/convex", () => ({
+  api: {
+    functions: {
+      admin: { featureFlags: { getFeatureFlag: "flags.getFeatureFlag" } },
+      ee: { billing: { getSubscriptionStatus: "billing.getSubscriptionStatus" } },
+      memberActivity: { getBillableSummary: "memberActivity.getBillableSummary" },
+    },
+  },
+  // Only the group-giving flag matters here: it gates the finance quick links.
+  useQuery: (ref: string) => (ref === "flags.getFeatureFlag" ? true : undefined),
+}));
+
+jest.mock("@togather/shared/config", () => ({
+  DOMAIN_CONFIG: { landingUrl: "https://example.test" },
+}));
+
+jest.mock("expo-localization", () => ({
+  getLocales: () => [{ regionCode: "US" }],
+}));
+
+jest.mock("expo-linking", () => ({ openURL: jest.fn() }));
+
+jest.mock("expo-file-system/legacy", () => ({
+  uploadAsync: jest.fn(),
+  FileSystemUploadType: { BINARY_CONTENT: "binary" },
+}));
+
+jest.mock("@components/ui", () => ({ ImagePicker: () => null }));
+
+jest.mock("../GroupTypeEditModal", () => ({ GroupTypeEditModal: () => null }));
+jest.mock("../ArchiveCommunityModal", () => ({ ArchiveCommunityModal: () => null }));
+jest.mock("../ColorPicker", () => ({ ColorPicker: () => null }));
+jest.mock("../ColorPreview", () => ({ ColorPreview: () => null }));
+
+// The hook results are FROZEN module-level singletons, not fresh objects per
+// call. `SettingsContent` has a `useEffect` keyed on `settings` that sets
+// state, so a mock returning a new object every render re-runs that effect
+// forever and the test process dies of heap exhaustion rather than failing.
+jest.mock("../../hooks", () => {
+  const settings = {
+    name: "Demo Community",
+    subdomain: "demo",
+    churchFeatures: {},
+  };
+  const communitySettings = {
+    settings,
+    isLoading: false,
+    isError: false,
+    refetch: jest.fn(),
+    updateSettings: jest.fn(),
+    isUpdating: false,
+    uploadLogo: jest.fn(),
+    isUploadingLogo: false,
+    archiveCommunity: jest.fn(),
+  };
+  const groupTypes = {
+    groupTypes: [],
+    isLoading: false,
+    refetch: jest.fn(),
+    updateGroupType: jest.fn(),
+    isUpdating: false,
+    createGroupType: jest.fn(),
+    isCreating: false,
+  };
+  return {
+    useCommunitySettings: () => communitySettings,
+    useGroupTypes: () => groupTypes,
+  };
+});
+
+jest.mock("../../../integrations/hooks/useIntegrations", () => {
+  const integrations = { data: [], isLoading: false, refetch: jest.fn() };
+  return { useAvailableIntegrations: () => integrations };
+});
+
+jest.mock("../../../explore/constants", () => ({
+  getGroupTypeColor: () => "#25D366",
+}));
+
+jest.mock("@providers/AuthProvider", () => {
+  const auth = {
+    community: { id: "community-1" },
+    token: "token-1",
+    user: { is_primary_admin: false },
+    exitToCommunitySelection: jest.fn(),
+  };
+  return { useAuth: () => auth };
+});
+
+jest.mock("@hooks/useCommunityTheme", () => ({
+  useCommunityTheme: () => ({ primaryColor: "#25D366" }),
+}));
+
+jest.mock("@hooks/useTheme", () => ({
+  useTheme: () => ({
+    colors: {
+      text: "#000",
+      textSecondary: "#555",
+      textTertiary: "#999",
+      surface: "#fff",
+      surfaceSecondary: "#eee",
+      background: "#fff",
+      border: "#ccc",
+      error: "#FF3B30",
+      success: "#34C759",
+      warning: "#FF9500",
+      inputBackground: "#fff",
+      inputBorder: "#ccc",
+      inputPlaceholder: "#999",
+    },
+    isDark: false,
+  }),
+}));
+
+describe("SettingsContent — leaves the (user) settings modal before pushing", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCanDismiss.mockReturnValue(true);
+  });
+
+  /** Asserts dismissAll ran, and ran BEFORE the push (order matters). */
+  const expectDismissedThenPushed = (expected: string) => {
+    expect(mockDismissAll).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith(expected);
+    expect(mockDismissAll.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPush.mock.invocationCallOrder[0],
+    );
+  };
+
+  it.each([
+    ["Community Finance", "/finance-setup"],
+    ["Card provider", "/finance-setup/card-provider"],
+    ["Financial controls", "/finance-setup/financial-controls"],
+  ])("dismisses before opening %s", (label, path) => {
+    const { getByText } = render(<SettingsContent />);
+    fireEvent.press(getByText(label));
+    expectDismissedThenPushed(path);
+  });
+
+  it("keeps in-(user) destinations a plain push", () => {
+    const { getByText } = render(<SettingsContent />);
+    fireEvent.press(getByText("Community-Wide Events"));
+    expect(mockPush).toHaveBeenCalledWith("/(user)/admin/community-wide-events");
+    expect(mockDismissAll).not.toHaveBeenCalled();
+  });
+
+  it("does not call dismissAll in the legacy shell, where there is no modal", () => {
+    // `/(tabs)/admin` renders this same component with nothing to dismiss.
+    mockCanDismiss.mockReturnValue(false);
+    const { getByText } = render(<SettingsContent />);
+    fireEvent.press(getByText("Card provider"));
+    expect(mockDismissAll).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/finance-setup/card-provider");
+  });
+});

--- a/apps/mobile/features/finance/leader/CardDetailScreen.tsx
+++ b/apps/mobile/features/finance/leader/CardDetailScreen.tsx
@@ -172,7 +172,15 @@ export function CardDetailScreen() {
             style={[styles.headerSubtitle, { color: colors.textSecondary }]}
             numberOfLines={1}
           >
-            {card ? `Virtual card ··${card.last4}` : "Loading…"}
+            {/* A card that never got issued has no last4, and the template
+                used to interpolate the null straight into the header:
+                "Virtual card ··null". The digits are a detail of a card that
+                exists; when there aren't any, say less. */}
+            {!card
+              ? "Loading…"
+              : card.last4
+                ? `Virtual card ··${card.last4}`
+                : "Virtual card"}
           </Text>
         </View>
       </View>
@@ -195,10 +203,10 @@ export function CardDetailScreen() {
 function toCardDetail(raw: any): CardDetail {
   return {
     id: String(raw.id),
-    name: raw.name,
+    name: raw.name ?? null,
     holderUserId: String(raw.holderUserId),
     holderName: raw.holderName,
-    last4: raw.last4,
+    last4: raw.last4 ?? null,
     status: raw.status,
     spendLimitCents: raw.spendLimitCents ?? null,
     limitPeriod: raw.limitPeriod ?? null,
@@ -228,6 +236,9 @@ function toCardDetail(raw: any): CardDetail {
     viewerCanFreeze: !!raw.viewerCanFreeze,
     viewerCanUnfreeze: !!raw.viewerCanUnfreeze,
     viewerCanCancel: !!raw.viewerCanCancel,
+    // Null for every viewer the server decided may not read it — the screen
+    // never has to make that judgement itself.
+    failureMessage: raw.failureMessage ?? null,
   };
 }
 

--- a/apps/mobile/features/finance/leader/CardDetailView.tsx
+++ b/apps/mobile/features/finance/leader/CardDetailView.tsx
@@ -22,7 +22,12 @@ import { Badge, Skeleton, ConfirmModal, ImagePicker } from "@components/ui";
 // rather than the "@components/ui" barrel.
 import { CustomModal as Modal } from "@components/ui/Modal";
 import { formatCents } from "../format";
-import { formatCardLimit, CARD_CHARGE_SETTLEMENT_NOTE, type CardDetail } from "./types";
+import {
+  formatCardLimit,
+  CARD_CHARGE_SETTLEMENT_NOTE,
+  CARD_FAILED_GENERIC_MESSAGE,
+  type CardDetail,
+} from "./types";
 
 export interface CardDetailViewProps {
   /** `undefined` while loading, `null` if the card couldn't be found/loaded. */
@@ -104,7 +109,11 @@ export function CardDetailView({
             <Text style={styles.cardArtBrand}>TOGATHER</Text>
             <View style={styles.cardArtChip} />
           </View>
-          <Text style={styles.cardArtNumber}>•••• •••• •••• {card.last4}</Text>
+          {/* A card that never issued has no last4; four more dots is the
+              honest placeholder, and it keeps the art from ending mid-air. */}
+          <Text style={styles.cardArtNumber}>
+            •••• •••• •••• {card.last4 ?? "••••"}
+          </Text>
           <View style={styles.cardArtMetaRow}>
             <CardArtMetaItem label="Cardholder" value={card.holderName} />
             <CardArtMetaItem label="Expires" value="••/••" />
@@ -128,11 +137,26 @@ export function CardDetailView({
             </Text>
           </View>
         )}
+        {/* The failure, in the provider's own words when the viewer is
+            entitled to them. `getCardDetail` decides that — `failureMessage`
+            is null for anyone without the community's financial controls, and
+            they keep the generic line. The message is UNTRUSTED provider text:
+            it goes through <Text> (never markup) and is capped at four lines,
+            because a 300-character apology pushes the rest of the screen off
+            the bottom. */}
         {isFailed && (
-          <View style={[styles.frozenStrip, { backgroundColor: colors.surface }]}>
+          <View
+            style={[styles.frozenStrip, { backgroundColor: colors.surface }]}
+            testID="card-failed-strip"
+          >
             <Ionicons name="alert-circle-outline" size={16} color={colors.error} />
-            <Text style={[styles.frozenStripText, { color: colors.error }]}>
-              Something went wrong issuing this card. Contact support.
+            <Text
+              style={[styles.frozenStripText, { color: colors.error }]}
+              numberOfLines={4}
+            >
+              {card.failureMessage
+                ? `This card couldn't be issued: ${card.failureMessage}`
+                : CARD_FAILED_GENERIC_MESSAGE}
             </Text>
           </View>
         )}

--- a/apps/mobile/features/finance/leader/CommunityFinanceHomeScreen.tsx
+++ b/apps/mobile/features/finance/leader/CommunityFinanceHomeScreen.tsx
@@ -1,0 +1,190 @@
+/**
+ * CommunityFinanceHomeScreen — data wrapper for `/finance-setup`, the
+ * community's Finance home (ADR-032 §2, ADR-033 §5). Owns the screen chrome
+ * and hands plain props to CommunityFinanceHomeView.
+ *
+ * IT ABSORBS THE ONBOARDING CHECKLIST rather than sitting beside it. While the
+ * community's giving isn't live, this route still renders the checklist — the
+ * setup flow is the only thing there is to do, and its own deep links
+ * (`/finance-setup/intake`, Stripe's return URL) keep working untouched. The
+ * moment it goes live the checklist has nothing left to say, so the home takes
+ * over: before this split, a finished community landed on four ticked boxes
+ * and a dead end.
+ *
+ * Same two-layer gate as CardProviderScreen and FinancialControlsScreen:
+ * `user?.is_admin` decides whether the queries run at all, and
+ * `CommunityFinanceAccessBoundary` catches the community-admin-without-a-grant
+ * case that `getCommunityFinanceOverview` refuses. See CommunityFinanceAccess.tsx.
+ */
+import React, { useState } from "react";
+import { View, StyleSheet } from "react-native";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useAuth } from "@providers/AuthProvider";
+import {
+  useAuthenticatedQuery,
+  useAuthenticatedMutation,
+  api,
+} from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { useTheme } from "@hooks/useTheme";
+import { ToastManager } from "@components/ui";
+import { WaSubScreenHeader } from "@components/wa";
+import { formatError } from "@/utils/error-handling";
+import {
+  CommunityFinanceHomeView,
+  COMMUNITY_FINANCE_HOME_DENIED_MESSAGE,
+  type CommunityFinanceHomeState,
+} from "./CommunityFinanceHomeView";
+import {
+  CommunityFinanceAccessBoundary,
+  CommunityFinanceAccessDenied,
+} from "./CommunityFinanceAccess";
+import { FinanceOnboardingStatusContent } from "./FinanceOnboardingStatusScreen";
+import type { CommunityFinanceOverview } from "./types";
+
+export function CommunityFinanceHomeScreen() {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  const handleBack = () => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.push("/(tabs)" as any);
+    }
+  };
+
+  return (
+    <View
+      style={[
+        styles.screen,
+        { backgroundColor: colors.backgroundGrouped, paddingTop: insets.top },
+      ]}
+    >
+      <WaSubScreenHeader title="Finance" onBack={handleBack} />
+      <CommunityFinanceAccessBoundary
+        fallback={
+          <CommunityFinanceAccessDenied
+            message={COMMUNITY_FINANCE_HOME_DENIED_MESSAGE}
+          />
+        }
+      >
+        <CommunityFinanceHomeContent />
+      </CommunityFinanceAccessBoundary>
+    </View>
+  );
+}
+
+/** Split from the screen so the boundary sits between the chrome and the query. */
+function CommunityFinanceHomeContent() {
+  const router = useRouter();
+  const { user, community, isLoading: isAuthLoading } = useAuth();
+  const communityId = community?.id as Id<"communities"> | undefined;
+  const isCommunityAdmin = user?.is_admin === true;
+
+  const raw = useAuthenticatedQuery(
+    api.functions.finance.giving.getCommunityFinanceOverview,
+    communityId && isCommunityAdmin ? { communityId } : "skip",
+  );
+
+  const enableGroupGiving = useAuthenticatedMutation(
+    api.functions.finance.onboarding.enableGroupGiving,
+  );
+  const [enablingGroupId, setEnablingGroupId] = useState<string | null>(null);
+
+  const state: CommunityFinanceHomeState =
+    !isAuthLoading && !isCommunityAdmin
+      ? "not-allowed"
+      : raw === undefined
+        ? "loading"
+        : "ready";
+
+  const overview: CommunityFinanceOverview | undefined = raw
+    ? toOverview(raw)
+    : undefined;
+
+  const handleEnableGiving = async (groupId: string) => {
+    if (!communityId || enablingGroupId) return;
+    setEnablingGroupId(groupId);
+    try {
+      await enableGroupGiving({
+        communityId,
+        groupId: groupId as Id<"groups">,
+      });
+      ToastManager.success("Giving enabled for this group");
+    } catch (error) {
+      ToastManager.error(formatError(error, "Failed to enable giving"));
+    } finally {
+      setEnablingGroupId(null);
+    }
+  };
+
+  // The checklist takeover. Deliberately AFTER the hooks above, never inside a
+  // condition — and only once the query has answered, so a live community
+  // doesn't flash the setup flow on every open.
+  if (overview && overview.onboardingStatus !== "live") {
+    return <FinanceOnboardingStatusContent />;
+  }
+
+  return (
+    <CommunityFinanceHomeView
+      state={state}
+      overview={overview}
+      onOpenFund={(groupId) =>
+        router.push(`/(user)/leader-tools/${groupId}/giving` as any)
+      }
+      onEnableGiving={handleEnableGiving}
+      enablingGroupId={enablingGroupId}
+      onOpenCardProvider={() => router.push("/finance-setup/card-provider" as any)}
+      onOpenFinancialControls={() =>
+        router.push("/finance-setup/financial-controls" as any)
+      }
+      onOpenOrganizationDetails={() => router.push("/finance-setup/intake" as any)}
+    />
+  );
+}
+
+function toOverview(raw: any): CommunityFinanceOverview {
+  return {
+    onboardingStatus: raw.onboardingStatus ?? null,
+    canEnableGiving: !!raw.canEnableGiving,
+    provider: {
+      name: raw.provider?.name ?? "none",
+      connected: !!raw.provider?.connected,
+      accountLabel: raw.provider?.accountLabel ?? null,
+      status: raw.provider?.status ?? null,
+    },
+    totals: {
+      balanceCents: raw.totals?.balanceCents ?? 0,
+      monthDonatedCents: raw.totals?.monthDonatedCents ?? 0,
+      monthSpentCents: raw.totals?.monthSpentCents ?? 0,
+      cardCount: raw.totals?.cardCount ?? 0,
+      fundCount: raw.totals?.fundCount ?? 0,
+    },
+    funds: (raw.funds ?? []).map((fund: any) => ({
+      fundId: String(fund.fundId),
+      groupId: fund.groupId ? String(fund.groupId) : null,
+      groupName: fund.groupName ?? null,
+      fundName: fund.fundName,
+      type: fund.type,
+      status: fund.status,
+      balanceCents: fund.balanceCents,
+      monthDonatedCents: fund.monthDonatedCents,
+      monthSpentCents: fund.monthSpentCents,
+      cardCount: fund.cardCount ?? 0,
+    })),
+    groupsWithoutFunds: (raw.groupsWithoutFunds ?? []).map((group: any) => ({
+      groupId: String(group.groupId),
+      groupName: group.groupName,
+    })),
+    financeGrantCount: raw.financeGrantCount ?? 0,
+  };
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+});

--- a/apps/mobile/features/finance/leader/CommunityFinanceHomeView.tsx
+++ b/apps/mobile/features/finance/leader/CommunityFinanceHomeView.tsx
@@ -1,0 +1,313 @@
+/**
+ * CommunityFinanceHomeView — presentational Finance home for a community
+ * (ADR-032 §2, ADR-033 §5). Plain props only, no Convex — see
+ * CommunityFinanceHomeScreen.tsx for the data wrapper.
+ *
+ * WHY THIS SCREEN EXISTS. Every community-level finance surface used to be a
+ * flat quick link in Community settings, and `/finance-setup` was the
+ * onboarding checklist and nothing else — so a community whose setup was
+ * finished landed on four ticked boxes with no way onward, and there was no
+ * screen anywhere that answered "how much money does this community have, and
+ * which groups can receive it?". This is that screen, and it is the PARENT of
+ * the card-provider and financial-controls ones rather than their sibling.
+ *
+ * Structure, top to bottom, on the `bg.grouped` canvas the wrapper paints
+ * (the GroupInfoScreen/GivingHubView anatomy):
+ *   1. Hero `WaInsetGroup` — total balance across every fund, with this
+ *      month's given and spent underneath.
+ *   2. "Groups & funds" — one cell per fund, then one per group that has no
+ *      fund yet, each with an inline "Enable giving" action.
+ *   3. "Setup" — card provider (with its status inline), financial controls
+ *      (with the holder count inline), and the organization's own details.
+ *
+ * PROVIDER NAMES ARE ALLOWED HERE, and only here. Group-level card surfaces
+ * are provider-ANONYMOUS on purpose (ADR-033 §1: a group didn't choose the
+ * issuer, so it gets the behaviour and not the brand). This community DID
+ * choose it, and "Card provider ›" with no name is exactly the row an admin
+ * has to open to learn anything.
+ */
+import React, { useMemo } from "react";
+import { View, Text, StyleSheet, ScrollView } from "react-native";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+import { waAccentPalette } from "@utils/waPalette";
+import { Skeleton } from "@components/ui";
+import { WaCell, WaInsetGroup } from "@components/wa";
+import {
+  WA_CELL_PADDING,
+  WA_GROUP_MARGIN,
+  WA_GROUP_SPACING,
+  WA_TYPE_FOOTNOTE,
+  WA_TYPE_SUBTITLE,
+} from "@components/wa/metrics";
+import { formatCents } from "../format";
+import { CommunityFinanceAccessDenied } from "./CommunityFinanceAccess";
+import {
+  CARD_PROVIDER_DISPLAY_NAMES,
+  ENABLE_GIVING_LABEL,
+  ENABLE_GIVING_PENDING_LABEL,
+  enableGivingBlockedReason,
+  type CommunityFinanceOverview,
+  type CommunityFundRow,
+} from "./types";
+
+export type CommunityFinanceHomeState = "loading" | "not-allowed" | "ready";
+
+/** Shared by this screen's own not-allowed state and its access boundary's fallback. */
+export const COMMUNITY_FINANCE_HOME_DENIED_MESSAGE =
+  "This community's money — its balances, its card provider, and who can spend from it — is only visible to people who hold its financial controls. Ask your community's primary admin.";
+
+/** Hero balance type size — matches the giving hub's, so the two read as one family. */
+const HERO_BALANCE_SIZE = 36;
+const HERO_LABEL_SIZE = 13.5;
+
+export interface CommunityFinanceHomeViewProps {
+  state: CommunityFinanceHomeState;
+  /** `undefined` while loading. */
+  overview: CommunityFinanceOverview | undefined;
+  /** Opens a fund's group Giving hub ("Fund settings"). */
+  onOpenFund: (groupId: string) => void;
+  /** Turns giving on for a group that has no fund yet. */
+  onEnableGiving: (groupId: string) => void;
+  /** Group id currently being enabled, for the row-level label swap. */
+  enablingGroupId: string | null;
+  onOpenCardProvider: () => void;
+  onOpenFinancialControls: () => void;
+  onOpenOrganizationDetails: () => void;
+}
+
+export function CommunityFinanceHomeView({
+  state,
+  overview,
+  onOpenFund,
+  onEnableGiving,
+  enablingGroupId,
+  onOpenCardProvider,
+  onOpenFinancialControls,
+  onOpenOrganizationDetails,
+}: CommunityFinanceHomeViewProps) {
+  const { colors, isDark } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+  const accent = useMemo(
+    () => waAccentPalette(primaryColor, isDark).accent,
+    [primaryColor, isDark],
+  );
+
+  if (state === "loading" || (state === "ready" && overview === undefined)) {
+    return (
+      <View style={styles.loadingPad} testID="community-finance-home-loading">
+        <Skeleton width="100%" height={120} borderRadius={24} />
+        <Skeleton width="100%" height={160} borderRadius={24} style={{ marginTop: 16 }} />
+      </View>
+    );
+  }
+
+  if (state === "not-allowed" || overview === undefined) {
+    return (
+      <View style={styles.container} testID="community-finance-home-not-allowed">
+        <CommunityFinanceAccessDenied message={COMMUNITY_FINANCE_HOME_DENIED_MESSAGE} />
+      </View>
+    );
+  }
+
+  const { totals, funds, groupsWithoutFunds, provider } = overview;
+  const blockedReason = enableGivingBlockedReason(overview.onboardingStatus);
+
+  return (
+    <View style={styles.container}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* 1. HERO — what the community holds, and this month's movement. */}
+        <WaInsetGroup>
+          <View style={styles.hero}>
+            <Text style={[styles.heroLabel, { color: colors.textSecondary }]}>
+              {totals.fundCount === 1 ? "Across 1 fund" : `Across ${totals.fundCount} funds`}
+            </Text>
+            <Text
+              style={[styles.heroBalance, { color: colors.text }]}
+              testID="community-finance-total-balance"
+            >
+              {formatCents(totals.balanceCents)}
+            </Text>
+            <Text style={[styles.heroMonth, { color: colors.textSecondary }]}>
+              {formatCents(totals.monthDonatedCents)} given ·{" "}
+              {formatCents(totals.monthSpentCents)} spent this month
+            </Text>
+          </View>
+        </WaInsetGroup>
+
+        {/* 2. GROUPS & FUNDS */}
+        <View style={styles.section}>
+          <WaInsetGroup
+            header="Groups & funds"
+            footer={
+              blockedReason ??
+              "Each group's fund keeps its own balance. Tap one to manage its cards, roles, and approvals."
+            }
+          >
+            {funds.length === 0 && groupsWithoutFunds.length === 0 ? (
+              <View key="funds-empty" style={styles.emptyCell}>
+                <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+                  This community has no groups yet.
+                </Text>
+              </View>
+            ) : null}
+
+            {funds.map((fund) => (
+              <WaCell
+                key={fund.fundId}
+                icon={fund.type === "general" ? "business-outline" : "wallet-outline"}
+                title={fund.groupName ?? fund.fundName}
+                description={fundSubtitle(fund)}
+                // The general fund has no group, so there is no "Fund settings"
+                // hub to open — it renders as a read-only line rather than a
+                // chevron that goes nowhere.
+                onPress={fund.groupId ? () => onOpenFund(fund.groupId!) : undefined}
+                trailingAccessory={fund.groupId ? undefined : <View />}
+                testID={`community-finance-fund-${fund.fundId}`}
+              />
+            ))}
+
+            {groupsWithoutFunds.map((group) => {
+              const isEnabling = enablingGroupId === group.groupId;
+              return (
+                <WaCell
+                  key={group.groupId}
+                  icon="add-circle-outline"
+                  iconColor={blockedReason ? colors.textTertiary : accent}
+                  title={group.groupName}
+                  description={
+                    isEnabling
+                      ? ENABLE_GIVING_PENDING_LABEL
+                      : blockedReason
+                        ? "Giving unavailable"
+                        : ENABLE_GIVING_LABEL
+                  }
+                  descriptionColor={blockedReason ? undefined : accent}
+                  onPress={
+                    blockedReason || isEnabling
+                      ? undefined
+                      : () => onEnableGiving(group.groupId)
+                  }
+                  disabled={!!blockedReason || isEnabling}
+                  trailingAccessory={<View />}
+                  testID={`community-finance-enable-${group.groupId}`}
+                />
+              );
+            })}
+          </WaInsetGroup>
+        </View>
+
+        {/* 3. SETUP */}
+        <View style={styles.section}>
+          <WaInsetGroup header="Setup">
+            <WaCell
+              icon="card-outline"
+              title="Card provider"
+              description={providerSubtitle(provider)}
+              onPress={onOpenCardProvider}
+              testID="community-finance-card-provider"
+            />
+            <WaCell
+              icon="key-outline"
+              title="Financial controls"
+              description={financialControlsSubtitle(overview.financeGrantCount)}
+              onPress={onOpenFinancialControls}
+              testID="community-finance-controls"
+            />
+            <WaCell
+              icon="document-text-outline"
+              title="Organization details"
+              description="Legal name, EIN, and address"
+              onPress={onOpenOrganizationDetails}
+              testID="community-finance-organization-details"
+            />
+          </WaInsetGroup>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+/** "$250.00 · $30.00 spent this month · 1 card" — the fund's line, in one read. */
+function fundSubtitle(fund: CommunityFundRow): string {
+  const parts = [
+    formatCents(fund.balanceCents),
+    `${formatCents(fund.monthSpentCents)} spent this month`,
+  ];
+  if (fund.cardCount > 0) {
+    parts.push(fund.cardCount === 1 ? "1 card" : `${fund.cardCount} cards`);
+  }
+  if (fund.status !== "active") {
+    parts.push(fund.status === "frozen" ? "Frozen" : "Closed");
+  }
+  return parts.join(" · ");
+}
+
+function providerSubtitle(provider: CommunityFinanceOverview["provider"]): string {
+  const name = CARD_PROVIDER_DISPLAY_NAMES[provider.name];
+  if (provider.name === "none") return "Not connected";
+  if (provider.connected) return `${name} · Connected`;
+  if (provider.status === "error") return `${name} · Needs attention`;
+  if (provider.status === "revoked") return `${name} · Disconnected`;
+  return name;
+}
+
+/**
+ * The primary admin always holds financial controls and has no grant row, so
+ * the count is of everyone it was GIVEN to — the same population the
+ * Financial controls screen lists. Saying "1 person" when the answer is
+ * "the primary admin, plus one" is the kind of small wrongness that makes an
+ * admin distrust the whole screen.
+ */
+function financialControlsSubtitle(grantCount: number): string {
+  if (grantCount === 0) return "Primary admins only";
+  return grantCount === 1
+    ? "Primary admins, plus 1 other"
+    : `Primary admins, plus ${grantCount} others`;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  loadingPad: {
+    padding: WA_GROUP_MARGIN,
+  },
+  scrollContent: {
+    paddingTop: 8,
+    paddingBottom: 32,
+  },
+  section: {
+    marginTop: WA_GROUP_SPACING,
+  },
+  hero: {
+    alignItems: "center",
+    paddingVertical: 20,
+    paddingHorizontal: WA_CELL_PADDING,
+    gap: 4,
+  },
+  heroLabel: {
+    fontSize: HERO_LABEL_SIZE,
+    fontWeight: "600",
+  },
+  heroBalance: {
+    fontSize: HERO_BALANCE_SIZE,
+    fontWeight: "700",
+    fontVariant: ["tabular-nums"],
+  },
+  heroMonth: {
+    fontSize: WA_TYPE_FOOTNOTE,
+    textAlign: "center",
+  },
+  emptyCell: {
+    minHeight: 54,
+    justifyContent: "center",
+    paddingHorizontal: WA_CELL_PADDING,
+  },
+  emptyText: {
+    fontSize: WA_TYPE_SUBTITLE,
+  },
+});

--- a/apps/mobile/features/finance/leader/CommunityFinanceHomeView.tsx
+++ b/apps/mobile/features/finance/leader/CommunityFinanceHomeView.tsx
@@ -46,7 +46,7 @@ import {
   CARD_PROVIDER_DISPLAY_NAMES,
   ENABLE_GIVING_LABEL,
   ENABLE_GIVING_PENDING_LABEL,
-  enableGivingBlockedReason,
+  enableGivingBlockedReasonFor,
   type CommunityFinanceOverview,
   type CommunityFundRow,
 } from "./types";
@@ -111,7 +111,7 @@ export function CommunityFinanceHomeView({
   }
 
   const { totals, funds, groupsWithoutFunds, provider } = overview;
-  const blockedReason = enableGivingBlockedReason(overview.onboardingStatus);
+  const blockedReason = enableGivingBlockedReasonFor(overview);
 
   return (
     <View style={styles.container}>

--- a/apps/mobile/features/finance/leader/CommunityFinanceHomeView.tsx
+++ b/apps/mobile/features/finance/leader/CommunityFinanceHomeView.tsx
@@ -26,12 +26,12 @@
  * choose it, and "Card provider ›" with no name is exactly the row an admin
  * has to open to learn anything.
  */
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { View, Text, StyleSheet, ScrollView } from "react-native";
 import { useTheme } from "@hooks/useTheme";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { waAccentPalette } from "@utils/waPalette";
-import { Skeleton } from "@components/ui";
+import { Skeleton, ConfirmModal } from "@components/ui";
 import { WaCell, WaInsetGroup } from "@components/wa";
 import {
   WA_CELL_PADDING,
@@ -88,6 +88,7 @@ export function CommunityFinanceHomeView({
 }: CommunityFinanceHomeViewProps) {
   const { colors, isDark } = useTheme();
   const { primaryColor } = useCommunityTheme();
+  const [confirmingDetailsEdit, setConfirmingDetailsEdit] = useState(false);
   const accent = useMemo(
     () => waAccentPalette(primaryColor, isDark).accent,
     [primaryColor, isDark],
@@ -217,16 +218,40 @@ export function CommunityFinanceHomeView({
               onPress={onOpenFinancialControls}
               testID="community-finance-controls"
             />
+            {/* THE INTAKE FORM IS NOT AN EDITOR. Its submit calls
+                `startOnboarding`, which sets `onboardingStatus` back to
+                "collecting" unconditionally and re-schedules provisioning —
+                and `prepareDonationIntent` refuses any community that isn't
+                "live", so re-submitting even the unchanged prefilled values
+                stops new donations until Stripe's `account.updated` webhook
+                puts the community back. This screen only ever renders for a
+                LIVE community (the wrapper hands the screen to the checklist
+                otherwise), so that is the only case this row has. Correcting a
+                wrong EIN is still a real need, so the row stays — behind a
+                confirmation that states the consequence BEFORE the tap that
+                causes it, which is this screen's whole thesis. */}
             <WaCell
               icon="document-text-outline"
               title="Organization details"
               description="Legal name, EIN, and address"
-              onPress={onOpenOrganizationDetails}
+              onPress={() => setConfirmingDetailsEdit(true)}
               testID="community-finance-organization-details"
             />
           </WaInsetGroup>
         </View>
       </ScrollView>
+
+      <ConfirmModal
+        visible={confirmingDetailsEdit}
+        title="Editing these pauses giving"
+        message="Changing your organization's details re-submits them to our payments and banking partners, so your community goes back into verification and can't take new donations until it clears. Existing funds and cards are untouched."
+        confirmText="Edit details"
+        onConfirm={() => {
+          setConfirmingDetailsEdit(false);
+          onOpenOrganizationDetails();
+        }}
+        onCancel={() => setConfirmingDetailsEdit(false)}
+      />
     </View>
   );
 }

--- a/apps/mobile/features/finance/leader/CreateCardScreen.tsx
+++ b/apps/mobile/features/finance/leader/CreateCardScreen.tsx
@@ -26,12 +26,13 @@ import {
 } from "./CreateCardView";
 import { financeDisplayName } from "./utils";
 import type { CardholderCandidate, CardLimitPeriod } from "./types";
+import { isCardSlotFull } from "./types";
 
 const CARDHOLDER_ROLES = new Set(["cardholder", "manager", "finance_admin"]);
 
-/** Card statuses that mean the card is dead and doesn't occupy a fund's slot —
- * the client-side mirror of `DEAD_CARD_STATUSES` in cards.ts. */
-const DEAD_CARD_STATUSES = new Set(["canceled", "failed"]);
+// The "does this fund have room for another card?" rule lives in types.ts
+// (`isCardSlotFull`), so the one client-side copy of the server's dead-status
+// denylist is testable on its own and can't drift per screen.
 
 export function CreateCardScreen() {
   const router = useRouter();
@@ -100,15 +101,12 @@ export function CreateCardScreen() {
   const managedLimit = !!cardsRaw?.capabilities?.managedFundLimit;
   const maxCardsPerFund = cardsRaw?.capabilities?.maxCardsPerFund ?? null;
 
-  const liveCardCount = useMemo(
-    () =>
-      (cardsRaw?.cards ?? []).filter(
-        (card: any) => !DEAD_CARD_STATUSES.has(card.status),
-      ).length,
-    [cardsRaw],
+  // A `failed` card doesn't hold the slot — on a one-card-per-fund provider
+  // that is exactly what makes a retry possible after a refused provisioning.
+  const cardSlotFull = useMemo(
+    () => isCardSlotFull(cardsRaw?.cards ?? [], maxCardsPerFund),
+    [cardsRaw, maxCardsPerFund],
   );
-  const cardSlotFull =
-    maxCardsPerFund !== null && liveCardCount >= maxCardsPerFund;
 
   const state: CreateCardState =
     myFundRole === undefined || cardsRaw === undefined

--- a/apps/mobile/features/finance/leader/FinanceOnboardingFormScreen.tsx
+++ b/apps/mobile/features/finance/leader/FinanceOnboardingFormScreen.tsx
@@ -76,7 +76,7 @@ export function FinanceOnboardingFormScreen() {
         </TouchableOpacity>
         <View style={styles.headerContent}>
           <Text style={[styles.headerTitle, { color: colors.text }]}>Set up giving</Text>
-          <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>Church details</Text>
+          <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>Organization details</Text>
         </View>
       </View>
 

--- a/apps/mobile/features/finance/leader/FinanceOnboardingFormView.tsx
+++ b/apps/mobile/features/finance/leader/FinanceOnboardingFormView.tsx
@@ -91,7 +91,7 @@ export function FinanceOnboardingFormView({
         showsVerticalScrollIndicator={false}
       >
       <View style={[styles.section, { backgroundColor: colors.surface }]}>
-        <Text style={[styles.sectionTitle, { color: colors.text }]}>Church details</Text>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Organization details</Text>
         <Text style={[styles.sectionDescription, { color: colors.textSecondary }]}>
           One form, collected once — we submit this to both our payments and banking
           partners on your behalf.
@@ -103,7 +103,7 @@ export function FinanceOnboardingFormView({
           label="Legal name"
           required
           error={errors.legalName}
-          placeholder="First Community Church"
+          placeholder="First Community Inc."
           testID="onboarding-legal-name"
         />
 

--- a/apps/mobile/features/finance/leader/FinanceOnboardingStatusScreen.tsx
+++ b/apps/mobile/features/finance/leader/FinanceOnboardingStatusScreen.tsx
@@ -3,6 +3,13 @@
  * onboarding checklist (ADR-032 §2 step 4). Convex reactivity keeps
  * `getOnboardingStatus` fresh as Stripe/Increase webhooks land, so this
  * screen needs no manual polling.
+ *
+ * `FinanceOnboardingStatusContent` is the same thing WITHOUT chrome, so the
+ * Finance home can take the screen over with this checklist while the
+ * community's giving isn't live yet — and hand it back the moment it is.
+ * Before that split, `/finance-setup` was the checklist and nothing else: a
+ * community whose setup was finished landed on four ticked boxes with no way
+ * onward, which is precisely the dead end the Finance home exists to close.
  */
 import React, { useState } from "react";
 import { View, StyleSheet, TouchableOpacity, Text, Platform } from "react-native";
@@ -34,6 +41,27 @@ const FINANCE_SETUP_DEEP_LINK = `${DOMAIN_CONFIG.appUrl}/finance-setup`;
 export function FinanceOnboardingStatusScreen() {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  return (
+    <View style={{ flex: 1, backgroundColor: colors.surfaceSecondary }}>
+      <View style={[styles.header, { paddingTop: insets.top + 8, backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
+        <TouchableOpacity style={styles.backButton} onPress={() => router.back()} testID="back-button">
+          <Ionicons name="arrow-back" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <View style={styles.headerContent}>
+          <Text style={[styles.headerTitle, { color: colors.text }]}>Community Finance</Text>
+          <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>Set up giving</Text>
+        </View>
+      </View>
+
+      <FinanceOnboardingStatusContent />
+    </View>
+  );
+}
+
+/** The checklist and its two actions, with no screen chrome of its own. */
+export function FinanceOnboardingStatusContent() {
   const router = useRouter();
   const { community } = useAuth();
 
@@ -93,34 +121,22 @@ export function FinanceOnboardingStatusScreen() {
   };
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.surfaceSecondary }}>
-      <View style={[styles.header, { paddingTop: insets.top + 8, backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
-        <TouchableOpacity style={styles.backButton} onPress={() => router.back()} testID="back-button">
-          <Ionicons name="arrow-back" size={24} color={colors.text} />
-        </TouchableOpacity>
-        <View style={styles.headerContent}>
-          <Text style={[styles.headerTitle, { color: colors.text }]}>Community Finance</Text>
-          <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>Set up giving</Text>
-        </View>
-      </View>
-
-      <FinanceOnboardingStatusView
-        isLoading={status === undefined}
-        formSubmitted={!!status?.formSubmitted}
-        providersReady={!!status?.providersReady}
-        paymentsVerified={!!status?.paymentsVerified}
-        bankAccountsReady={!!status?.bankAccountsReady}
-        onboardingStatus={status?.onboardingStatus ?? "collecting"}
-        blockedReason={status?.blockedReason}
-        provisioningError={status?.provisioningError}
-        linkError={linkError}
-        isLoadingLink={isLoadingLink}
-        isRetrying={isRetrying}
-        onStartForm={() => router.push("/finance-setup/intake")}
-        onContinueIdentityVerification={handleContinueIdentityVerification}
-        onRetryProvisioning={handleRetryProvisioning}
-      />
-    </View>
+    <FinanceOnboardingStatusView
+      isLoading={status === undefined}
+      formSubmitted={!!status?.formSubmitted}
+      providersReady={!!status?.providersReady}
+      paymentsVerified={!!status?.paymentsVerified}
+      bankAccountsReady={!!status?.bankAccountsReady}
+      onboardingStatus={status?.onboardingStatus ?? "collecting"}
+      blockedReason={status?.blockedReason}
+      provisioningError={status?.provisioningError}
+      linkError={linkError}
+      isLoadingLink={isLoadingLink}
+      isRetrying={isRetrying}
+      onStartForm={() => router.push("/finance-setup/intake")}
+      onContinueIdentityVerification={handleContinueIdentityVerification}
+      onRetryProvisioning={handleRetryProvisioning}
+    />
   );
 }
 

--- a/apps/mobile/features/finance/leader/FinanceOnboardingStatusView.tsx
+++ b/apps/mobile/features/finance/leader/FinanceOnboardingStatusView.tsx
@@ -1,6 +1,6 @@
 /**
  * FinanceOnboardingStatusView — the community admin's onboarding checklist
- * (ADR-032 §2 step 4: Church details / Identity verification / Bank
+ * (ADR-032 §2 step 4: Organization details / Identity verification / Bank
  * accounts). Plain props only, no Convex — see
  * FinanceOnboardingStatusScreen.tsx for the data wrapper, which relies on
  * Convex reactivity to auto-refresh this as webhooks land.
@@ -103,7 +103,7 @@ export function FinanceOnboardingStatusView({
   const items: ChecklistItem[] = [
     {
       key: "details",
-      title: "Church details",
+      title: "Organization details",
       description: "Legal name, EIN, and address",
       state: formSubmitted ? "done" : "in_progress",
     },
@@ -176,11 +176,11 @@ export function FinanceOnboardingStatusView({
               the intake screen prefills nothing but startOnboarding upserts,
               so resubmitting corrected details is the recovery path. */}
           <Button variant="secondary" onPress={onStartForm} style={styles.editButton}>
-            Edit church details
+            Edit organization details
           </Button>
           <Text style={[styles.helperText, { color: colors.textSecondary }]}>
             Something went wrong creating your accounts. Retrying is safe — no
-            duplicates will be created. If the error points at your church
+            duplicates will be created. If the error points at your organization
             details, edit and resubmit them instead.
           </Text>
           {linkError ? (

--- a/apps/mobile/features/finance/leader/GivingHubScreen.tsx
+++ b/apps/mobile/features/finance/leader/GivingHubScreen.tsx
@@ -28,7 +28,7 @@ import { useMembersPage } from "@features/leader-tools/hooks/useMembersPage";
 import { formatError } from "@/utils/error-handling";
 import { GivingHubView, type GivingHubState } from "./GivingHubView";
 import type { FundCard, GivingExpense, GivingHubBalanceSummary } from "./types";
-import { enableGivingBlockedReason } from "./types";
+import { enableGivingBlockedReasonFor } from "./types";
 
 export function GivingHubScreen() {
   const { colors } = useTheme();
@@ -109,7 +109,12 @@ export function GivingHubScreen() {
     // answered: guessing "member" for a beat renders the dead-end copy at a
     // finance holder and then swaps it, which reads as a bug.
     if (!givingContext) {
-      if (communityFinanceAccess === undefined && !myFundRole) return "loading";
+      // `community?.id` guards the never-answers case: with no active
+      // community the access query is skipped, so it stays `undefined`
+      // forever and waiting on it would wedge this on the spinner.
+      if (community?.id && communityFinanceAccess === undefined && !myFundRole) {
+        return "loading";
+      }
       return canManageCommunityFinance ? "no-fund-admin" : "no-fund-member";
     }
     return "ready";
@@ -119,6 +124,7 @@ export function GivingHubScreen() {
     canManageCommunityFinance,
     communityFinanceAccess,
     myFundRole,
+    community?.id,
   ]);
 
   const expenses: GivingExpense[] = useMemo(
@@ -273,7 +279,7 @@ export function GivingHubScreen() {
           isEnablingGiving={isEnablingGiving}
           enableGivingBlockedReason={
             communityFinanceAccess?.canManage
-              ? enableGivingBlockedReason(communityFinanceAccess.onboardingStatus)
+              ? enableGivingBlockedReasonFor(communityFinanceAccess)
               : null
           }
           onOpenCommunityFinance={openCommunityFinance}

--- a/apps/mobile/features/finance/leader/GivingHubScreen.tsx
+++ b/apps/mobile/features/finance/leader/GivingHubScreen.tsx
@@ -28,6 +28,7 @@ import { useMembersPage } from "@features/leader-tools/hooks/useMembersPage";
 import { formatError } from "@/utils/error-handling";
 import { GivingHubView, type GivingHubState } from "./GivingHubView";
 import type { FundCard, GivingExpense, GivingHubBalanceSummary } from "./types";
+import { enableGivingBlockedReason } from "./types";
 
 export function GivingHubScreen() {
   const { colors } = useTheme();
@@ -83,17 +84,42 @@ export function GivingHubScreen() {
   // removes from these surfaces. Including it would re-admit that whole
   // population client-side and show them the "Enable Giving" CTA below, which
   // can now only throw against `enableGroupGiving`'s new gate — the
-  // affordance-that-only-errors trap cards.ts calls out. (It is also the
-  // wrong community: `is_admin` is scoped to the viewer's ACTIVE community,
-  // while `myFundRole` is computed server-side for the FUND's community.)
-  const canManageCommunityFinance = !!myFundRole?.canManageCommunityFinance;
+  // affordance-that-only-errors trap cards.ts calls out.
+  //
+  // `myFundRole` ALONE cannot answer it on the path that matters. It needs a
+  // `fundId`, and the whole point of the no-fund state is that there isn't
+  // one — so the answer was permanently `false` there and every finance
+  // holder, primary admins included, got the "ask a community admin" dead end
+  // pointing at a screen they were already entitled to use. The community-
+  // level query below has no such dependency, and is non-throwing precisely
+  // so a surface that only needs to decide whether to OFFER an action can ask.
+  // Both are kept: the fund-scoped one still governs the ready state's
+  // controls, where it is computed for the FUND's community rather than the
+  // viewer's active one.
+  const communityFinanceAccess = useAuthenticatedQuery(
+    api.functions.finance.communityRoles.getMyCommunityFinanceAccess,
+    community?.id ? { communityId: community.id as Id<"communities"> } : "skip",
+  );
+  const canManageCommunityFinance =
+    !!myFundRole?.canManageCommunityFinance || !!communityFinanceAccess?.canManage;
 
   const state: GivingHubState = useMemo(() => {
     if (isLoadingGroup || givingContext === undefined) return "loading";
-    if (!givingContext)
+    // Don't decide between the two no-fund states until the access query has
+    // answered: guessing "member" for a beat renders the dead-end copy at a
+    // finance holder and then swaps it, which reads as a bug.
+    if (!givingContext) {
+      if (communityFinanceAccess === undefined && !myFundRole) return "loading";
       return canManageCommunityFinance ? "no-fund-admin" : "no-fund-member";
+    }
     return "ready";
-  }, [isLoadingGroup, givingContext, canManageCommunityFinance]);
+  }, [
+    isLoadingGroup,
+    givingContext,
+    canManageCommunityFinance,
+    communityFinanceAccess,
+    myFundRole,
+  ]);
 
   const expenses: GivingExpense[] = useMemo(
     () => (expensesRaw ?? []).map(toGivingExpense),
@@ -180,6 +206,19 @@ export function GivingHubScreen() {
     }
   };
 
+  /**
+   * This screen lives under `/(user)/leader-tools/...`, i.e. inside the
+   * `(user)` route group that `app/_layout.tsx` presents as a modal. A native
+   * modal sits above every navigator screen, so pushing the ROOT-stack
+   * `/finance-setup` from here would land it BEHIND the still-open modal on
+   * iOS. Dismiss the modal stack first — same pattern as `CommunityPageScreen`'s
+   * `pushOutOfModal` and `SettingsContent`'s.
+   */
+  const openCommunityFinance = () => {
+    if (router.canDismiss?.()) router.dismissAll();
+    router.push("/finance-setup" as never);
+  };
+
   const handleShareFund = async () => {
     if (!group?.shortId) return;
     const groupUrl = DOMAIN_CONFIG.groupShareUrl(group.shortId);
@@ -232,6 +271,12 @@ export function GivingHubScreen() {
           onDeny={handleDeny}
           onEnableGiving={handleEnableGiving}
           isEnablingGiving={isEnablingGiving}
+          enableGivingBlockedReason={
+            communityFinanceAccess?.canManage
+              ? enableGivingBlockedReason(communityFinanceAccess.onboardingStatus)
+              : null
+          }
+          onOpenCommunityFinance={openCommunityFinance}
           onViewRoles={() => router.push(`/(user)/leader-tools/${groupId}/giving/roles`)}
           onCreateCardPress={() => router.push(`/(user)/leader-tools/${groupId}/giving/cards/new` as any)}
           onSharePress={group?.shortId ? handleShareFund : undefined}

--- a/apps/mobile/features/finance/leader/GivingHubView.tsx
+++ b/apps/mobile/features/finance/leader/GivingHubView.tsx
@@ -79,7 +79,11 @@ import type {
   GivingHubBalanceSummary,
   CardStatus,
 } from "./types";
-import { formatCardLimit } from "./types";
+import {
+  formatCardLimit,
+  ENABLE_GIVING_LABEL,
+  ENABLE_GIVING_PENDING_LABEL,
+} from "./types";
 
 export type GivingHubState = "loading" | "no-fund-admin" | "no-fund-member" | "ready";
 
@@ -117,6 +121,15 @@ export interface GivingHubViewProps {
 
   onEnableGiving: () => void;
   isEnablingGiving: boolean;
+  /**
+   * Why `enableGroupGiving` would refuse right now, or `null` when it wouldn't
+   * — `enableGivingBlockedReason`, the same function the Finance home's
+   * per-group rows use, so the two surfaces never disagree about whether
+   * giving can be turned on.
+   */
+  enableGivingBlockedReason?: string | null;
+  /** Opens the community Finance home. Undefined hides the link. */
+  onOpenCommunityFinance?: () => void;
 
   onViewRoles: () => void;
   onCreateCardPress: () => void;
@@ -143,6 +156,8 @@ export function GivingHubView({
   onDeny,
   onEnableGiving,
   isEnablingGiving,
+  enableGivingBlockedReason = null,
+  onOpenCommunityFinance,
   onViewRoles,
   onCreateCardPress,
   onSharePress,
@@ -171,29 +186,57 @@ export function GivingHubView({
     );
   }
 
-  // Not-set-up states: same logic and copy as before the restyle, re-hosted on
-  // the grouped canvas the screen wrapper paints.
+  // Not-set-up states. The ADMIN one turns the action on THIS screen rather
+  // than sending someone to find it: both this and the Finance home's
+  // per-group row call the same `enableGroupGiving` and share their copy
+  // through `types.ts`, so neither can drift into promising something the
+  // other refuses.
   if (state === "no-fund-admin") {
     return (
-      <View style={styles.container}>
+      <View style={styles.container} testID="giving-hub-no-fund-admin">
         <EmptyState
           icon="wallet-outline"
           title="Giving isn't set up for this group yet"
-          message={`Enable giving for ${groupName} so members can donate directly and leaders can spend and reimburse from a group fund.`}
-          actionLabel={isEnablingGiving ? "Enabling…" : "Enable giving for this group"}
-          onAction={onEnableGiving}
+          message={
+            enableGivingBlockedReason
+              ? `${enableGivingBlockedReason} Then you can enable giving for ${groupName} here.`
+              : `Enable giving for ${groupName} so members can donate directly and leaders can spend and reimburse from a group fund.`
+          }
+          // Blocked is a real state, not a disabled button: the precondition is
+          // stated above and the fix lives on the Finance home, which the link
+          // below opens.
+          actionLabel={
+            enableGivingBlockedReason
+              ? undefined
+              : isEnablingGiving
+                ? ENABLE_GIVING_PENDING_LABEL
+                : `${ENABLE_GIVING_LABEL} for this group`
+          }
+          onAction={enableGivingBlockedReason ? undefined : onEnableGiving}
         />
+        {onOpenCommunityFinance ? (
+          <TouchableOpacity
+            onPress={onOpenCommunityFinance}
+            accessibilityRole="button"
+            style={styles.emptyStateLink}
+            testID="giving-hub-open-community-finance"
+          >
+            <Text style={[styles.emptyStateLinkText, { color: accent }]}>
+              Open community Finance
+            </Text>
+          </TouchableOpacity>
+        ) : null}
       </View>
     );
   }
 
   if (state === "no-fund-member") {
     return (
-      <View style={styles.container}>
+      <View style={styles.container} testID="giving-hub-no-fund-member">
         <EmptyState
           icon="wallet-outline"
           title="Giving isn't set up for this group yet"
-          message="Ask a community admin to enable giving for this group from Community Finance settings."
+          message="Ask someone with your community's financial controls to enable giving for this group from Community settings › Finance."
         />
       </View>
     );
@@ -281,7 +324,14 @@ export function GivingHubView({
                 <WaCell
                   key={card.id}
                   icon="card-outline"
-                  title={`${card.name} ·· ${card.last4}`}
+                  // Same guard as the card detail header: a card that never
+                  // issued has no last4, and interpolating it rendered
+                  // "Groceries ·· null" in the roster.
+                  title={
+                    card.last4
+                      ? `${card.name ?? "Card"} ·· ${card.last4}`
+                      : (card.name ?? "Card")
+                  }
                   description={`${card.holderName} · ${formatCardLimit(card, formatCents)}`}
                   onPress={() => onViewCard(card.id)}
                   testID={`giving-hub-card-${card.id}`}
@@ -599,6 +649,15 @@ const styles = StyleSheet.create({
   },
   emptyText: {
     fontSize: WA_TYPE_SUBTITLE,
+  },
+  emptyStateLink: {
+    alignSelf: "center",
+    paddingVertical: 12,
+    paddingHorizontal: WA_CELL_PADDING,
+  },
+  emptyStateLinkText: {
+    fontSize: WA_TYPE_SUBTITLE,
+    fontWeight: WA_WEIGHT_SEMIBOLD,
   },
   cardTrailing: {
     flexDirection: "row",

--- a/apps/mobile/features/finance/leader/__tests__/CardDetailView.test.tsx
+++ b/apps/mobile/features/finance/leader/__tests__/CardDetailView.test.tsx
@@ -35,6 +35,7 @@ function makeCard(overrides: Partial<CardDetail> = {}): CardDetail {
     viewerCanFreeze: true,
     viewerCanUnfreeze: true,
     viewerCanCancel: true,
+    failureMessage: null,
     ...overrides,
   };
 }
@@ -340,6 +341,65 @@ describe("CardDetailView", () => {
       expect(
         screen.getByText(
           "Saved to the fund and sent on to your community's card provider.",
+        ),
+      ).toBeTruthy();
+    });
+  });
+
+  /**
+   * A card that never got issued. Both halves come from a real staging
+   * failure: Privacy refused with "Insufficient privileges to create UNLOCKED
+   * cards" — an account-plan problem the admin could have acted on — and the
+   * screen showed a generic apology above a card whose number read "··null".
+   */
+  describe("a card that failed to issue", () => {
+    it("does not render a null where the digits would be", () => {
+      render(
+        <CardDetailView
+          {...baseProps}
+          card={makeCard({ status: "failed", last4: null })}
+        />,
+      );
+
+      expect(screen.queryByText(/null/)).toBeNull();
+      expect(screen.getByText("•••• •••• •••• ••••")).toBeTruthy();
+    });
+
+    it("surfaces the provider's own reason when the viewer may read it", () => {
+      render(
+        <CardDetailView
+          {...baseProps}
+          card={makeCard({
+            status: "failed",
+            last4: null,
+            failureMessage:
+              "Insufficient privileges to create UNLOCKED cards — this account may not have general-purpose cards enabled.",
+          })}
+        />,
+      );
+
+      expect(screen.getByTestId("card-failed-strip")).toBeTruthy();
+      expect(
+        screen.getByText(/Insufficient privileges to create UNLOCKED cards/),
+      ).toBeTruthy();
+      expect(
+        screen.queryByText(
+          "Something went wrong issuing this card. Contact support.",
+        ),
+      ).toBeNull();
+    });
+
+    it("keeps the generic line for a viewer the server gave no reason to", () => {
+      render(
+        <CardDetailView
+          {...baseProps}
+          card={makeCard({ status: "failed", last4: null, failureMessage: null })}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          "Something went wrong issuing this card. Contact support.",
         ),
       ).toBeTruthy();
     });

--- a/apps/mobile/features/finance/leader/__tests__/CommunityFinanceHomeView.test.tsx
+++ b/apps/mobile/features/finance/leader/__tests__/CommunityFinanceHomeView.test.tsx
@@ -162,6 +162,27 @@ describe("CommunityFinanceHomeView", () => {
       fireEvent.press(screen.getByTestId("community-finance-enable-group-youth"));
       expect(baseProps.onEnableGiving).not.toHaveBeenCalled();
     });
+
+    // The server's `canEnableGiving` is the authority, not the status the
+    // screen happens to be able to read: `enableGroupGiving` also refuses an
+    // archived community, which "live" cannot explain. The action still has
+    // to be withheld, with words rather than a status the row can't map.
+    it("withholds the action whenever the server says it would be refused", () => {
+      render(
+        <CommunityFinanceHomeView
+          {...baseProps}
+          overview={makeOverview({
+            onboardingStatus: "live",
+            canEnableGiving: false,
+          })}
+        />,
+      );
+
+      expect(screen.getByText(/can't be enabled/i)).toBeTruthy();
+      expect(screen.queryByText("Enable giving")).toBeNull();
+      fireEvent.press(screen.getByTestId("community-finance-enable-group-youth"));
+      expect(baseProps.onEnableGiving).not.toHaveBeenCalled();
+    });
   });
 
   describe("setup rows", () => {

--- a/apps/mobile/features/finance/leader/__tests__/CommunityFinanceHomeView.test.tsx
+++ b/apps/mobile/features/finance/leader/__tests__/CommunityFinanceHomeView.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * CommunityFinanceHomeView — the community Finance home.
+ *
+ * What these pin is the thing the founder's staging pass found missing: a
+ * screen that answers "how much money does this community have, and which
+ * groups can receive it?", with the enable-giving action ON it rather than
+ * described in prose pointing somewhere else.
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { CommunityFinanceHomeView } from "../CommunityFinanceHomeView";
+import type { CommunityFinanceOverview } from "../types";
+
+function makeOverview(
+  overrides: Partial<CommunityFinanceOverview> = {},
+): CommunityFinanceOverview {
+  return {
+    onboardingStatus: "live",
+    canEnableGiving: true,
+    provider: {
+      name: "privacy",
+      connected: true,
+      accountLabel: "Grace Church Ops",
+      status: "active",
+    },
+    totals: {
+      balanceCents: 35_000,
+      monthDonatedCents: 5_000,
+      monthSpentCents: 1_800,
+      cardCount: 1,
+      fundCount: 2,
+    },
+    funds: [
+      {
+        fundId: "fund-general",
+        groupId: null,
+        groupName: null,
+        fundName: "General Fund",
+        type: "general",
+        status: "active",
+        balanceCents: 10_000,
+        monthDonatedCents: 1_000,
+        monthSpentCents: 600,
+        cardCount: 0,
+      },
+      {
+        fundId: "fund-worship",
+        groupId: "group-worship",
+        groupName: "Worship Team",
+        fundName: "Worship Team Fund",
+        type: "group",
+        status: "active",
+        balanceCents: 25_000,
+        monthDonatedCents: 4_000,
+        monthSpentCents: 1_200,
+        cardCount: 1,
+      },
+    ],
+    groupsWithoutFunds: [{ groupId: "group-youth", groupName: "Youth" }],
+    financeGrantCount: 1,
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  state: "ready" as const,
+  overview: makeOverview(),
+  onOpenFund: jest.fn(),
+  onEnableGiving: jest.fn(),
+  enablingGroupId: null,
+  onOpenCardProvider: jest.fn(),
+  onOpenFinancialControls: jest.fn(),
+  onOpenOrganizationDetails: jest.fn(),
+};
+
+describe("CommunityFinanceHomeView", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("overview header", () => {
+    it("leads with the community's total balance and this month's movement", () => {
+      render(<CommunityFinanceHomeView {...baseProps} />);
+
+      expect(screen.getByTestId("community-finance-total-balance")).toBeTruthy();
+      expect(screen.getByText("$350.00")).toBeTruthy();
+      expect(screen.getByText("Across 2 funds")).toBeTruthy();
+      expect(
+        screen.getByText("$50.00 given · $18.00 spent this month"),
+      ).toBeTruthy();
+    });
+
+    it("says 'fund' rather than 'funds' when there is one", () => {
+      render(
+        <CommunityFinanceHomeView
+          {...baseProps}
+          overview={makeOverview({
+            totals: { ...makeOverview().totals, fundCount: 1 },
+          })}
+        />,
+      );
+      expect(screen.getByText("Across 1 fund")).toBeTruthy();
+    });
+  });
+
+  describe("groups & funds", () => {
+    it("gives each fund its balance, month spend and live card count in one line", () => {
+      render(<CommunityFinanceHomeView {...baseProps} />);
+
+      expect(screen.getByText("Worship Team")).toBeTruthy();
+      expect(
+        screen.getByText("$250.00 · $12.00 spent this month · 1 card"),
+      ).toBeTruthy();
+      // No cards -> the clause is dropped, not rendered as "0 cards".
+      expect(screen.getByText("$100.00 · $6.00 spent this month")).toBeTruthy();
+    });
+
+    it("opens a group's fund settings when its row is tapped", () => {
+      render(<CommunityFinanceHomeView {...baseProps} />);
+      fireEvent.press(screen.getByTestId("community-finance-fund-fund-worship"));
+      expect(baseProps.onOpenFund).toHaveBeenCalledWith("group-worship");
+    });
+
+    it("leaves the general fund inert — it has no group hub to open", () => {
+      render(<CommunityFinanceHomeView {...baseProps} />);
+      fireEvent.press(screen.getByTestId("community-finance-fund-fund-general"));
+      expect(baseProps.onOpenFund).not.toHaveBeenCalled();
+    });
+
+    it("offers Enable giving on a group that has no fund", () => {
+      render(<CommunityFinanceHomeView {...baseProps} />);
+
+      expect(screen.getByText("Youth")).toBeTruthy();
+      expect(screen.getByText("Enable giving")).toBeTruthy();
+      fireEvent.press(screen.getByTestId("community-finance-enable-group-youth"));
+      expect(baseProps.onEnableGiving).toHaveBeenCalledWith("group-youth");
+    });
+
+    it("shows the row as in-flight while its mutation runs", () => {
+      render(
+        <CommunityFinanceHomeView {...baseProps} enablingGroupId="group-youth" />,
+      );
+      expect(screen.getByText("Enabling…")).toBeTruthy();
+      fireEvent.press(screen.getByTestId("community-finance-enable-group-youth"));
+      expect(baseProps.onEnableGiving).not.toHaveBeenCalled();
+    });
+
+    // enableGroupGiving's own first precondition, restated BEFORE the tap.
+    it("refuses to offer Enable giving until the community's giving is live, and says why", () => {
+      render(
+        <CommunityFinanceHomeView
+          {...baseProps}
+          overview={makeOverview({
+            onboardingStatus: "verifying",
+            canEnableGiving: false,
+          })}
+        />,
+      );
+
+      expect(screen.getByText(/isn't finished yet/i)).toBeTruthy();
+      expect(screen.queryByText("Enable giving")).toBeNull();
+      fireEvent.press(screen.getByTestId("community-finance-enable-group-youth"));
+      expect(baseProps.onEnableGiving).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("setup rows", () => {
+    it("names the provider and its connection state inline", () => {
+      render(<CommunityFinanceHomeView {...baseProps} />);
+      expect(screen.getByText("Privacy.com · Connected")).toBeTruthy();
+
+      fireEvent.press(screen.getByTestId("community-finance-card-provider"));
+      expect(baseProps.onOpenCardProvider).toHaveBeenCalled();
+    });
+
+    it("says 'Not connected' when no provider has been chosen", () => {
+      render(
+        <CommunityFinanceHomeView
+          {...baseProps}
+          overview={makeOverview({
+            provider: {
+              name: "none",
+              connected: false,
+              accountLabel: null,
+              status: null,
+            },
+          })}
+        />,
+      );
+      expect(screen.getByText("Not connected")).toBeTruthy();
+    });
+
+    // The primary admin holds financial controls with no grant row at all, so
+    // the count must never read as the whole population.
+    it("counts financial-controls holders without forgetting the primary admins", () => {
+      render(<CommunityFinanceHomeView {...baseProps} />);
+      expect(screen.getByText("Primary admins, plus 1 other")).toBeTruthy();
+
+      render(
+        <CommunityFinanceHomeView
+          {...baseProps}
+          overview={makeOverview({ financeGrantCount: 0 })}
+        />,
+      );
+      expect(screen.getByText("Primary admins only")).toBeTruthy();
+    });
+
+    it("keeps the organization's own details reachable once setup is done", () => {
+      render(<CommunityFinanceHomeView {...baseProps} />);
+      expect(screen.getByText("Organization details")).toBeTruthy();
+      fireEvent.press(
+        screen.getByTestId("community-finance-organization-details"),
+      );
+      expect(baseProps.onOpenOrganizationDetails).toHaveBeenCalled();
+    });
+
+    // Community-agnostic copy: generic surfaces say "community", never "church".
+    it("never calls the community a church", () => {
+      const { toJSON } = render(<CommunityFinanceHomeView {...baseProps} />);
+      expect(JSON.stringify(toJSON())).not.toMatch(/church/i);
+    });
+  });
+
+  describe("empty and gated states", () => {
+    it("renders a skeleton while the overview is loading", () => {
+      render(
+        <CommunityFinanceHomeView {...baseProps} state="loading" overview={undefined} />,
+      );
+      expect(screen.getByTestId("community-finance-home-loading")).toBeTruthy();
+    });
+
+    it("explains the refusal rather than showing an empty screen", () => {
+      render(
+        <CommunityFinanceHomeView
+          {...baseProps}
+          state="not-allowed"
+          overview={undefined}
+        />,
+      );
+      expect(screen.getByTestId("community-finance-home-not-allowed")).toBeTruthy();
+      expect(screen.getByText("You need financial-controls access")).toBeTruthy();
+    });
+
+    it("a community with no funds yet still lists every group it could enable", () => {
+      render(
+        <CommunityFinanceHomeView
+          {...baseProps}
+          overview={makeOverview({
+            funds: [],
+            totals: {
+              balanceCents: 0,
+              monthDonatedCents: 0,
+              monthSpentCents: 0,
+              cardCount: 0,
+              fundCount: 0,
+            },
+            groupsWithoutFunds: [
+              { groupId: "group-worship", groupName: "Worship Team" },
+              { groupId: "group-youth", groupName: "Youth" },
+            ],
+          })}
+        />,
+      );
+
+      expect(screen.getByText("$0.00")).toBeTruthy();
+      expect(screen.getAllByText("Enable giving")).toHaveLength(2);
+    });
+
+    it("says so plainly when the community has no groups at all", () => {
+      render(
+        <CommunityFinanceHomeView
+          {...baseProps}
+          overview={makeOverview({
+            funds: [],
+            groupsWithoutFunds: [],
+            totals: {
+              balanceCents: 0,
+              monthDonatedCents: 0,
+              monthSpentCents: 0,
+              cardCount: 0,
+              fundCount: 0,
+            },
+          })}
+        />,
+      );
+      expect(screen.getByText("This community has no groups yet.")).toBeTruthy();
+    });
+  });
+});

--- a/apps/mobile/features/finance/leader/__tests__/CommunityFinanceHomeView.test.tsx
+++ b/apps/mobile/features/finance/leader/__tests__/CommunityFinanceHomeView.test.tsx
@@ -226,12 +226,21 @@ describe("CommunityFinanceHomeView", () => {
       expect(screen.getByText("Primary admins only")).toBeTruthy();
     });
 
-    it("keeps the organization's own details reachable once setup is done", () => {
+    // The intake form re-runs onboarding (`startOnboarding` drops the status
+    // back to "collecting"), which stops new donations until verification
+    // clears. The row stays — a wrong EIN has to be fixable — but the
+    // consequence is stated BEFORE the tap that causes it, not after.
+    it("warns that editing the organization's details pauses giving, and only then opens the form", () => {
       render(<CommunityFinanceHomeView {...baseProps} />);
       expect(screen.getByText("Organization details")).toBeTruthy();
+
       fireEvent.press(
         screen.getByTestId("community-finance-organization-details"),
       );
+      expect(baseProps.onOpenOrganizationDetails).not.toHaveBeenCalled();
+      expect(screen.getByText(/can't take new donations/i)).toBeTruthy();
+
+      fireEvent.press(screen.getByText("Edit details"));
       expect(baseProps.onOpenOrganizationDetails).toHaveBeenCalled();
     });
 

--- a/apps/mobile/features/finance/leader/__tests__/FinanceOnboardingStatusView.test.tsx
+++ b/apps/mobile/features/finance/leader/__tests__/FinanceOnboardingStatusView.test.tsx
@@ -116,7 +116,7 @@ describe("FinanceOnboardingStatusView", () => {
     expect(baseProps.onRetryProvisioning).toHaveBeenCalled();
     // Deterministic provider rejections need corrected data, not a retry —
     // the failure state must offer a path back to the intake form.
-    fireEvent.press(screen.getByText("Edit church details"));
+    fireEvent.press(screen.getByText("Edit organization details"));
     expect(baseProps.onStartForm).toHaveBeenCalled();
     expect(screen.queryByText("Continue identity verification")).toBeNull();
   });

--- a/apps/mobile/features/finance/leader/__tests__/GivingHubView.test.tsx
+++ b/apps/mobile/features/finance/leader/__tests__/GivingHubView.test.tsx
@@ -304,18 +304,68 @@ describe("GivingHubView", () => {
     });
   });
 
+  /**
+   * The no-fund states are the ones the founder hit on staging: a finance
+   * holder was shown the non-holder's "ask a community admin" copy, which is a
+   * dead end pointing at a screen they were already entitled to use. These
+   * pin BOTH viewer classes — the action for the holder, the honest referral
+   * for everyone else.
+   */
   describe("top-level states", () => {
-    it("renders the enable-giving CTA for community admins when no fund exists", () => {
-      render(<GivingHubView {...baseProps} state="no-fund-admin" expenses={[]} />);
+    it("renders the enable-giving CTA for finance holders when no fund exists", () => {
+      const onEnableGiving = jest.fn();
+      render(
+        <GivingHubView
+          {...baseProps}
+          state="no-fund-admin"
+          expenses={[]}
+          onEnableGiving={onEnableGiving}
+        />,
+      );
 
-      expect(screen.getByText("Enable giving for this group")).toBeTruthy();
+      fireEvent.press(screen.getByText("Enable giving for this group"));
+      expect(onEnableGiving).toHaveBeenCalled();
     });
 
-    it("renders an explainer (no CTA) for non-admins when no fund exists", () => {
+    it("links a finance holder to the Finance home from the empty state", () => {
+      const onOpenCommunityFinance = jest.fn();
+      render(
+        <GivingHubView
+          {...baseProps}
+          state="no-fund-admin"
+          expenses={[]}
+          onOpenCommunityFinance={onOpenCommunityFinance}
+        />,
+      );
+
+      fireEvent.press(screen.getByTestId("giving-hub-open-community-finance"));
+      expect(onOpenCommunityFinance).toHaveBeenCalled();
+    });
+
+    // Same precondition text the Finance home's per-group rows use.
+    it("states the precondition instead of a button that could only fail", () => {
+      render(
+        <GivingHubView
+          {...baseProps}
+          state="no-fund-admin"
+          expenses={[]}
+          enableGivingBlockedReason="Your community's giving setup isn't finished yet — finish verification first, then enable groups."
+        />,
+      );
+
+      expect(screen.getByText(/isn't finished yet/i)).toBeTruthy();
+      expect(screen.queryByText("Enable giving for this group")).toBeNull();
+    });
+
+    it("renders an explainer (no CTA) for non-holders when no fund exists", () => {
       render(<GivingHubView {...baseProps} state="no-fund-member" expenses={[]} />);
 
       expect(screen.queryByText("Enable giving for this group")).toBeNull();
-      expect(screen.getByText(/Ask a community admin/)).toBeTruthy();
+      expect(screen.queryByTestId("giving-hub-open-community-finance")).toBeNull();
+      // Names the surface accurately: the referral has to point somewhere the
+      // reader can actually be sent.
+      expect(screen.getByText(/financial controls/i)).toBeTruthy();
+      expect(screen.getByText(/Community settings › Finance/)).toBeTruthy();
     });
   });
 });

--- a/apps/mobile/features/finance/leader/__tests__/cardSlot.test.ts
+++ b/apps/mobile/features/finance/leader/__tests__/cardSlot.test.ts
@@ -1,0 +1,60 @@
+/**
+ * `isCardSlotFull` / `countLiveCards` — the client-side mirror of
+ * `assertFundCardSlotFree` in `apps/convex/functions/finance/cards.ts`.
+ *
+ * The case that matters is RETRY. A card whose provisioning was refused by the
+ * provider (Privacy's "Insufficient privileges to create UNLOCKED cards", the
+ * real staging failure) lands as `failed`, and the server frees the fund's
+ * slot for it — so the Create-card button has to come back. A client denylist
+ * that missed `failed` would leave the fund with one dead card and no way to
+ * replace it, while the server would have said yes all along.
+ */
+import { countLiveCards, isCardSlotFull } from "../types";
+
+describe("countLiveCards", () => {
+  it("counts a pending card — it's a card about to exist at the issuer", () => {
+    expect(countLiveCards([{ status: "pending" }, { status: "active" }])).toBe(2);
+  });
+
+  it("doesn't count the dead ones, in any spelling the DB may hold", () => {
+    expect(
+      countLiveCards([
+        { status: "canceled" },
+        { status: "closed" },
+        { status: "CLOSED" },
+        { status: "failed" },
+      ]),
+    ).toBe(0);
+  });
+
+  it("counts a frozen card — it's disabled, not gone", () => {
+    expect(countLiveCards([{ status: "disabled" }])).toBe(1);
+  });
+});
+
+describe("isCardSlotFull", () => {
+  it("is never full where the provider declares no cap", () => {
+    expect(
+      isCardSlotFull([{ status: "active" }, { status: "active" }], null),
+    ).toBe(false);
+  });
+
+  it("is full at a one-card provider once a live card exists", () => {
+    expect(isCardSlotFull([{ status: "active" }], 1)).toBe(true);
+  });
+
+  // The retry case.
+  it("is NOT full when the fund's only card failed to issue", () => {
+    expect(isCardSlotFull([{ status: "failed" }], 1)).toBe(false);
+  });
+
+  it("stays free after several failed attempts", () => {
+    expect(
+      isCardSlotFull([{ status: "failed" }, { status: "failed" }], 1),
+    ).toBe(false);
+  });
+
+  it("is empty-safe", () => {
+    expect(isCardSlotFull([], 1)).toBe(false);
+  });
+});

--- a/apps/mobile/features/finance/leader/index.ts
+++ b/apps/mobile/features/finance/leader/index.ts
@@ -18,7 +18,10 @@ export { FinanceOnboardingFormScreen } from "./FinanceOnboardingFormScreen";
 export { FinanceOnboardingFormView } from "./FinanceOnboardingFormView";
 export type { FinanceOnboardingFormViewProps, FinanceOnboardingFormValues } from "./FinanceOnboardingFormView";
 
-export { FinanceOnboardingStatusScreen } from "./FinanceOnboardingStatusScreen";
+export {
+  FinanceOnboardingStatusScreen,
+  FinanceOnboardingStatusContent,
+} from "./FinanceOnboardingStatusScreen";
 export { FinanceOnboardingStatusView } from "./FinanceOnboardingStatusView";
 export type { FinanceOnboardingStatusViewProps, ChecklistItemState } from "./FinanceOnboardingStatusView";
 
@@ -32,5 +35,12 @@ export type {
   FinancialControlsViewProps,
   FinancialControlsState,
 } from "./FinancialControlsView";
+
+export { CommunityFinanceHomeScreen } from "./CommunityFinanceHomeScreen";
+export { CommunityFinanceHomeView } from "./CommunityFinanceHomeView";
+export type {
+  CommunityFinanceHomeViewProps,
+  CommunityFinanceHomeState,
+} from "./CommunityFinanceHomeView";
 
 export * from "./types";

--- a/apps/mobile/features/finance/leader/types.ts
+++ b/apps/mobile/features/finance/leader/types.ts
@@ -84,10 +84,12 @@ export type CardLimitPeriod = "week" | "month" | "charge";
 
 export interface FundCard {
   id: string;
-  name: string;
+  /** Null on a card that failed to issue — never interpolate it unguarded. */
+  name: string | null;
   holderUserId: string;
   holderName: string;
-  last4: string;
+  /** Null until the provider issues the card (and forever, if it never does). */
+  last4: string | null;
   status: CardStatus;
   spendLimitCents: number | null;
   limitPeriod: CardLimitPeriod | null;
@@ -151,6 +153,63 @@ export interface CardDetail extends FundCard {
   viewerCanFreeze: boolean;
   viewerCanUnfreeze: boolean;
   viewerCanCancel: boolean;
+  /**
+   * Why a `failed` card was never issued, in the PROVIDER's own words — or
+   * null, which is what every viewer without the community's financial
+   * controls gets. Untrusted vendor text: render it as text, never as markup,
+   * and never let it displace the generic line for people who can't act on it.
+   */
+  failureMessage: string | null;
+}
+
+/** The line a viewer sees when there's no stored reason they may read. */
+export const CARD_FAILED_GENERIC_MESSAGE =
+  "Something went wrong issuing this card. Contact support.";
+
+/**
+ * Card statuses that mean the card is dead and doesn't occupy a fund's slot —
+ * the client-side mirror of `DEAD_CARD_STATUSES` in
+ * `apps/convex/functions/finance/cards.ts`.
+ *
+ * It must contain everything the server's does. Missing an entry doesn't fail
+ * safe: the client would refuse a card the server would happily issue, which
+ * is a fund stuck with no way to replace a dead card. `closed`/`CLOSED` are
+ * the pre-normalization spellings an older build could have written; `failed`
+ * is the one that matters most in practice, because a refused provisioning is
+ * exactly the case where the admin needs to try again.
+ */
+const DEAD_CARD_STATUSES: ReadonlySet<string> = new Set([
+  "canceled",
+  "closed",
+  "CLOSED",
+  "failed",
+]);
+
+/** How many of a fund's cards still occupy its slot. `pending` counts — a row
+ * waiting on the provider is a card about to exist. */
+export function countLiveCards(cards: Array<{ status: string }>): number {
+  return cards.filter((card) => !DEAD_CARD_STATUSES.has(card.status)).length;
+}
+
+/**
+ * Whether the provider's per-fund cap is already used up, so "Create card"
+ * would only error. `null` means the provider declares no cap.
+ */
+export function isCardSlotFull(
+  cards: Array<{ status: string }>,
+  maxCardsPerFund: number | null,
+): boolean {
+  if (maxCardsPerFund === null) return false;
+  return countLiveCards(cards) >= maxCardsPerFund;
+}
+
+/** `listFundCards`' return shape — a fund's card roster plus whether the
+ * viewer can issue new cards (finance_admin, incl. the community-admin
+ * override — same gate `createFundCard` enforces). */
+export interface ListFundCardsResult {
+  cards: FundCard[];
+  viewerCanManageCards: boolean;
+  capabilities: CardCapabilities;
 }
 
 /** A fund member eligible to hold a card — cardholder role or higher. */

--- a/apps/mobile/features/finance/leader/types.ts
+++ b/apps/mobile/features/finance/leader/types.ts
@@ -416,6 +416,13 @@ export const ENABLE_GIVING_PENDING_LABEL = "Enabling…";
  * rather than after it: the mutation's refusals are accurate but they arrive
  * as a toast on a screen that can't act on them, and the fix always lives back
  * on the Finance home.
+ *
+ * The wording has to be true on BOTH callers — the Finance home's per-group
+ * row and the group Giving hub's empty state — so it names the community
+ * Finance screen rather than saying "this screen". In practice the hub is the
+ * only place a blocked reason is ever SEEN: the home hands the whole screen
+ * to the onboarding checklist while the status isn't `"live"`, so "this
+ * screen" would have been wrong every time it rendered.
  */
 export function enableGivingBlockedReason(
   onboardingStatus: OnboardingStatus | null,
@@ -425,13 +432,36 @@ export function enableGivingBlockedReason(
       return null;
     case null:
     case undefined:
-      return "Set up giving for your community first — that's the Setup section on this screen.";
+      return "Set up giving for your community first — that's the Setup section on your community's Finance screen.";
     case "stripe_blocked":
     case "increase_blocked":
       return "Your community's giving setup needs attention before groups can be enabled.";
     default:
       return "Your community's giving setup isn't finished yet — finish verification first, then enable groups.";
   }
+}
+
+/** The words for a refusal the onboarding status alone doesn't explain. */
+export const ENABLE_GIVING_UNAVAILABLE_REASON =
+  "Giving can't be enabled for groups in this community right now.";
+
+/**
+ * The one function both surfaces ask. The SERVER decides whether
+ * `enableGroupGiving` would accept (`canEnableGiving`, computed next to the
+ * mutation's own gate); the status only supplies the words. Deriving the
+ * answer from `onboardingStatus` alone would drift the moment the mutation
+ * refuses for a reason the status can't see — an archived community being the
+ * live example — leaving a button that always errors.
+ */
+export function enableGivingBlockedReasonFor(access: {
+  canEnableGiving: boolean;
+  onboardingStatus: OnboardingStatus | null;
+}): string | null {
+  if (access.canEnableGiving) return null;
+  return (
+    enableGivingBlockedReason(access.onboardingStatus) ??
+    ENABLE_GIVING_UNAVAILABLE_REASON
+  );
 }
 
 /**

--- a/apps/mobile/features/finance/leader/types.ts
+++ b/apps/mobile/features/finance/leader/types.ts
@@ -153,15 +153,6 @@ export interface CardDetail extends FundCard {
   viewerCanCancel: boolean;
 }
 
-/** `listFundCards`' return shape — a fund's card roster plus whether the
- * viewer can issue new cards (finance_admin, incl. the community-admin
- * override — same gate `createFundCard` enforces). */
-export interface ListFundCardsResult {
-  cards: FundCard[];
-  viewerCanManageCards: boolean;
-  capabilities: CardCapabilities;
-}
-
 /** A fund member eligible to hold a card — cardholder role or higher. */
 export interface CardholderCandidate {
   userId: string;
@@ -288,6 +279,101 @@ export interface CommunityFinanceRoleRow {
  */
 export const FINANCIAL_CONTROLS_NOTE =
   "The community's primary admin always has financial controls and is the only person who can give or take them. Anyone they give them to must already be a community admin.";
+
+// ============================================================================
+// Community Finance home (the parent of every surface above)
+// ============================================================================
+
+/** Every issuer a community can be on, as an admin should hear it named. */
+export const CARD_PROVIDER_DISPLAY_NAMES: Record<
+  "increase" | "privacy" | "bill" | "none",
+  string
+> = {
+  increase: "Togather-issued cards",
+  privacy: BYO_PROVIDER_LABELS.privacy.name,
+  bill: BYO_PROVIDER_LABELS.bill.name,
+  none: "Not set up",
+};
+
+/** One fund's line on the Finance home. Mirrors `getCommunityFinanceOverview`. */
+export interface CommunityFundRow {
+  fundId: string;
+  /** Null for the community's general fund, which belongs to no group. */
+  groupId: string | null;
+  groupName: string | null;
+  fundName: string;
+  type: "group" | "general";
+  status: "active" | "frozen" | "closed";
+  balanceCents: number;
+  monthDonatedCents: number;
+  monthSpentCents: number;
+  /** LIVE cards only — a canceled or failed one isn't a card the fund has. */
+  cardCount: number;
+}
+
+/** A group giving could be turned on for. */
+export interface CommunityGroupWithoutFund {
+  groupId: string;
+  groupName: string;
+}
+
+export interface CommunityFinanceOverview {
+  onboardingStatus: OnboardingStatus | null;
+  /** `enableGroupGiving`'s first precondition: the community's giving is live. */
+  canEnableGiving: boolean;
+  provider: {
+    name: "increase" | "privacy" | "bill" | "none";
+    connected: boolean;
+    /** Provider-supplied text — untrusted, rendered as text only. */
+    accountLabel: string | null;
+    status: CardProviderConnectionStatus | null;
+  };
+  totals: {
+    balanceCents: number;
+    monthDonatedCents: number;
+    monthSpentCents: number;
+    cardCount: number;
+    fundCount: number;
+  };
+  funds: CommunityFundRow[];
+  groupsWithoutFunds: CommunityGroupWithoutFund[];
+  /** Active grants. The primary admin holds the controls with no row at all. */
+  financeGrantCount: number;
+}
+
+/**
+ * The label on every "turn giving on for this group" control, wherever it
+ * appears — the Finance home's per-group row and the group Giving hub's empty
+ * state both call `enableGroupGiving`, so they have to say the same thing.
+ */
+export const ENABLE_GIVING_LABEL = "Enable giving";
+export const ENABLE_GIVING_PENDING_LABEL = "Enabling…";
+
+/**
+ * Why "Enable giving" can't be pressed yet, in the admin's words — or `null`
+ * when it can.
+ *
+ * These are `enableGroupGiving`'s OWN preconditions, restated before the tap
+ * rather than after it: the mutation's refusals are accurate but they arrive
+ * as a toast on a screen that can't act on them, and the fix always lives back
+ * on the Finance home.
+ */
+export function enableGivingBlockedReason(
+  onboardingStatus: OnboardingStatus | null,
+): string | null {
+  switch (onboardingStatus) {
+    case "live":
+      return null;
+    case null:
+    case undefined:
+      return "Set up giving for your community first — that's the Setup section on this screen.";
+    case "stripe_blocked":
+    case "increase_blocked":
+      return "Your community's giving setup needs attention before groups can be enabled.";
+    default:
+      return "Your community's giving setup isn't finished yet — finish verification first, then enable groups.";
+  }
+}
 
 /**
  * Giving hub balance header + month-to-date stat tiles. Mirrors the fields


### PR DESCRIPTION
## Summary

Everything the founder hit in live staging testing, plus the missing hub:

- **Modal bug fixed** with the repo's established `dismissAll`-then-push pattern (same fix as four prior screens; `canDismiss()` makes it correct in both shells). Documented trade-off: back returns to the tab shell, not the settings sheet.
- **`/finance-setup` is now the Finance home**: hero totals (balance / month given / month spent / cards), a Groups & funds list (tap → the group's Giving hub), **Enable giving** inline on fund-less groups with preconditions surfaced *before* the tap, provider + financial-controls rows with inline status, and the old onboarding checklist demoted to a Setup section (full-screen only while not yet live). Settings collapses to one Finance row.
- **The Giving-hub dead end was a missing primitive**: the admin empty-state keyed off fund-scoped `getMyFundRole.canManageCommunityFinance` — permanently false with no fund. New non-throwing `getMyCommunityFinanceAccess`; finance holders now get the inline Enable action, shared implementation with the home.
- **Card polish from the live provisioning failure**: `··null` fixed at its root (client typed `last4` as `string` while the server returns null); the stored vendor failure message ("…may not have UNLOCKED cards enabled — check the plan…") now surfaces on card detail **to financial-controls holders only** (group surfaces stay provider-anonymous); retry-after-failure verified and the client's dead-status mirror unified.
- Copy: "Church details" → "Organization details" (community-agnostic rule).

## Evidence
```
convex: 768 passed / 25 files (26 new — overview aggregation, month windowing, gates)
mobile: 420 passed / 29 files (30 new — both shells' navigation, enable flows, render states)
tsc convex clean · zero errors in touched mobile files · eslint clean
```
Overview cost note: no community+time ledger index exists, so the month window fans out per fund over the existing `by_fund` range — bounded by the month; documented in the query.

### Deploy note
Function logic + mobile; no schema. Merge deploys staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcamCRXMUU1DhocRpr59YD