### PR TITLE
fix(polls): let shared-announcements leaders post and moderate polls

### DIFF
--- a/apps/convex/__tests__/messaging/shared-announcements.test.ts
+++ b/apps/convex/__tests__/messaging/shared-announcements.test.ts
@@ -674,6 +674,98 @@ describe("posting rights on a shared announcements channel", () => {
 });
 
 // ============================================================================
+// Moderation rights
+// ============================================================================
+
+describe("poll moderation on a shared announcements channel", () => {
+  /** Owner-group leader posts a poll; returns its pollId. */
+  async function ownerPoll(
+    t: ReturnType<typeof convexTest>,
+    data: SeedData
+  ): Promise<Id<"polls">> {
+    const { pollId } = await t.mutation(
+      api.functions.messaging.polls.createPoll,
+      {
+        token: data.ownerLeaderToken,
+        channelId: data.ownerAnnouncementsChannelId,
+        question: "Owner leader poll",
+        options: ["Yes", "No"],
+        allowMultiple: false,
+      }
+    );
+    return pollId;
+  }
+
+  // A leader of an accepted secondary group is mirrored to channel role
+  // "admin" by the membership sync, which already lets them delete plain
+  // messages in the shared channel. Poll moderation must match — otherwise
+  // the same person can delete a text announcement but not the poll next to
+  // it.
+  test("leader of an accepted secondary group can close another leader's poll", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const pollId = await ownerPoll(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await t.mutation(api.functions.messaging.polls.closePoll, {
+      token: data.secondaryLeaderToken,
+      pollId,
+    });
+
+    const poll = await t.run((ctx) => ctx.db.get(pollId));
+    expect(poll?.status).toBe("closed");
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("leader of an accepted secondary group can delete another leader's poll", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const pollId = await ownerPoll(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await t.mutation(api.functions.messaging.polls.deletePoll, {
+      token: data.secondaryLeaderToken,
+      pollId,
+    });
+
+    const poll = await t.run((ctx) => ctx.db.get(pollId));
+    expect(poll).toBeNull();
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("non-leader member of an accepted secondary group cannot close a poll", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const pollId = await ownerPoll(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await expect(
+      t.mutation(api.functions.messaging.polls.closePoll, {
+        token: data.secondaryMemberToken,
+        pollId,
+      })
+    ).rejects.toThrow(/Only the poll author or a leader can close this poll/);
+  });
+});
+
+// ============================================================================
 // Leaving / removal restores the group's own channel
 // ============================================================================
 

--- a/apps/convex/__tests__/messaging/shared-announcements.test.ts
+++ b/apps/convex/__tests__/messaging/shared-announcements.test.ts
@@ -599,6 +599,78 @@ describe("posting rights on a shared announcements channel", () => {
 
     await t.finishAllScheduledFunctions(vi.runAllTimers);
   });
+
+  // Polls and availability requests post through `assertCanPostInChannel`
+  // rather than `sendMessage`. Both must honour the same shared-share rule —
+  // a secondary group's leader who can send a text announcement must also be
+  // able to post a poll in that channel.
+  test("leader of an accepted secondary group can create a poll", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const { messageId, pollId } = await t.mutation(
+      api.functions.messaging.polls.createPoll,
+      {
+        token: data.secondaryLeaderToken,
+        channelId: data.ownerAnnouncementsChannelId,
+        question: "Prayer Night this Friday",
+        options: ["Sign me up!", "Bringing a friend"],
+        allowMultiple: false,
+      }
+    );
+    const message = await t.run((ctx) => ctx.db.get(messageId));
+    expect(message?.channelId).toBe(data.ownerAnnouncementsChannelId);
+    expect(message?.contentType).toBe("poll");
+    expect(message?.pollId).toBe(pollId);
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("non-leader member of an accepted secondary group cannot create a poll", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await expect(
+      t.mutation(api.functions.messaging.polls.createPoll, {
+        token: data.secondaryMemberToken,
+        channelId: data.ownerAnnouncementsChannelId,
+        question: "I should not be able to post",
+        options: ["A", "B"],
+        allowMultiple: false,
+      })
+    ).rejects.toThrow(/Only group leaders can post in Announcements/);
+  });
+
+  test("owning group leader can still create a poll", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedData(t);
+
+    await inviteSecondary(t, data);
+    await acceptShare(t, data);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const { messageId } = await t.mutation(
+      api.functions.messaging.polls.createPoll,
+      {
+        token: data.ownerLeaderToken,
+        channelId: data.ownerAnnouncementsChannelId,
+        question: "Owner leader poll",
+        options: ["Yes", "No"],
+        allowMultiple: false,
+      }
+    );
+    expect(messageId).toBeDefined();
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
 });
 
 // ============================================================================

--- a/apps/convex/__tests__/messaging/shared-channels.test.ts
+++ b/apps/convex/__tests__/messaging/shared-channels.test.ts
@@ -1046,3 +1046,79 @@ describe("linked-group leader channel visibility", () => {
     expect(primaryRow?.isEnabled).toBe(true);
   });
 });
+
+// ============================================================================
+// Poll moderation is NOT conferred by a share on a non-announcements channel
+// ============================================================================
+
+describe("poll moderation on a shared custom channel", () => {
+  // Regression guard. Leaders of an accepted secondary group are mirrored to
+  // channel role "admin" for shared ANNOUNCEMENTS channels only
+  // (`channelIsSharedAnnouncements` in functions/sync/memberships.ts). Other
+  // shared channel types use manual membership, so a secondary group's leader
+  // has no standing here — they may not even be a channel member. Poll
+  // moderation must not hand them rights that `deleteMessage`, which reads the
+  // mirrored channel role, would refuse.
+  test("leader of an accepted secondary group cannot delete a poll in a shared custom channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedSharedChannelTestData(t);
+
+    await t.mutation(api.functions.messaging.sharedChannels.inviteGroupToChannel, {
+      token: data.primaryLeaderToken,
+      channelId: data.channelId,
+      groupId: data.secondaryGroupId,
+    });
+    await t.mutation(api.functions.messaging.sharedChannels.respondToChannelInvite, {
+      token: data.secondaryLeaderToken,
+      channelId: data.channelId,
+      groupId: data.secondaryGroupId,
+      response: "accepted",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const { pollId } = await t.mutation(api.functions.messaging.polls.createPoll, {
+      token: data.primaryLeaderToken,
+      channelId: data.channelId,
+      question: "Primary group poll",
+      options: ["Yes", "No"],
+      allowMultiple: false,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await expect(
+      t.mutation(api.functions.messaging.polls.deletePoll, {
+        token: data.secondaryLeaderToken,
+        pollId,
+      })
+    ).rejects.toThrow(/Only the poll author or a leader can delete this poll/);
+
+    const poll = await t.run((ctx) => ctx.db.get(pollId));
+    expect(poll).not.toBeNull();
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("owning group's leader can still delete a poll in a shared custom channel", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seedSharedChannelTestData(t);
+
+    const { pollId } = await t.mutation(api.functions.messaging.polls.createPoll, {
+      token: data.primaryMemberToken,
+      channelId: data.channelId,
+      question: "Member's poll",
+      options: ["Yes", "No"],
+      allowMultiple: false,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await t.mutation(api.functions.messaging.polls.deletePoll, {
+      token: data.primaryLeaderToken,
+      pollId,
+    });
+
+    const poll = await t.run((ctx) => ctx.db.get(pollId));
+    expect(poll).toBeNull();
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+});

--- a/apps/convex/functions/messaging/helpers.ts
+++ b/apps/convex/functions/messaging/helpers.ts
@@ -49,29 +49,34 @@ export async function isCommunityAdminForChannel(
 }
 
 /**
- * Whether `userId` may post in an announcements channel.
+ * Whether `userId` is a leader of ANY group participating in `channel` — the
+ * owning group, or any group with an ACCEPTED share entry.
  *
- * Announcements channels are leader-broadcast: every active group member is a
- * channel member (so unread counts work) but only group leaders can post.
- * Leadership is read from `groupMembers` rather than the channel-member role
- * because the latter is denormalized at sync time and may lag the
+ * This is the one definition of "leader of this channel", and it's the same
+ * standing the membership sync denormalizes onto `chatChannelMembers.role`
+ * (`isLeaderOfAny` → channel role "admin", see `functions/sync/memberships.ts`).
+ * Leadership is read from `groupMembers` rather than that mirrored channel
+ * role because the mirror is written asynchronously and may lag the
  * source-of-truth.
  *
- * For SHARED announcements channels, leaders of any ACCEPTED secondary group
- * can post too — they're leaders of a group that receives the channel. Pending
- * invitees get nothing (they have no channel membership either).
+ * Two rules ride on it, and they must agree — a leader who can post in a
+ * shared channel is also a moderator of it:
+ * - Posting: announcements channels are leader-broadcast (every active member
+ *   is a channel member so unread counts work, but only leaders post).
+ *   `sendMessage`, polls, and availability requests all gate on this.
+ * - Moderation: editing / closing / deleting a poll, and seeing voter
+ *   identities on an anonymous poll.
  *
- * Every post path into an announcements channel must go through this helper:
- * plain messages (`sendMessage`), polls, and availability requests
- * (`assertCanPostInChannel`). Keeping it in one place is what stopped polls
- * from silently applying a stricter rule than text messages.
+ * Pending (not yet accepted) invitees get nothing — they have no channel
+ * membership either. Returns false for ad-hoc DM channels, which have no
+ * owning group and are author-moderated.
  */
-export async function canPostInAnnouncementsChannel(
+export async function isParticipatingGroupLeader(
   ctx: QueryCtx,
-  channel: Doc<"chatChannels">,
+  channel: Doc<"chatChannels"> | null,
   userId: Id<"users">
 ): Promise<boolean> {
-  if (!channel.groupId) return false;
+  if (!channel?.groupId) return false;
 
   const ownerMembership = await ctx.db
     .query("groupMembers")

--- a/apps/convex/functions/messaging/helpers.ts
+++ b/apps/convex/functions/messaging/helpers.ts
@@ -49,23 +49,32 @@ export async function isCommunityAdminForChannel(
 }
 
 /**
- * Whether `userId` is a leader of ANY group participating in `channel` — the
- * owning group, or any group with an ACCEPTED share entry.
+ * Whether `userId` is a leader of a group participating in `channel`: the
+ * owning group always, plus — on shared ANNOUNCEMENTS channels only — any
+ * group with an ACCEPTED share entry.
  *
- * This is the one definition of "leader of this channel", and it's the same
- * standing the membership sync denormalizes onto `chatChannelMembers.role`
- * (`isLeaderOfAny` → channel role "admin", see `functions/sync/memberships.ts`).
- * Leadership is read from `groupMembers` rather than that mirrored channel
- * role because the mirror is written asynchronously and may lag the
- * source-of-truth.
- *
- * Two rules ride on it, and they must agree — a leader who can post in a
- * shared channel is also a moderator of it:
+ * This is the one definition of "leader of this channel". Two rules ride on
+ * it, and they must agree, since a leader who can post in a channel is also a
+ * moderator of it:
  * - Posting: announcements channels are leader-broadcast (every active member
  *   is a channel member so unread counts work, but only leaders post).
  *   `sendMessage`, polls, and availability requests all gate on this.
  * - Moderation: editing / closing / deleting a poll, and seeing voter
  *   identities on an anonymous poll.
+ *
+ * Leadership is read from `groupMembers` rather than the mirrored
+ * `chatChannelMembers.role` because that mirror is written asynchronously and
+ * may lag the source-of-truth.
+ *
+ * The announcements-only restriction on secondary leaders is deliberate and
+ * matches `channelIsSharedAnnouncements` in `functions/sync/memberships.ts`:
+ * that sync mirrors leaders of accepted secondaries to channel role "admin"
+ * for shared ANNOUNCEMENTS channels and nothing else. Other shared channel
+ * types use manual membership (`addChannelMembers`) and never confer that
+ * standing, so treating a secondary leader as a moderator there would let
+ * someone who isn't even a channel member delete a poll — while the plain
+ * `deleteMessage` path, which reads the mirrored channel role, would reject
+ * that same user.
  *
  * Pending (not yet accepted) invitees get nothing — they have no channel
  * membership either. Returns false for ad-hoc DM channels, which have no
@@ -86,6 +95,8 @@ export async function isParticipatingGroupLeader(
     .filter((q) => q.eq(q.field("leftAt"), undefined))
     .first();
   if (isLeaderRole(ownerMembership?.role)) return true;
+
+  if (channel.channelType !== "announcements") return false;
 
   for (const sharedGroup of channel.sharedGroups ?? []) {
     if (sharedGroup.status !== "accepted") continue;

--- a/apps/convex/functions/messaging/helpers.ts
+++ b/apps/convex/functions/messaging/helpers.ts
@@ -8,6 +8,7 @@ import { ConvexError } from "convex/values";
 import type { MutationCtx, QueryCtx } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { isCommunityAdmin } from "../../lib/permissions";
+import { isLeaderRole } from "../../lib/helpers";
 
 /**
  * Whether `userId` may view this group's channels purely on community-admin
@@ -45,6 +46,55 @@ export async function isCommunityAdminForChannel(
 ): Promise<boolean> {
   if (!channel.groupId) return false;
   return isCommunityAdminForGroup(ctx, channel.groupId, userId);
+}
+
+/**
+ * Whether `userId` may post in an announcements channel.
+ *
+ * Announcements channels are leader-broadcast: every active group member is a
+ * channel member (so unread counts work) but only group leaders can post.
+ * Leadership is read from `groupMembers` rather than the channel-member role
+ * because the latter is denormalized at sync time and may lag the
+ * source-of-truth.
+ *
+ * For SHARED announcements channels, leaders of any ACCEPTED secondary group
+ * can post too — they're leaders of a group that receives the channel. Pending
+ * invitees get nothing (they have no channel membership either).
+ *
+ * Every post path into an announcements channel must go through this helper:
+ * plain messages (`sendMessage`), polls, and availability requests
+ * (`assertCanPostInChannel`). Keeping it in one place is what stopped polls
+ * from silently applying a stricter rule than text messages.
+ */
+export async function canPostInAnnouncementsChannel(
+  ctx: QueryCtx,
+  channel: Doc<"chatChannels">,
+  userId: Id<"users">
+): Promise<boolean> {
+  if (!channel.groupId) return false;
+
+  const ownerMembership = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_group_user", (q) =>
+      q.eq("groupId", channel.groupId!).eq("userId", userId)
+    )
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
+    .first();
+  if (isLeaderRole(ownerMembership?.role)) return true;
+
+  for (const sharedGroup of channel.sharedGroups ?? []) {
+    if (sharedGroup.status !== "accepted") continue;
+    const secondaryMembership = await ctx.db
+      .query("groupMembers")
+      .withIndex("by_group_user", (q) =>
+        q.eq("groupId", sharedGroup.groupId).eq("userId", userId)
+      )
+      .filter((q) => q.eq(q.field("leftAt"), undefined))
+      .first();
+    if (isLeaderRole(secondaryMembership?.role)) return true;
+  }
+
+  return false;
 }
 
 /**

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -26,7 +26,10 @@ import {
 import { checkRateLimit } from "../../lib/rateLimit";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
 import { canAccessEventChannel } from "./eventChat";
-import { isCommunityAdminForChannel } from "./helpers";
+import {
+  canPostInAnnouncementsChannel,
+  isCommunityAdminForChannel,
+} from "./helpers";
 import { resolveChannelCommunityId } from "../../lib/messaging/communityScope";
 import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
 import { truncateChars } from "../../lib/textPreview";
@@ -1365,13 +1368,9 @@ export const sendMessage = mutation({
         }
       }
 
-      // Announcements channels are leader-broadcast: every active group
-      // member is a channel member (so unread counts work) but only group
-      // leaders can post. Block sends from non-leaders here regardless of
-      // channel-member role, since channel role is denormalized at sync time
-      // and may lag the source-of-truth on `groupMembers`. For shared
-      // announcements channels, leaders of any ACCEPTED secondary group can
-      // post too; pending invitees get nothing.
+      // Announcements channels are leader-broadcast — see
+      // `canPostInAnnouncementsChannel` for who counts as a leader (including
+      // leaders of accepted secondary groups on a shared channel).
       if (channel.channelType === "announcements") {
         if (!channelIsLeaderEnabled(channel) || channel.isArchived) {
           throw new Error("This channel is disabled");
@@ -1379,31 +1378,7 @@ export const sendMessage = mutation({
         if (!channel.groupId) {
           throw new Error("Invalid announcements channel");
         }
-        const groupMembership = await ctx.db
-          .query("groupMembers")
-          .withIndex("by_group_user", (q) =>
-            q.eq("groupId", channel.groupId!).eq("userId", userId)
-          )
-          .filter((q) => q.eq(q.field("leftAt"), undefined))
-          .first();
-        let canPost = isLeaderRole(groupMembership?.role);
-        if (!canPost) {
-          for (const sg of channel.sharedGroups ?? []) {
-            if (sg.status !== "accepted") continue;
-            const secondaryMembership = await ctx.db
-              .query("groupMembers")
-              .withIndex("by_group_user", (q) =>
-                q.eq("groupId", sg.groupId).eq("userId", userId)
-              )
-              .filter((q) => q.eq(q.field("leftAt"), undefined))
-              .first();
-            if (isLeaderRole(secondaryMembership?.role)) {
-              canPost = true;
-              break;
-            }
-          }
-        }
-        if (!canPost) {
+        if (!(await canPostInAnnouncementsChannel(ctx, channel, userId))) {
           throw new ConvexError({
             code: "FORBIDDEN",
             message: "Only group leaders can post in Announcements",

--- a/apps/convex/functions/messaging/messages.ts
+++ b/apps/convex/functions/messaging/messages.ts
@@ -27,8 +27,8 @@ import { checkRateLimit } from "../../lib/rateLimit";
 import { DOMAIN_CONFIG } from "@togather/shared/config";
 import { canAccessEventChannel } from "./eventChat";
 import {
-  canPostInAnnouncementsChannel,
   isCommunityAdminForChannel,
+  isParticipatingGroupLeader,
 } from "./helpers";
 import { resolveChannelCommunityId } from "../../lib/messaging/communityScope";
 import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
@@ -1369,7 +1369,7 @@ export const sendMessage = mutation({
       }
 
       // Announcements channels are leader-broadcast — see
-      // `canPostInAnnouncementsChannel` for who counts as a leader (including
+      // `isParticipatingGroupLeader` for who counts as a leader (including
       // leaders of accepted secondary groups on a shared channel).
       if (channel.channelType === "announcements") {
         if (!channelIsLeaderEnabled(channel) || channel.isArchived) {
@@ -1378,7 +1378,7 @@ export const sendMessage = mutation({
         if (!channel.groupId) {
           throw new Error("Invalid announcements channel");
         }
-        if (!(await canPostInAnnouncementsChannel(ctx, channel, userId))) {
+        if (!(await isParticipatingGroupLeader(ctx, channel, userId))) {
           throw new ConvexError({
             code: "FORBIDDEN",
             message: "Only group leaders can post in Announcements",

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -363,7 +363,10 @@ export const voteOnPoll = mutation({
         channel.channelType === "announcements"
       ) {
         const enabled = channelIsLeaderEnabled(channel);
-        if (!enabled && !(await isParticipatingGroupLeader(ctx, channel, userId))) {
+        if (
+          !enabled &&
+          !(await isParticipatingGroupLeader(ctx, channel, userId))
+        ) {
           throw new ConvexError("This channel is disabled");
         }
       }

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -14,7 +14,7 @@
 
 import { v, ConvexError } from "convex/values";
 import { mutation, query } from "../../_generated/server";
-import type { MutationCtx, QueryCtx } from "../../_generated/server";
+import type { MutationCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
@@ -23,13 +23,12 @@ import {
   channelEffectiveEnabledForGroup,
   channelIsLeaderEnabled,
   isCustomChannel,
-  isLeaderRole,
 } from "../../lib/helpers";
 import { getDisplayName, getMediaUrl } from "../../lib/utils";
 import { canAccessEventChannel } from "./eventChat";
 import {
-  canPostInAnnouncementsChannel,
   isCommunityAdminForChannel,
+  isParticipatingGroupLeader,
 } from "./helpers";
 import { generateMessagePreview } from "./messages";
 import { checkRateLimit } from "../../lib/rateLimit";
@@ -124,7 +123,7 @@ export async function assertCanPostInChannel(
     if (!channel.groupId) {
       throw new ConvexError("Invalid announcements channel");
     }
-    if (!(await canPostInAnnouncementsChannel(ctx, channel, userId))) {
+    if (!(await isParticipatingGroupLeader(ctx, channel, userId))) {
       throw new ConvexError({
         code: "FORBIDDEN",
         message: "Only group leaders can post in Announcements",
@@ -179,26 +178,6 @@ export async function assertCanPostInChannel(
       );
     }
   }
-}
-
-/**
- * Whether `userId` is a leader of the group that owns `channel`.
- * Returns false for ad-hoc channels (no group) — author-only moderation.
- */
-async function isChannelGroupLeader(
-  ctx: QueryCtx | MutationCtx,
-  channel: Doc<"chatChannels"> | null,
-  userId: Id<"users">,
-): Promise<boolean> {
-  if (!channel?.groupId) return false;
-  const m = await ctx.db
-    .query("groupMembers")
-    .withIndex("by_group_user", (q) =>
-      q.eq("groupId", channel.groupId!).eq("userId", userId),
-    )
-    .filter((q) => q.eq(q.field("leftAt"), undefined))
-    .first();
-  return isLeaderRole(m?.role);
 }
 
 /**
@@ -384,7 +363,7 @@ export const voteOnPoll = mutation({
         channel.channelType === "announcements"
       ) {
         const enabled = channelIsLeaderEnabled(channel);
-        if (!enabled && !(await isChannelGroupLeader(ctx, channel, userId))) {
+        if (!enabled && !(await isParticipatingGroupLeader(ctx, channel, userId))) {
           throw new ConvexError("This channel is disabled");
         }
       }
@@ -501,7 +480,7 @@ export const editPoll = mutation({
 
     const channel = await ctx.db.get(poll.channelId);
     const isAuthor = poll.authorId === userId;
-    const isLeader = await isChannelGroupLeader(ctx, channel, userId);
+    const isLeader = await isParticipatingGroupLeader(ctx, channel, userId);
     if (!isAuthor && !isLeader) {
       throw new ConvexError({
         code: "FORBIDDEN",
@@ -651,7 +630,7 @@ export const closePoll = mutation({
 
     const channel = await ctx.db.get(poll.channelId);
     const isAuthor = poll.authorId === userId;
-    const isLeader = await isChannelGroupLeader(ctx, channel, userId);
+    const isLeader = await isParticipatingGroupLeader(ctx, channel, userId);
     if (!isAuthor && !isLeader) {
       throw new ConvexError({
         code: "FORBIDDEN",
@@ -683,7 +662,7 @@ export const deletePoll = mutation({
 
     const channel = await ctx.db.get(poll.channelId);
     const isAuthor = poll.authorId === userId;
-    const isLeader = await isChannelGroupLeader(ctx, channel, userId);
+    const isLeader = await isParticipatingGroupLeader(ctx, channel, userId);
     if (!isAuthor && !isLeader) {
       throw new ConvexError({
         code: "FORBIDDEN",
@@ -814,7 +793,7 @@ export const getPoll = query({
       .collect();
 
     const isAuthor = poll.authorId === userId;
-    const isLeader = await isChannelGroupLeader(ctx, channel, userId);
+    const isLeader = await isParticipatingGroupLeader(ctx, channel, userId);
     const canVote = poll.status === "active";
     const canModerate = isAuthor || isLeader;
     const canSeeIdentities = !poll.isAnonymous || isAuthor || isLeader;
@@ -965,7 +944,7 @@ export const getPollVoters = query({
     }
 
     const isAuthor = poll.authorId === userId;
-    const isLeader = await isChannelGroupLeader(ctx, channel, userId);
+    const isLeader = await isParticipatingGroupLeader(ctx, channel, userId);
     const canSeeIdentities =
       !poll.isAnonymous || isAuthor || isLeader;
 

--- a/apps/convex/functions/messaging/polls.ts
+++ b/apps/convex/functions/messaging/polls.ts
@@ -27,7 +27,10 @@ import {
 } from "../../lib/helpers";
 import { getDisplayName, getMediaUrl } from "../../lib/utils";
 import { canAccessEventChannel } from "./eventChat";
-import { isCommunityAdminForChannel } from "./helpers";
+import {
+  canPostInAnnouncementsChannel,
+  isCommunityAdminForChannel,
+} from "./helpers";
 import { generateMessagePreview } from "./messages";
 import { checkRateLimit } from "../../lib/rateLimit";
 
@@ -121,14 +124,7 @@ export async function assertCanPostInChannel(
     if (!channel.groupId) {
       throw new ConvexError("Invalid announcements channel");
     }
-    const groupMembership = await ctx.db
-      .query("groupMembers")
-      .withIndex("by_group_user", (q) =>
-        q.eq("groupId", channel.groupId!).eq("userId", userId),
-      )
-      .filter((q) => q.eq(q.field("leftAt"), undefined))
-      .first();
-    if (!isLeaderRole(groupMembership?.role)) {
+    if (!(await canPostInAnnouncementsChannel(ctx, channel, userId))) {
       throw new ConvexError({
         code: "FORBIDDEN",
         message: "Only group leaders can post in Announcements",


### PR DESCRIPTION
## The bug

A leader of a group that **accepted** a shared announcements channel could send text messages there, but got `Only group leaders can post in Announcements` when posting a poll.

Reported with a screenshot: the New Poll sheet opened fine, only **Send** failed.

## Root cause

The announcements "leaders only" rule existed in three hand-written copies, and only one of them knew about shared channels:

| Path | Owning-group leader | Accepted secondary-group leader |
| --- | --- | --- |
| `sendMessage` (text) | ✅ | ✅ walks `sharedGroups` |
| `assertCanPostInChannel` (polls, availability requests) | ✅ | ❌ **owning group only** |
| `isChannelGroupLeader` (poll moderation) | ✅ | ❌ **owning group only** |

A secondary group's leader is not a member of the owning group at all, so their `groupMembers` lookup came back empty and both poll paths rejected them. `assertCanPostInChannel`'s own doc comment called itself a "mirror of `sendMessage`'s post-permission flow" — it just didn't mirror the shared-channel part.

The `GroupsAndChannels` onboarding guide already documented the intended behavior verbatim — *"Leaders of the owning group **and** of every group that accepted can post."* The spec was right; the code was wrong.

## The fix

One helper, `isParticipatingGroupLeader` in `functions/messaging/helpers.ts`: leader of the owning group always, plus — **on shared announcements channels only** — leaders of any group with an accepted share entry. All three call sites now read from it, so they can't drift again.

The announcements-only scope is deliberate and matches `channelIsSharedAnnouncements` in `functions/sync/memberships.ts`, which mirrors secondary leaders to channel role `admin` for announcements channels and nothing else.

## Adjacent issues fixed

- **Availability requests** — post through the same `assertCanPostInChannel`, so they were broken in shared announcements channels too. Fixed by the same change.
- **Poll moderation** — a secondary leader could delete a plain text announcement (via the mirrored channel `admin` role in `deleteMessage`) but could not edit, close, or delete the poll sitting right next to it. Same person, same channel, two different answers. Now consistent.
- **Anonymous-poll voter identities** — gated on the same helper, so they were hidden from secondary leaders. Fixed alongside.

## Review finding addressed (Codex P1)

The first pass generalized the helper too far — it walked `sharedGroups` for **every** channel type. On shared *custom* channels, membership is manual (`addChannelMembers`) and secondary leaders are never mirrored to `admin`, so that would have let a secondary leader who isn't even a channel member edit, close, or delete polls and unmask anonymous voters, given a `pollId`. `editPoll` / `closePoll` / `deletePoll` have no channel-membership gate of their own, so the helper was the only thing in the way.

Fixed in a756ba2 by restricting the `sharedGroups` walk to announcements channels. Verified the guard is real by temporarily reverting it — the delete succeeds and the regression test fails.

## Not changed

The mobile composer gate was already correct — it resolves leadership against the group being viewed, which is why the poll sheet opened and only the Send failed. This is a server-only fix; no mobile, native, or dependency changes. No onboarding-guide update needed: the guide already describes the now-correct behavior.

## Testing

Wrote the failing tests first. The "leader of an accepted secondary group can create a poll" test reproduced the exact `FORBIDDEN` error from the report before the fix.

Eight new tests:
- `__tests__/messaging/shared-announcements.test.ts` — poll create (secondary leader ✅ / secondary non-leader ❌ / owner leader ✅) and moderation (close ✅ / delete ✅ / non-leader close ❌)
- `__tests__/messaging/shared-channels.test.ts` — the P1 guard: secondary leader **cannot** moderate polls in a shared *custom* channel ❌, owning-group leader still can ✅

Net effect on production code: 49 lines of duplicated permission logic removed, replaced by one documented helper.

- `apps/convex` suite: **181 files, 3384 tests, all passing**
- `tsc --noEmit` on `apps/convex`: clean