### PR TITLE
feat(events): private (unlisted) events

### DIFF
--- a/apps/convex/__tests__/meetings-private-visibility.test.ts
+++ b/apps/convex/__tests__/meetings-private-visibility.test.ts
@@ -327,3 +327,106 @@ describe("creating a private event", () => {
     );
   });
 });
+
+// ============================================================================
+// Regression: the two list queries that never had an audience filter at all.
+// Both scope by group membership and return everything else, which is exactly
+// what "private" must not honour. Caught by review on #766.
+// ============================================================================
+
+describe("private events stay out of the group page and upcoming lists", () => {
+  test("listByGroup hides it from an uninvited group member", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const meetingId = await insertPrivateEvent(t, data);
+
+    const rows = await t.query(api.functions.meetings.index.listByGroup, {
+      token: data.groupOnlyToken,
+      groupId: data.groupId,
+    });
+    expect(rows.map((m: any) => m._id)).not.toContain(meetingId);
+  });
+
+  test("listByGroup hides it from an unauthenticated caller", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const meetingId = await insertPrivateEvent(t, data);
+
+    const rows = await t.query(api.functions.meetings.index.listByGroup, {
+      groupId: data.groupId,
+    });
+    expect(rows.map((m: any) => m._id)).not.toContain(meetingId);
+  });
+
+  test("listByGroup still shows it to the host", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const meetingId = await insertPrivateEvent(t, data);
+
+    const rows = await t.query(api.functions.meetings.index.listByGroup, {
+      token: data.hostToken,
+      groupId: data.groupId,
+    });
+    expect(rows.map((m: any) => m._id)).toContain(meetingId);
+  });
+
+  test("listByGroup still shows it to an invitee", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const meetingId = await insertPrivateEvent(t, data);
+    await invite(t, data, meetingId, data.invitedId);
+
+    const rows = await t.query(api.functions.meetings.index.listByGroup, {
+      token: data.invitedToken,
+      groupId: data.groupId,
+    });
+    expect(rows.map((m: any) => m._id)).toContain(meetingId);
+  });
+
+  test("listByGroup still returns ordinary group events to everyone", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const groupMeetingId = await t.run(async (ctx) =>
+      ctx.db.insert("meetings", {
+        groupId: data.groupId,
+        title: "Regular Group Night",
+        scheduledAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+        meetingType: 1,
+        status: "scheduled",
+        visibility: "group",
+        createdById: data.hostId,
+        createdAt: Date.now(),
+      })
+    );
+
+    const rows = await t.query(api.functions.meetings.index.listByGroup, {
+      groupId: data.groupId,
+    });
+    expect(rows.map((m: any) => m._id)).toContain(groupMeetingId);
+  });
+
+  test("listUpcomingForUser hides it from an uninvited group member", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const meetingId = await insertPrivateEvent(t, data);
+
+    const rows = await t.query(
+      api.functions.meetings.index.listUpcomingForUser,
+      { token: data.groupOnlyToken }
+    );
+    expect(rows.map((m: any) => m._id)).not.toContain(meetingId);
+  });
+
+  test("listUpcomingForUser still shows it to an invitee", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const meetingId = await insertPrivateEvent(t, data);
+    await invite(t, data, meetingId, data.invitedId);
+
+    const rows = await t.query(
+      api.functions.meetings.index.listUpcomingForUser,
+      { token: data.invitedToken }
+    );
+    expect(rows.map((m: any) => m._id)).toContain(meetingId);
+  });
+});

--- a/apps/convex/__tests__/meetings-private-visibility.test.ts
+++ b/apps/convex/__tests__/meetings-private-visibility.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Private (unlisted) events.
+ *
+ * `visibility: "private"` is for a gathering the host wants to keep small: a
+ * Prayer Team night that shouldn't go out to the whole community. It appears
+ * in NO browse, search, or feed on group membership alone. You get in by
+ * holding the link, or by being invited.
+ *
+ * The line these tests pin down: being a member of the hosting group is worth
+ * nothing here. If group membership leaked a private event into someone's
+ * list, the feature would be pointless.
+ *
+ * Note what private deliberately is NOT: sealed. Anyone the link reaches can
+ * open and RSVP — distribution is the control, the same bargain as an unlisted
+ * video. `canAccessMeeting` returning true for any authenticated caller is
+ * therefore correct, not a gap: reaching it means you already hold the id.
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe, vi, afterEach } from "vitest";
+import schema from "../schema";
+import { modules } from "../test.setup";
+import { api } from "../_generated/api";
+import { generateTokens } from "../lib/auth";
+import type { Id } from "../_generated/dataModel";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+vi.useFakeTimers();
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+let phoneSeq = 300;
+
+interface Seed {
+  communityId: Id<"communities">;
+  groupId: Id<"groups">;
+  hostId: Id<"users">;
+  hostToken: string;
+  invitedId: Id<"users">;
+  invitedToken: string;
+  /** In the hosting group, but not invited. Must see nothing. */
+  groupOnlyId: Id<"users">;
+  groupOnlyToken: string;
+}
+
+async function makeUser(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+  groupId: Id<"groups">,
+  role: "leader" | "member",
+  name: string
+) {
+  phoneSeq += 1;
+  const userId = await t.run(async (ctx) => {
+    const id = await ctx.db.insert("users", {
+      firstName: name,
+      lastName: "Tester",
+      phone: `+1555888${String(phoneSeq).padStart(4, "0")}`,
+      phoneVerified: true,
+      activeCommunityId: communityId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await ctx.db.insert("userCommunities", {
+      userId: id,
+      communityId,
+      status: 1,
+      roles: role === "leader" ? 3 : 1,
+      createdAt: Date.now(),
+    });
+    await ctx.db.insert("groupMembers", {
+      userId: id,
+      groupId,
+      role,
+      joinedAt: Date.now(),
+      notificationsEnabled: true,
+    });
+    return id;
+  });
+  const { accessToken } = await generateTokens(userId);
+  return { userId, token: accessToken };
+}
+
+async function seed(t: ReturnType<typeof convexTest>): Promise<Seed> {
+  const { communityId, groupTypeId } = await t.run(async (ctx) => {
+    const communityId = await ctx.db.insert("communities", {
+      name: "Private Events Community",
+      subdomain: "private-events",
+      slug: "private-events",
+      timezone: "America/New_York",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Groups",
+      slug: "small-groups",
+      isActive: true,
+      displayOrder: 1,
+      createdAt: Date.now(),
+    });
+    return { communityId, groupTypeId };
+  });
+
+  const groupId = await t.run(async (ctx) =>
+    ctx.db.insert("groups", {
+      name: "Host Group",
+      communityId,
+      groupTypeId,
+      isPublic: true,
+      isArchived: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+  );
+
+  const host = await makeUser(t, communityId, groupId, "leader", "Host");
+  const invited = await makeUser(t, communityId, groupId, "member", "Invited");
+  const groupOnly = await makeUser(t, communityId, groupId, "member", "GroupOnly");
+
+  return {
+    communityId,
+    groupId,
+    hostId: host.userId,
+    hostToken: host.token,
+    invitedId: invited.userId,
+    invitedToken: invited.token,
+    groupOnlyId: groupOnly.userId,
+    groupOnlyToken: groupOnly.token,
+  };
+}
+
+async function insertPrivateEvent(
+  t: ReturnType<typeof convexTest>,
+  data: Seed,
+  opts: { shortId?: string } = {}
+): Promise<Id<"meetings">> {
+  return t.run(async (ctx) =>
+    ctx.db.insert("meetings", {
+      groupId: data.groupId,
+      title: "Prayer Team Night",
+      scheduledAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      meetingType: 1,
+      status: "scheduled",
+      visibility: "private",
+      rsvpEnabled: true,
+      rsvpOptions: [{ id: 1, label: "Going", enabled: true }],
+      hostUserIds: [data.hostId],
+      shortId: opts.shortId ?? "priv12345",
+      createdById: data.hostId,
+      createdAt: Date.now(),
+    })
+  );
+}
+
+async function invite(
+  t: ReturnType<typeof convexTest>,
+  data: Seed,
+  meetingId: Id<"meetings">,
+  recipientUserId: Id<"users">
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("eventInvites", {
+      meetingId,
+      groupId: data.groupId,
+      communityId: data.communityId,
+      sentById: data.hostId,
+      recipientUserId,
+      channels: ["push"],
+      status: "sent",
+      inviteRound: 1,
+      lastSentAt: Date.now(),
+      createdAt: Date.now(),
+    });
+  });
+}
+
+async function listedFor(
+  t: ReturnType<typeof convexTest>,
+  data: Seed,
+  token: string
+): Promise<string[]> {
+  const result = await t.query(api.functions.meetings.index.communityEvents, {
+    token,
+    communityId: data.communityId,
+  });
+  return result.events.map((e: any) => e.id);
+}
+
+// ============================================================================
+
+describe("private events stay out of listings", () => {
+  test("a group member who wasn't invited does not see it", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const meetingId = await insertPrivateEvent(t, data);
+
+    expect(await listedFor(t, data, data.groupOnlyToken)).not.toContain(
+      meetingId
+    );
+  });
+
+  test("an invited person sees it", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const meetingId = await insertPrivateEvent(t, data);
+    await invite(t, data, meetingId, data.invitedId);
+
+    expect(await listedFor(t, data, data.invitedToken)).toContain(meetingId);
+  });
+
+  test("the host sees their own private event", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const meetingId = await insertPrivateEvent(t, data);
+
+    expect(await listedFor(t, data, data.hostToken)).toContain(meetingId);
+  });
+
+  test("a signed-out visitor sees nothing", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const meetingId = await insertPrivateEvent(t, data);
+
+    const result = await t.query(api.functions.meetings.index.communityEvents, {
+      communityId: data.communityId,
+    });
+    expect(result.events.map((e: any) => e.id)).not.toContain(meetingId);
+  });
+
+  test("a group event is still listed — the exclusion is specific to private", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const groupMeetingId = await t.run(async (ctx) =>
+      ctx.db.insert("meetings", {
+        groupId: data.groupId,
+        title: "Regular Group Night",
+        scheduledAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+        meetingType: 1,
+        status: "scheduled",
+        visibility: "group",
+        createdById: data.hostId,
+        createdAt: Date.now(),
+      })
+    );
+
+    expect(await listedFor(t, data, data.groupOnlyToken)).toContain(
+      groupMeetingId
+    );
+  });
+});
+
+describe("private events are reachable by link", () => {
+  test("anyone with the link can open it", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    await insertPrivateEvent(t, data, { shortId: "linkme123" });
+
+    const detail = await t.query(api.functions.meetings.index.getByShortId, {
+      shortId: "linkme123",
+      token: data.groupOnlyToken,
+    });
+    expect(detail).not.toBeNull();
+    expect(detail?.hasAccess).toBe(true);
+  });
+
+  test("someone with the link can RSVP", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+    const meetingId = await insertPrivateEvent(t, data);
+
+    await t.mutation(api.functions.meetingRsvps.submit, {
+      token: data.groupOnlyToken,
+      meetingId,
+      optionId: 1,
+    });
+
+    const rsvps = await t.run((ctx) =>
+      ctx.db
+        .query("meetingRsvps")
+        .filter((q) => q.eq(q.field("meetingId"), meetingId))
+        .collect()
+    );
+    expect(rsvps).toHaveLength(1);
+  });
+});
+
+describe("creating a private event", () => {
+  test("persists the visibility", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+
+    const meetingId = await t.mutation(api.functions.meetings.index.create, {
+      token: data.hostToken,
+      groupId: data.groupId,
+      scheduledAt: Date.now() + 7 * 86400000,
+      title: "Prayer Team Night",
+      meetingType: 1,
+      visibility: "private",
+    });
+
+    const meeting = await t.run((ctx) =>
+      ctx.db.get(meetingId as Id<"meetings">)
+    );
+    expect(meeting?.visibility).toBe("private");
+    // No audience list to maintain — invites and the link carry it.
+    expect(meeting?.shortId).toBeTruthy();
+  });
+
+  test("a created private event stays out of another member's list", async () => {
+    const t = convexTest(schema, modules);
+    const data = await seed(t);
+
+    const meetingId = await t.mutation(api.functions.meetings.index.create, {
+      token: data.hostToken,
+      groupId: data.groupId,
+      scheduledAt: Date.now() + 7 * 86400000,
+      title: "Prayer Team Night",
+      meetingType: 1,
+      visibility: "private",
+    });
+
+    expect(await listedFor(t, data, data.groupOnlyToken)).not.toContain(
+      meetingId
+    );
+  });
+});

--- a/apps/convex/functions/meetingRsvps.ts
+++ b/apps/convex/functions/meetingRsvps.ts
@@ -13,6 +13,11 @@ import { query, mutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { now, getMediaUrl } from "../lib/utils";
+import {
+  audienceOf,
+  audienceDenialMessage,
+  canAccessMeeting,
+} from "../lib/meetingAudience";
 import { requireAuth, getOptionalAuth } from "../lib/auth";
 import {
   PAST_EVENT_BUFFER_MS,
@@ -473,58 +478,10 @@ export const submit = mutation({
       throw new Error("Cannot RSVP to past event");
     }
 
-    // Check visibility-based membership
-    const visibility = meeting.visibility || "group";
-
-    if (visibility === "group" || visibility === "groups") {
-      // For group-scoped events, user must be an active member of the hosting
-      // group — or, for "groups" visibility, of one of the shared-with groups.
-      const isActiveMember = async (groupId: typeof meeting.groupId) => {
-        const membership = await ctx.db
-          .query("groupMembers")
-          .withIndex("by_group_user", (q) =>
-            q.eq("groupId", groupId).eq("userId", userId)
-          )
-          .first();
-        return (
-          !!membership &&
-          !membership.leftAt &&
-          (!membership.requestStatus ||
-            membership.requestStatus === "accepted")
-        );
-      };
-
-      let allowed = await isActiveMember(meeting.groupId);
-      if (!allowed && visibility === "groups") {
-        for (const sharedGroupId of meeting.visibleGroupIds ?? []) {
-          if (await isActiveMember(sharedGroupId)) {
-            allowed = true;
-            break;
-          }
-        }
-      }
-      if (!allowed) {
-        throw new Error("You must be a group member to RSVP to this event");
-      }
-    } else if (visibility === "community") {
-      // For community-wide events, user must be a member of the community
-      const group = await ctx.db.get(meeting.groupId);
-      if (!group) {
-        throw new Error("Group not found");
-      }
-
-      const communityMembership = await ctx.db
-        .query("userCommunities")
-        .withIndex("by_user_community", (q) =>
-          q.eq("userId", userId).eq("communityId", group.communityId)
-        )
-        .first();
-
-      if (!communityMembership) {
-        throw new Error("You must be a community member to RSVP to this event");
-      }
+    // Audience gate — identical rule to what the event lists render.
+    if (!(await canAccessMeeting(ctx, audienceOf(meeting), userId))) {
+      throw new Error(audienceDenialMessage(meeting, "RSVP to"));
     }
-    // For public events, anyone authenticated can RSVP (no additional check needed)
 
     // Validate the option exists and is enabled
     const rsvpOptions = (meeting.rsvpOptions as RsvpOption[] | null) || [];

--- a/apps/convex/functions/meetings/attendance.ts
+++ b/apps/convex/functions/meetings/attendance.ts
@@ -11,6 +11,11 @@ import { Id, Doc } from "../../_generated/dataModel";
 import { now } from "../../lib/utils";
 import { requireAuth, getOptionalAuth } from "../../lib/auth";
 import { canEditMeeting } from "../../lib/meetingPermissions";
+import {
+  audienceOf,
+  audienceDenialMessage,
+  canAccessMeeting,
+} from "../../lib/meetingAudience";
 
 // ============================================================================
 // Attendance Management
@@ -447,58 +452,10 @@ export const selfReportAttendance = mutation({
       throw new Error("Meeting not found");
     }
 
-    // Check visibility-based membership
-    const visibility = meeting.visibility || "group";
-
-    if (visibility === "group" || visibility === "groups") {
-      // For group-scoped events, user must be an active member of the hosting
-      // group — or, for "groups" visibility, of one of the shared-with groups.
-      const isActiveMember = async (groupId: typeof meeting.groupId) => {
-        const membership = await ctx.db
-          .query("groupMembers")
-          .withIndex("by_group_user", (q) =>
-            q.eq("groupId", groupId).eq("userId", userId)
-          )
-          .first();
-        return (
-          !!membership &&
-          !membership.leftAt &&
-          (!membership.requestStatus ||
-            membership.requestStatus === "accepted")
-        );
-      };
-
-      let allowed = await isActiveMember(meeting.groupId);
-      if (!allowed && visibility === "groups") {
-        for (const sharedGroupId of meeting.visibleGroupIds ?? []) {
-          if (await isActiveMember(sharedGroupId)) {
-            allowed = true;
-            break;
-          }
-        }
-      }
-      if (!allowed) {
-        throw new Error("You must be a group member to attend this event");
-      }
-    } else if (visibility === "community") {
-      // For community-wide events, user must be a member of the community
-      const group = await ctx.db.get(meeting.groupId);
-      if (!group) {
-        throw new Error("Group not found");
-      }
-
-      const communityMembership = await ctx.db
-        .query("userCommunities")
-        .withIndex("by_user_community", (q) =>
-          q.eq("userId", userId).eq("communityId", group.communityId)
-        )
-        .first();
-
-      if (!communityMembership) {
-        throw new Error("You must be a community member to attend this event");
-      }
+    // Audience gate — identical rule to what the event lists render.
+    if (!(await canAccessMeeting(ctx, audienceOf(meeting), userId))) {
+      throw new Error(audienceDenialMessage(meeting, "attend"));
     }
-    // For public events, any authenticated user can report (no additional check needed)
 
     // Check for existing attendance record
     const existing = await ctx.db

--- a/apps/convex/functions/meetings/events.ts
+++ b/apps/convex/functions/meetings/events.ts
@@ -21,6 +21,10 @@ import { Id, Doc } from "../../_generated/dataModel";
 import { getMediaUrl } from "../../lib/utils";
 import { getOptionalAuth } from "../../lib/auth";
 import { PAST_EVENT_BUFFER_MS } from "../../lib/meetingConfig";
+import {
+  isMeetingVisibleTo,
+  resolveViewerTeamIds,
+} from "../../lib/meetingAudience";
 import { getHostUserIds, isMeetingHost } from "../../lib/meetingPermissions";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
@@ -145,8 +149,13 @@ export const listForEventsTab = query({
     );
     const inWindowMeetings = perGroupFetches.flat();
 
+    const windowTeamIds = await resolveViewerTeamIds(
+      ctx,
+      inWindowMeetings,
+      userId
+    );
     const visibleInWindow = inWindowMeetings.filter((m) =>
-      isVisible(m, userId, userGroupIds, isCommunityMember)
+      isVisible(m, userId, userGroupIds, isCommunityMember, windowTeamIds)
     );
 
     // nextUp: upcoming within 48h. Both types; CWE-collapsed. Past floor is
@@ -181,8 +190,13 @@ export const listForEventsTab = query({
       userLeaderGroupIds,
       userRsvpMeetingIds
     );
+    const myEventsTeamIds = await resolveViewerTeamIds(
+      ctx,
+      myEventsMeetings,
+      userId
+    );
     const myEventsVisible = myEventsMeetings.filter((m) =>
-      isVisible(m, userId, userGroupIds, isCommunityMember)
+      isVisible(m, userId, userGroupIds, isCommunityMember, myEventsTeamIds)
     );
     // myEvents shows the exact meeting the user is going to — don't
     // collapse into CWE cards here. If they RSVP'd to "Manhattan Service",
@@ -262,8 +276,9 @@ export const getCommunityWideEventChildren = query({
       })
       .filter(Boolean) as MeetingWithGroup[];
 
+    const viewerTeamIds = await resolveViewerTeamIds(ctx, withGroup, userId);
     const visible = withGroup.filter((m) =>
-      isVisible(m, userId, userGroupIds, isCommunityMember)
+      isVisible(m, userId, userGroupIds, isCommunityMember, viewerTeamIds)
     );
     visible.sort((a, b) => a.scheduledAt - b.scheduledAt);
 
@@ -331,8 +346,9 @@ export const listLaterEvents = query({
       })
       .filter((m): m is MeetingWithGroup => m !== null);
 
+    const viewerTeamIds = await resolveViewerTeamIds(ctx, withGroup, userId);
     const visible = withGroup.filter((m) =>
-      isVisible(m, userId, userGroupIds, isCommunityMember)
+      isVisible(m, userId, userGroupIds, isCommunityMember, viewerTeamIds)
     );
 
     const enrichment = await buildEnrichment(ctx, visible, {
@@ -540,22 +556,27 @@ async function loadMyEventsMeetings(
   return withGroup;
 }
 
+/**
+ * Thin adapter over the shared audience rule in `lib/meetingAudience.ts`.
+ *
+ * `userTeamIds` carries the serving teams the viewer is on, and is only
+ * consulted for `visibility: "team"` events. Callers that never surface
+ * team-scoped events may pass an empty set — team events then stay hidden,
+ * which is the safe direction to fail.
+ */
 export function isVisible(
   m: MeetingWithGroup,
   userId: Id<"users"> | null,
   userGroupIds: Set<string>,
-  isCommunityMember: boolean
+  isCommunityMember: boolean,
+  userTeamIds: Set<string> = new Set()
 ): boolean {
-  const visibility = m.visibility || "group";
-  if (visibility === "public") return true;
-  if (visibility === "community") return userId !== null && isCommunityMember;
-  if (visibility === "groups") {
-    // Visible to members of the hosting group OR any of the explicitly
-    // shared-with groups.
-    if (userGroupIds.has(m.groupId)) return true;
-    return (m.visibleGroupIds ?? []).some((id) => userGroupIds.has(id));
-  }
-  return userGroupIds.has(m.groupId);
+  return isMeetingVisibleTo(m, {
+    userId,
+    groupIds: userGroupIds,
+    teamIds: userTeamIds,
+    isCommunityMember,
+  });
 }
 
 type Enrichment = {

--- a/apps/convex/functions/meetings/events.ts
+++ b/apps/convex/functions/meetings/events.ts
@@ -23,7 +23,7 @@ import { getOptionalAuth } from "../../lib/auth";
 import { PAST_EVENT_BUFFER_MS } from "../../lib/meetingConfig";
 import {
   isMeetingVisibleTo,
-  resolveViewerTeamIds,
+  resolveInvitedMeetingIds,
 } from "../../lib/meetingAudience";
 import { getHostUserIds, isMeetingHost } from "../../lib/meetingPermissions";
 
@@ -149,13 +149,13 @@ export const listForEventsTab = query({
     );
     const inWindowMeetings = perGroupFetches.flat();
 
-    const windowTeamIds = await resolveViewerTeamIds(
+    const windowInvitedIds = await resolveInvitedMeetingIds(
       ctx,
       inWindowMeetings,
       userId
     );
     const visibleInWindow = inWindowMeetings.filter((m) =>
-      isVisible(m, userId, userGroupIds, isCommunityMember, windowTeamIds)
+      isVisible(m, userId, userGroupIds, isCommunityMember, windowInvitedIds)
     );
 
     // nextUp: upcoming within 48h. Both types; CWE-collapsed. Past floor is
@@ -190,13 +190,13 @@ export const listForEventsTab = query({
       userLeaderGroupIds,
       userRsvpMeetingIds
     );
-    const myEventsTeamIds = await resolveViewerTeamIds(
+    const myEventsInvitedIds = await resolveInvitedMeetingIds(
       ctx,
       myEventsMeetings,
       userId
     );
     const myEventsVisible = myEventsMeetings.filter((m) =>
-      isVisible(m, userId, userGroupIds, isCommunityMember, myEventsTeamIds)
+      isVisible(m, userId, userGroupIds, isCommunityMember, myEventsInvitedIds)
     );
     // myEvents shows the exact meeting the user is going to — don't
     // collapse into CWE cards here. If they RSVP'd to "Manhattan Service",
@@ -276,9 +276,9 @@ export const getCommunityWideEventChildren = query({
       })
       .filter(Boolean) as MeetingWithGroup[];
 
-    const viewerTeamIds = await resolveViewerTeamIds(ctx, withGroup, userId);
+    const viewerInvitedIds = await resolveInvitedMeetingIds(ctx, withGroup, userId);
     const visible = withGroup.filter((m) =>
-      isVisible(m, userId, userGroupIds, isCommunityMember, viewerTeamIds)
+      isVisible(m, userId, userGroupIds, isCommunityMember, viewerInvitedIds)
     );
     visible.sort((a, b) => a.scheduledAt - b.scheduledAt);
 
@@ -346,9 +346,9 @@ export const listLaterEvents = query({
       })
       .filter((m): m is MeetingWithGroup => m !== null);
 
-    const viewerTeamIds = await resolveViewerTeamIds(ctx, withGroup, userId);
+    const viewerInvitedIds = await resolveInvitedMeetingIds(ctx, withGroup, userId);
     const visible = withGroup.filter((m) =>
-      isVisible(m, userId, userGroupIds, isCommunityMember, viewerTeamIds)
+      isVisible(m, userId, userGroupIds, isCommunityMember, viewerInvitedIds)
     );
 
     const enrichment = await buildEnrichment(ctx, visible, {
@@ -559,7 +559,7 @@ async function loadMyEventsMeetings(
 /**
  * Thin adapter over the shared audience rule in `lib/meetingAudience.ts`.
  *
- * `userTeamIds` carries the serving teams the viewer is on, and is only
+ * `userInvitedIds` carries the serving teams the viewer is on, and is only
  * consulted for `visibility: "team"` events. Callers that never surface
  * team-scoped events may pass an empty set — team events then stay hidden,
  * which is the safe direction to fail.
@@ -569,12 +569,12 @@ export function isVisible(
   userId: Id<"users"> | null,
   userGroupIds: Set<string>,
   isCommunityMember: boolean,
-  userTeamIds: Set<string> = new Set()
+  userInvitedIds: Set<string> = new Set()
 ): boolean {
   return isMeetingVisibleTo(m, {
     userId,
     groupIds: userGroupIds,
-    teamIds: userTeamIds,
+    invitedMeetingIds: userInvitedIds,
     isCommunityMember,
   });
 }

--- a/apps/convex/functions/meetings/explore.ts
+++ b/apps/convex/functions/meetings/explore.ts
@@ -14,7 +14,7 @@ import { isLeaderRole } from "../../lib/helpers";
 import { isMeetingHost } from "../../lib/meetingPermissions";
 import {
   isMeetingVisibleTo,
-  resolveViewerTeamIds,
+  resolveInvitedMeetingIds,
 } from "../../lib/meetingAudience";
 
 /**
@@ -214,12 +214,12 @@ export const communityEvents = query({
     }
 
     // Filter by visibility
-    const userTeamIds = await resolveViewerTeamIds(ctx, meetings, userId);
+    const userInvitedIds = await resolveInvitedMeetingIds(ctx, meetings, userId);
     meetings = meetings.filter((m) => {
       return isMeetingVisibleTo(m, {
         userId,
         groupIds: userGroupIds,
-        teamIds: userTeamIds,
+        invitedMeetingIds: userInvitedIds,
         isCommunityMember: userCommunityIds.has(args.communityId),
       });
     });
@@ -592,7 +592,7 @@ export const searchEvents = query({
 
     // Filter by date range and visibility
     const currentTime = now();
-    const userTeamIds = await resolveViewerTeamIds(
+    const userInvitedIds = await resolveInvitedMeetingIds(
       ctx,
       searchResults,
       userId
@@ -610,7 +610,7 @@ export const searchEvents = query({
       return isMeetingVisibleTo(meeting, {
         userId,
         groupIds: userGroupIds,
-        teamIds: userTeamIds,
+        invitedMeetingIds: userInvitedIds,
         isCommunityMember,
       });
     });

--- a/apps/convex/functions/meetings/explore.ts
+++ b/apps/convex/functions/meetings/explore.ts
@@ -12,6 +12,10 @@ import { now, getMediaUrl } from "../../lib/utils";
 import { getOptionalAuth } from "../../lib/auth";
 import { isLeaderRole } from "../../lib/helpers";
 import { isMeetingHost } from "../../lib/meetingPermissions";
+import {
+  isMeetingVisibleTo,
+  resolveViewerTeamIds,
+} from "../../lib/meetingAudience";
 
 /**
  * Resolve effective cover images for a batch of meetings, using the CWE
@@ -210,22 +214,14 @@ export const communityEvents = query({
     }
 
     // Filter by visibility
+    const userTeamIds = await resolveViewerTeamIds(ctx, meetings, userId);
     meetings = meetings.filter((m) => {
-      const visibility = m.visibility || "group";
-      if (visibility === "public") return true;
-      if (visibility === "community") {
-        // User must be authenticated AND a member of this community
-        return userId !== null && userCommunityIds.has(args.communityId);
-      }
-      if (visibility === "groups") {
-        // Hosting group members, or members of any explicitly shared-with group.
-        if (userGroupIds.has(m.groupId)) return true;
-        return (m.visibleGroupIds ?? []).some((id) => userGroupIds.has(id));
-      }
-      if (visibility === "group") {
-        return userGroupIds.has(m.groupId);
-      }
-      return false;
+      return isMeetingVisibleTo(m, {
+        userId,
+        groupIds: userGroupIds,
+        teamIds: userTeamIds,
+        isCommunityMember: userCommunityIds.has(args.communityId),
+      });
     });
 
     // Sort by scheduledAt ascending
@@ -596,6 +592,11 @@ export const searchEvents = query({
 
     // Filter by date range and visibility
     const currentTime = now();
+    const userTeamIds = await resolveViewerTeamIds(
+      ctx,
+      searchResults,
+      userId
+    );
     const filtered = searchResults.filter((meeting) => {
       if (!nonArchivedGroupIds.has(meeting.groupId)) return false;
       if (meeting.status === "cancelled") return false;
@@ -605,16 +606,13 @@ export const searchEvents = query({
       if (meeting.scheduledAt < afterCutoff) return false;
       if (args.startBefore && meeting.scheduledAt > args.startBefore) return false;
 
-      // Visibility filtering
-      const visibility = meeting.visibility ?? "group";
-      if (visibility === "public") return true;
-      if (visibility === "community") return isCommunityMember;
-      if (visibility === "groups") {
-        if (userGroupIds.has(meeting.groupId)) return true;
-        return (meeting.visibleGroupIds ?? []).some((id) => userGroupIds.has(id));
-      }
-      // Default "group" visibility: must be member
-      return userGroupIds.has(meeting.groupId);
+      // Visibility filtering — shared rule, see lib/meetingAudience.ts
+      return isMeetingVisibleTo(meeting, {
+        userId,
+        groupIds: userGroupIds,
+        teamIds: userTeamIds,
+        isCommunityMember,
+      });
     });
 
     // Take only the requested number

--- a/apps/convex/functions/meetings/queries.ts
+++ b/apps/convex/functions/meetings/queries.ts
@@ -14,6 +14,10 @@ import { getSeriesNumber } from "../eventSeries";
 import { isLeaderRole } from "../../lib/helpers";
 import { getHostUserIds, isMeetingHost } from "../../lib/meetingPermissions";
 import {
+  audienceOf,
+  canAccessMeeting,
+} from "../../lib/meetingAudience";
+import {
   GOING_RSVP_OPTION_ID,
   MAYBE_RSVP_OPTION_ID,
   CANT_GO_RSVP_OPTION_ID,
@@ -86,46 +90,10 @@ export const getByShortId = query({
       userRole = groupMembership.role || "member";
     }
 
-    // Check visibility-based access
-    const visibility = meeting.visibility || "group";
-    if (visibility === "public") {
-      hasAccess = true;
-    } else if (visibility === "community" && userId) {
-      // Check if user is in the community
-      const communityMembership = await ctx.db
-        .query("userCommunities")
-        .withIndex("by_user_community", (q) =>
-          q.eq("userId", userId).eq("communityId", group.communityId)
-        )
-        .first();
-      hasAccess = !!communityMembership;
-    } else if (groupMembership) {
-      hasAccess = true;
-    } else if (visibility === "groups" && userId) {
-      // Shared with specific groups: grant access to active members of any of
-      // the shared-with groups (the hosting group is already covered above).
-      for (const sharedGroupId of meeting.visibleGroupIds ?? []) {
-        const sharedMembership = await ctx.db
-          .query("groupMembers")
-          .withIndex("by_group_user", (q) =>
-            q.eq("groupId", sharedGroupId).eq("userId", userId)
-          )
-          .filter((q) =>
-            q.and(
-              q.eq(q.field("leftAt"), undefined),
-              q.or(
-                q.eq(q.field("requestStatus"), undefined),
-                q.eq(q.field("requestStatus"), "accepted")
-              )
-            )
-          )
-          .first();
-        if (sharedMembership) {
-          hasAccess = true;
-          break;
-        }
-      }
-    }
+    // Audience gate — one shared rule, see lib/meetingAudience.ts. Note this
+    // deliberately does NOT grant hosting-group members access to a
+    // team-scoped event; staying narrower than the group is the point.
+    hasAccess = await canAccessMeeting(ctx, audienceOf(meeting), userId);
 
     // Get group type name
     const groupType = await ctx.db.get(group.groupTypeId);

--- a/apps/convex/functions/meetings/queries.ts
+++ b/apps/convex/functions/meetings/queries.ts
@@ -16,6 +16,7 @@ import { getHostUserIds, isMeetingHost } from "../../lib/meetingPermissions";
 import {
   audienceOf,
   canAccessMeeting,
+  withoutHiddenPrivateEvents,
 } from "../../lib/meetingAudience";
 import {
   GOING_RSVP_OPTION_ID,
@@ -336,6 +337,10 @@ export const isCommunityWideEvent = query({
  */
 export const listByGroup = query({
   args: {
+    // Optional so existing unauthenticated callers keep working. When absent
+    // we simply can't recognize a host or invitee, so every private event is
+    // withheld — the safe direction to fail.
+    token: v.optional(v.string()),
     groupId: v.id("groups"),
     status: v.optional(meetingStatusValidator),
     startAfter: v.optional(v.number()),
@@ -357,7 +362,10 @@ export const listByGroup = query({
     // Filter by time range and status
     const meetings = await meetingsQuery.take(limit * 3); // Fetch extra for filtering
 
-    const filtered = meetings
+    const viewerId = await getOptionalAuth(ctx, args.token);
+    const visible = await withoutHiddenPrivateEvents(ctx, meetings, viewerId);
+
+    const filtered = visible
       .filter((m) => {
         if (args.status && m.status !== args.status) return false;
         if (args.startAfter && m.scheduledAt < args.startAfter) return false;
@@ -483,12 +491,16 @@ export const listUpcomingForUser = query({
       })
     );
 
-    // Flatten and sort by scheduledAt
-    const meetings = allMeetings
-      .flat()
+    // Flatten and sort by scheduledAt. Private events reach this list purely
+    // through group membership, which is exactly what must not grant access.
+    const meetings = await withoutHiddenPrivateEvents(
+      ctx,
+      allMeetings.flat(),
+      userId
+    );
+
+    return meetings
       .sort((a, b) => a.scheduledAt - b.scheduledAt)
       .slice(0, limit);
-
-    return meetings;
   },
 });

--- a/apps/convex/lib/meetingAudience.ts
+++ b/apps/convex/lib/meetingAudience.ts
@@ -8,10 +8,10 @@
  * - `"community"` — any member of the hosting group's community.
  * - `"group"`     — active members of the hosting group (the default).
  * - `"groups"`    — the hosting group, plus every group in `visibleGroupIds`.
- * - `"team"`      — the serving teams in `visibleTeamIds`, i.e. the people on
- *                   those rosters. Narrower than a group: a team is a roster
- *                   *inside* a group, so a "Prayer Team night" stays with the
- *                   Prayer Team instead of going out to the whole group.
+ * - `"private"`   — UNLISTED. Never appears in anyone's browse, search, or
+ *                   feed on group membership alone. You get in by holding the
+ *                   link, or by being invited. For a gathering someone wants
+ *                   to keep small, distribution is the control.
  *
  * This rule used to live in six hand-copied branches (`meetings/events.ts`,
  * `meetings/explore.ts` twice, `meetings/queries.ts`, `meetingRsvps.ts`, and
@@ -33,22 +33,29 @@ import type { Doc, Id } from "../_generated/dataModel";
 
 /** The audience-bearing fields of a meeting. */
 export type MeetingAudience = {
+  _id?: Id<"meetings">;
   groupId: Id<"groups">;
   visibility?: string;
   visibleGroupIds?: Id<"groups">[];
-  visibleTeamIds?: Id<"teams">[];
+  /** Who owns the event. Hosts always see their own private events. */
+  hostUserIds?: Id<"users">[];
+  createdById?: Id<"users">;
 };
 
 /**
  * A viewer's standing, resolved once and reused across many meetings.
  *
- * `groupIds` / `teamIds` hold ids the viewer is an ACTIVE member of. Callers
- * build them; see {@link resolveViewerTeamIds} for the team side.
+ * `groupIds` holds the groups the viewer is an ACTIVE member of. Callers build
+ * it; see {@link resolveInvitedMeetingIds} for the invite side.
  */
 export type ViewerStanding = {
   userId: Id<"users"> | null;
   groupIds: Set<string>;
-  teamIds: Set<string>;
+  /**
+   * Meetings this viewer was explicitly invited to (`eventInvites` rows).
+   * Only consulted for private events; see {@link resolveInvitedMeetingIds}.
+   */
+  invitedMeetingIds: Set<string>;
   isCommunityMember: boolean;
 };
 
@@ -61,9 +68,9 @@ export function meetingVisibility(meeting: MeetingAudience): string {
  * Whether `meeting` is visible to a viewer with the given standing.
  *
  * Pure and synchronous — safe to call in a `.filter()` over a page of
- * meetings. For team-scoped events the caller must have populated
- * `teamIds` (see {@link resolveViewerTeamIds}); an empty set simply hides
- * team-scoped events, which is the safe direction to fail.
+ * meetings. For private events the caller must have populated
+ * `invitedMeetingIds` (see {@link resolveInvitedMeetingIds}); an empty set
+ * simply hides them, which is the safe direction to fail.
  */
 export function isMeetingVisibleTo(
   meeting: MeetingAudience,
@@ -82,72 +89,64 @@ export function isMeetingVisibleTo(
     return (meeting.visibleGroupIds ?? []).some((id) => viewer.groupIds.has(id));
   }
 
-  if (visibility === "team") {
-    // Team-scoped events do NOT fall back to hosting-group membership: the
-    // whole point is to stay narrower than the group. Only people on one of
-    // the named rosters get in.
-    return (meeting.visibleTeamIds ?? []).some((id) => viewer.teamIds.has(id));
+  if (visibility === "private") {
+    // Unlisted: group membership grants nothing. It surfaces in a list only
+    // for the people who own it or were invited to it. Everyone else reaches
+    // it through the link, which is a different path entirely (see
+    // canAccessMeeting).
+    if (isMeetingOwner(meeting, viewer.userId)) return true;
+    return meeting._id ? viewer.invitedMeetingIds.has(meeting._id) : false;
   }
 
   return viewer.groupIds.has(meeting.groupId);
 }
 
+/** Hosts (and the creator, when no hosts are seated) own the event. */
+export function isMeetingOwner(
+  meeting: MeetingAudience,
+  userId: Id<"users"> | null
+): boolean {
+  if (!userId) return false;
+  const hosts = meeting.hostUserIds ?? [];
+  if (hosts.length > 0) return hosts.some((id) => id === userId);
+  return meeting.createdById === userId;
+}
+
 /**
- * Which of the teams referenced by `meetings` the viewer actually belongs to.
+ * Which of the given private meetings the viewer was explicitly invited to.
  *
- * A serving team's roster IS its linked chat channel's membership (see
- * `teams.channelId` and `chatChannels.isServingTeam` in schema.ts), so this
- * resolves team → channel → membership.
- *
- * Scoped to the teams the meetings in hand actually name, so a page with no
- * team-scoped events costs nothing and a page with a few costs a few reads —
- * rather than enumerating every team the viewer is on.
+ * Scoped to the private meetings actually in hand, so a page with none costs
+ * nothing — rather than loading every invite the viewer has ever received.
  */
-export async function resolveViewerTeamIds(
+export async function resolveInvitedMeetingIds(
   ctx: QueryCtx | MutationCtx,
   meetings: MeetingAudience[],
   userId: Id<"users"> | null
 ): Promise<Set<string>> {
   if (!userId) return new Set();
 
-  const referenced = new Set<string>();
+  const invited = new Set<string>();
   for (const m of meetings) {
-    if (meetingVisibility(m) !== "team") continue;
-    for (const id of m.visibleTeamIds ?? []) referenced.add(id);
+    if (meetingVisibility(m) !== "private" || !m._id) continue;
+    if (invited.has(m._id)) continue;
+    if (await isInvitedToMeeting(ctx, m._id, userId)) invited.add(m._id);
   }
-  if (referenced.size === 0) return new Set();
-
-  const memberOf = new Set<string>();
-  for (const teamId of referenced) {
-    if (await isOnTeamRoster(ctx, teamId as Id<"teams">, userId)) {
-      memberOf.add(teamId);
-    }
-  }
-  return memberOf;
+  return invited;
 }
 
-/**
- * Whether `userId` is on `teamId`'s roster — an active member of the team's
- * linked channel. A team with no channel has no roster to check, so nobody
- * passes; `meetings/index.ts` rejects such teams at create/update time so an
- * event can't be addressed to an audience that can never see it.
- */
-export async function isOnTeamRoster(
+/** Whether `userId` has an `eventInvites` row for `meetingId`. */
+export async function isInvitedToMeeting(
   ctx: QueryCtx | MutationCtx,
-  teamId: Id<"teams">,
+  meetingId: Id<"meetings">,
   userId: Id<"users">
 ): Promise<boolean> {
-  const team = await ctx.db.get(teamId);
-  if (!team || team.isArchived || !team.channelId) return false;
-
-  const membership = await ctx.db
-    .query("chatChannelMembers")
-    .withIndex("by_channel_user", (q) =>
-      q.eq("channelId", team.channelId!).eq("userId", userId)
+  const invite = await ctx.db
+    .query("eventInvites")
+    .withIndex("by_meeting_recipient", (q) =>
+      q.eq("meetingId", meetingId).eq("recipientUserId", userId)
     )
-    .filter((q) => q.eq(q.field("leftAt"), undefined))
     .first();
-  return !!membership;
+  return !!invite;
 }
 
 /**
@@ -204,11 +203,15 @@ export async function canAccessMeeting(
     return !!membership;
   }
 
-  if (visibility === "team") {
-    for (const teamId of meeting.visibleTeamIds ?? []) {
-      if (await isOnTeamRoster(ctx, teamId, userId)) return true;
-    }
-    return false;
+  if (visibility === "private") {
+    // Reaching this check at all means the caller already holds the event's
+    // id — which is only obtainable from the link or an invite, since private
+    // events appear in no listing. Possession of the link IS the grant, the
+    // same bargain as an unlisted video. Privacy here is "not discoverable",
+    // not "sealed": anyone the link is forwarded to can open and RSVP. That is
+    // what makes it usable for a host who wants to pass it around a small
+    // circle, and it is worth saying out loud rather than implying more.
+    return true;
   }
 
   if (await isActiveGroupMember(ctx, meeting.groupId, userId)) return true;
@@ -237,8 +240,8 @@ export function audienceDenialMessage(
   if (visibility === "community") {
     return `You must be a community member to ${action} this event`;
   }
-  if (visibility === "team") {
-    return `This event is limited to its team — you must be on the team to ${action} it`;
+  if (visibility === "private") {
+    return `This event is private — you need an invite or the link to ${action} it`;
   }
   return `You must be a group member to ${action} this event`;
 }
@@ -249,6 +252,8 @@ export function audienceOf(meeting: Doc<"meetings">): MeetingAudience {
     groupId: meeting.groupId,
     visibility: meeting.visibility,
     visibleGroupIds: meeting.visibleGroupIds,
-    visibleTeamIds: meeting.visibleTeamIds,
+    _id: meeting._id,
+    hostUserIds: meeting.hostUserIds,
+    createdById: meeting.createdById,
   };
 }

--- a/apps/convex/lib/meetingAudience.ts
+++ b/apps/convex/lib/meetingAudience.ts
@@ -101,6 +101,38 @@ export function isMeetingVisibleTo(
   return viewer.groupIds.has(meeting.groupId);
 }
 
+/**
+ * Strip private events the viewer neither owns nor was invited to.
+ *
+ * For list queries that were never audience-filtered at all — `listByGroup`
+ * and `listUpcomingForUser` scope by group membership and return everything
+ * else. That was survivable while every visibility level was at least as wide
+ * as the hosting group, but "private" is narrower, so membership alone must
+ * stop being enough.
+ *
+ * This deliberately filters ONLY private events rather than applying the full
+ * audience rule. Those queries have never enforced group/community/public
+ * scoping, and quietly tightening them here would change behavior well beyond
+ * this feature — `listByGroup` doesn't even take a token, so a full gate would
+ * empty the group page for every caller that doesn't pass one. Closing the
+ * hole this feature opens is in scope; retrofitting the rest is not.
+ */
+export async function withoutHiddenPrivateEvents<T extends MeetingAudience>(
+  ctx: QueryCtx | MutationCtx,
+  meetings: T[],
+  userId: Id<"users"> | null
+): Promise<T[]> {
+  const hasPrivate = meetings.some((m) => meetingVisibility(m) === "private");
+  if (!hasPrivate) return meetings;
+
+  const invited = await resolveInvitedMeetingIds(ctx, meetings, userId);
+  return meetings.filter((m) => {
+    if (meetingVisibility(m) !== "private") return true;
+    if (isMeetingOwner(m, userId)) return true;
+    return m._id ? invited.has(m._id) : false;
+  });
+}
+
 /** Hosts (and the creator, when no hosts are seated) own the event. */
 export function isMeetingOwner(
   meeting: MeetingAudience,

--- a/apps/convex/lib/meetingAudience.ts
+++ b/apps/convex/lib/meetingAudience.ts
@@ -1,0 +1,254 @@
+/**
+ * Meeting audience — who may see, RSVP to, and check in to an event.
+ *
+ * A meeting's `visibility` field is the single source of truth for its
+ * audience:
+ *
+ * - `"public"`    — anyone, signed in or not.
+ * - `"community"` — any member of the hosting group's community.
+ * - `"group"`     — active members of the hosting group (the default).
+ * - `"groups"`    — the hosting group, plus every group in `visibleGroupIds`.
+ * - `"team"`      — the serving teams in `visibleTeamIds`, i.e. the people on
+ *                   those rosters. Narrower than a group: a team is a roster
+ *                   *inside* a group, so a "Prayer Team night" stays with the
+ *                   Prayer Team instead of going out to the whole group.
+ *
+ * This rule used to live in six hand-copied branches (`meetings/events.ts`,
+ * `meetings/explore.ts` twice, `meetings/queries.ts`, `meetingRsvps.ts`, and
+ * `meetings/attendance.ts`). They drifted, and adding a case meant editing all
+ * six. Everything now reads from here so seeing an event and acting on it can
+ * never disagree.
+ *
+ * Two entry points, because the callers have genuinely different shapes:
+ * - {@link isMeetingVisibleTo} is a *pure* predicate for list rendering, where
+ *   the caller has already loaded the viewer's standing once and filters many
+ *   meetings against it.
+ * - {@link canAccessMeeting} does its own lookups for single-meeting checks
+ *   (RSVP, check-in, event detail), short-circuiting so it only reads what the
+ *   meeting's visibility actually requires.
+ */
+
+import type { QueryCtx, MutationCtx } from "../_generated/server";
+import type { Doc, Id } from "../_generated/dataModel";
+
+/** The audience-bearing fields of a meeting. */
+export type MeetingAudience = {
+  groupId: Id<"groups">;
+  visibility?: string;
+  visibleGroupIds?: Id<"groups">[];
+  visibleTeamIds?: Id<"teams">[];
+};
+
+/**
+ * A viewer's standing, resolved once and reused across many meetings.
+ *
+ * `groupIds` / `teamIds` hold ids the viewer is an ACTIVE member of. Callers
+ * build them; see {@link resolveViewerTeamIds} for the team side.
+ */
+export type ViewerStanding = {
+  userId: Id<"users"> | null;
+  groupIds: Set<string>;
+  teamIds: Set<string>;
+  isCommunityMember: boolean;
+};
+
+/** Meetings default to group-only when the field was never written. */
+export function meetingVisibility(meeting: MeetingAudience): string {
+  return meeting.visibility || "group";
+}
+
+/**
+ * Whether `meeting` is visible to a viewer with the given standing.
+ *
+ * Pure and synchronous — safe to call in a `.filter()` over a page of
+ * meetings. For team-scoped events the caller must have populated
+ * `teamIds` (see {@link resolveViewerTeamIds}); an empty set simply hides
+ * team-scoped events, which is the safe direction to fail.
+ */
+export function isMeetingVisibleTo(
+  meeting: MeetingAudience,
+  viewer: ViewerStanding
+): boolean {
+  const visibility = meetingVisibility(meeting);
+
+  if (visibility === "public") return true;
+
+  if (visibility === "community") {
+    return viewer.userId !== null && viewer.isCommunityMember;
+  }
+
+  if (visibility === "groups") {
+    if (viewer.groupIds.has(meeting.groupId)) return true;
+    return (meeting.visibleGroupIds ?? []).some((id) => viewer.groupIds.has(id));
+  }
+
+  if (visibility === "team") {
+    // Team-scoped events do NOT fall back to hosting-group membership: the
+    // whole point is to stay narrower than the group. Only people on one of
+    // the named rosters get in.
+    return (meeting.visibleTeamIds ?? []).some((id) => viewer.teamIds.has(id));
+  }
+
+  return viewer.groupIds.has(meeting.groupId);
+}
+
+/**
+ * Which of the teams referenced by `meetings` the viewer actually belongs to.
+ *
+ * A serving team's roster IS its linked chat channel's membership (see
+ * `teams.channelId` and `chatChannels.isServingTeam` in schema.ts), so this
+ * resolves team → channel → membership.
+ *
+ * Scoped to the teams the meetings in hand actually name, so a page with no
+ * team-scoped events costs nothing and a page with a few costs a few reads —
+ * rather than enumerating every team the viewer is on.
+ */
+export async function resolveViewerTeamIds(
+  ctx: QueryCtx | MutationCtx,
+  meetings: MeetingAudience[],
+  userId: Id<"users"> | null
+): Promise<Set<string>> {
+  if (!userId) return new Set();
+
+  const referenced = new Set<string>();
+  for (const m of meetings) {
+    if (meetingVisibility(m) !== "team") continue;
+    for (const id of m.visibleTeamIds ?? []) referenced.add(id);
+  }
+  if (referenced.size === 0) return new Set();
+
+  const memberOf = new Set<string>();
+  for (const teamId of referenced) {
+    if (await isOnTeamRoster(ctx, teamId as Id<"teams">, userId)) {
+      memberOf.add(teamId);
+    }
+  }
+  return memberOf;
+}
+
+/**
+ * Whether `userId` is on `teamId`'s roster — an active member of the team's
+ * linked channel. A team with no channel has no roster to check, so nobody
+ * passes; `meetings/index.ts` rejects such teams at create/update time so an
+ * event can't be addressed to an audience that can never see it.
+ */
+export async function isOnTeamRoster(
+  ctx: QueryCtx | MutationCtx,
+  teamId: Id<"teams">,
+  userId: Id<"users">
+): Promise<boolean> {
+  const team = await ctx.db.get(teamId);
+  if (!team || team.isArchived || !team.channelId) return false;
+
+  const membership = await ctx.db
+    .query("chatChannelMembers")
+    .withIndex("by_channel_user", (q) =>
+      q.eq("channelId", team.channelId!).eq("userId", userId)
+    )
+    .filter((q) => q.eq(q.field("leftAt"), undefined))
+    .first();
+  return !!membership;
+}
+
+/**
+ * Whether `userId` is an ACTIVE member of `groupId`.
+ *
+ * "Active" means present and accepted: no `leftAt`, and either no
+ * `requestStatus` (legacy rows) or an accepted one — a pending join request
+ * must not grant access to a group-scoped event.
+ */
+export async function isActiveGroupMember(
+  ctx: QueryCtx | MutationCtx,
+  groupId: Id<"groups">,
+  userId: Id<"users">
+): Promise<boolean> {
+  const membership = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_group_user", (q) =>
+      q.eq("groupId", groupId).eq("userId", userId)
+    )
+    .first();
+  return (
+    !!membership &&
+    !membership.leftAt &&
+    (!membership.requestStatus || membership.requestStatus === "accepted")
+  );
+}
+
+/**
+ * Whether `userId` may act on `meeting` — RSVP, check in, or open its detail.
+ *
+ * Does its own reads, short-circuiting on the meeting's visibility so a public
+ * event costs zero lookups and a group event costs one. Mirrors
+ * {@link isMeetingVisibleTo} exactly; the two must never disagree.
+ */
+export async function canAccessMeeting(
+  ctx: QueryCtx | MutationCtx,
+  meeting: MeetingAudience,
+  userId: Id<"users"> | null
+): Promise<boolean> {
+  const visibility = meetingVisibility(meeting);
+
+  if (visibility === "public") return true;
+  if (!userId) return false;
+
+  if (visibility === "community") {
+    const group = await ctx.db.get(meeting.groupId);
+    if (!group) return false;
+    const membership = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", userId).eq("communityId", group.communityId)
+      )
+      .first();
+    return !!membership;
+  }
+
+  if (visibility === "team") {
+    for (const teamId of meeting.visibleTeamIds ?? []) {
+      if (await isOnTeamRoster(ctx, teamId, userId)) return true;
+    }
+    return false;
+  }
+
+  if (await isActiveGroupMember(ctx, meeting.groupId, userId)) return true;
+
+  if (visibility === "groups") {
+    for (const sharedGroupId of meeting.visibleGroupIds ?? []) {
+      if (await isActiveGroupMember(ctx, sharedGroupId, userId)) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * The rejection message for a viewer who failed {@link canAccessMeeting}.
+ *
+ * `action` is the verb phrase the caller is gating — "RSVP to", "attend".
+ * Wording is kept per-visibility (rather than one generic string) because it
+ * tells the user what they'd have to be in order to get in.
+ */
+export function audienceDenialMessage(
+  meeting: MeetingAudience,
+  action: string
+): string {
+  const visibility = meetingVisibility(meeting);
+  if (visibility === "community") {
+    return `You must be a community member to ${action} this event`;
+  }
+  if (visibility === "team") {
+    return `This event is limited to its team — you must be on the team to ${action} it`;
+  }
+  return `You must be a group member to ${action} this event`;
+}
+
+/** Doc-typed convenience for callers holding a full meeting row. */
+export function audienceOf(meeting: Doc<"meetings">): MeetingAudience {
+  return {
+    groupId: meeting.groupId,
+    visibility: meeting.visibility,
+    visibleGroupIds: meeting.visibleGroupIds,
+    visibleTeamIds: meeting.visibleTeamIds,
+  };
+}

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -775,11 +775,17 @@ export default defineSchema({
     // Leaders/host still see the count with a "Visible to leaders only" badge.
     hideRsvpCount: v.optional(v.boolean()),
 
-    // Visibility
-    visibility: v.optional(v.string()), // 'group' | 'community' | 'public' | 'groups'
+    // Visibility. See `lib/meetingAudience.ts` — every read of these fields
+    // goes through it so "who can see this" and "who can RSVP" can't drift.
+    visibility: v.optional(v.string()), // 'group' | 'community' | 'public' | 'groups' | 'team'
     // When visibility is 'groups', members of these groups can also see and
     // RSVP, in addition to the hosting group. Ignored for other visibilities.
     visibleGroupIds: v.optional(v.array(v.id("groups"))),
+    // When visibility is 'team', ONLY the people on these serving teams'
+    // rosters can see and RSVP — not the hosting group at large. Lets a team
+    // keep its own night to itself without spinning up a whole separate group.
+    // Ignored for other visibilities.
+    visibleTeamIds: v.optional(v.array(v.id("teams"))),
 
     // Public sharing
     publicSlug: v.optional(v.string()),

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -777,15 +777,14 @@ export default defineSchema({
 
     // Visibility. See `lib/meetingAudience.ts` — every read of these fields
     // goes through it so "who can see this" and "who can RSVP" can't drift.
-    visibility: v.optional(v.string()), // 'group' | 'community' | 'public' | 'groups' | 'team'
+    // 'group' | 'community' | 'public' | 'groups' | 'private'
+    // 'private' is UNLISTED: it appears in no browse, search, or feed on group
+    // membership alone. You reach it by holding the link or being invited
+    // (`eventInvites`), so it needs no audience list of its own.
+    visibility: v.optional(v.string()),
     // When visibility is 'groups', members of these groups can also see and
     // RSVP, in addition to the hosting group. Ignored for other visibilities.
     visibleGroupIds: v.optional(v.array(v.id("groups"))),
-    // When visibility is 'team', ONLY the people on these serving teams'
-    // rosters can see and RSVP — not the hosting group at large. Lets a team
-    // keep its own night to itself without spinning up a whole separate group.
-    // Ignored for other visibilities.
-    visibleTeamIds: v.optional(v.array(v.id("teams"))),
 
     // Public sharing
     publicSlug: v.optional(v.string()),

--- a/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
@@ -312,11 +312,16 @@ export function CreateEventScreen() {
   const isCommunityWideContext =
     isCommunityWideEnabled || (isEditMode && !!meeting?.communityWideEventId);
 
-  // Guard against a stale "groups" selection once we're in a community-wide
-  // context (e.g. host enables the toggle, or a CWE child loads). Falls back to
-  // "community" so we never persist a "groups" event with a dropped audience.
+  // Guard against a stale narrow-audience selection once we're in a
+  // community-wide context (e.g. host enables the toggle, or a CWE child
+  // loads). Falls back to "community" so we never persist a "groups" event
+  // with a dropped audience, or a "private" event that a community-wide fan-out
+  // would contradict by definition.
   useEffect(() => {
-    if (isCommunityWideContext && visibility === "groups") {
+    if (
+      isCommunityWideContext &&
+      (visibility === "groups" || visibility === "private")
+    ) {
       setVisibility("community");
     }
   }, [isCommunityWideContext, visibility]);
@@ -1816,6 +1821,7 @@ export function CreateEventScreen() {
               value={visibility}
               onChange={setVisibility}
               allowSpecificGroups={!isCommunityWideContext}
+              allowPrivate={!isCommunityWideContext}
             />
             {visibility === "groups" && !isCommunityWideContext && community?.id && (
               <VisibleGroupsSelector

--- a/apps/mobile/features/leader-tools/components/VisibilitySelector.tsx
+++ b/apps/mobile/features/leader-tools/components/VisibilitySelector.tsx
@@ -5,7 +5,12 @@ import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 
-export type VisibilityLevel = "group" | "groups" | "community" | "public";
+export type VisibilityLevel =
+  | "group"
+  | "groups"
+  | "private"
+  | "community"
+  | "public";
 
 interface VisibilitySelectorProps {
   value: VisibilityLevel;
@@ -16,6 +21,11 @@ interface VisibilitySelectorProps {
    * audience can't be carried through to each child meeting.
    */
   allowSpecificGroups?: boolean;
+  /**
+   * When false, the "Private" option is hidden. Community-wide events fan out
+   * across a group type, and an unlisted event can't meaningfully fan out.
+   */
+  allowPrivate?: boolean;
 }
 
 interface VisibilityOption {
@@ -26,6 +36,12 @@ interface VisibilityOption {
 }
 
 const VISIBILITY_OPTIONS: VisibilityOption[] = [
+  {
+    value: "private",
+    label: "Private",
+    icon: "lock-closed",
+    description: "Hidden from everyone — share the link or invite people",
+  },
   {
     value: "group",
     label: "Group Only",
@@ -56,13 +72,16 @@ export function VisibilitySelector({
   value,
   onChange,
   allowSpecificGroups = true,
+  allowPrivate = true,
 }: VisibilitySelectorProps) {
   const { colors } = useTheme();
   const { primaryColor } = useCommunityTheme();
 
-  const options = allowSpecificGroups
-    ? VISIBILITY_OPTIONS
-    : VISIBILITY_OPTIONS.filter((o) => o.value !== "groups");
+  const options = VISIBILITY_OPTIONS.filter((o) => {
+    if (o.value === "groups" && !allowSpecificGroups) return false;
+    if (o.value === "private" && !allowPrivate) return false;
+    return true;
+  });
 
   return (
     <View style={styles.container}>

--- a/apps/web/src/pages/guides/Events.tsx
+++ b/apps/web/src/pages/guides/Events.tsx
@@ -112,16 +112,28 @@ export function Events() {
             this event. Only people who've RSVP'd can read or post in it.
           </Step>
           <Step n={5}>
-            <strong>Visibility.</strong> Choose <Term>Group Only</Term>,{" "}
-            <Term>Specific Groups</Term>, <Term>Community</Term>, or{" "}
-            <Term>Public</Term>. <Term>Specific Groups</Term> lets you pick a
-            handful of groups whose members can see and RSVP alongside the
-            hosting group — handy for an event aimed at a few teams (say, a
-            leaders' dinner across several locations) without opening it to the
-            whole community. Public means anyone with the link can view the
-            event; RSVPing still requires login.
+            <strong>Visibility.</strong> Choose <Term>Private</Term>,{" "}
+            <Term>Group Only</Term>, <Term>Specific Groups</Term>,{" "}
+            <Term>Community</Term>, or <Term>Public</Term>.{" "}
+            <Term>Specific Groups</Term> lets you pick a handful of groups whose
+            members can see and RSVP alongside the hosting group — handy for an
+            event aimed at a few teams (say, a leaders' dinner across several
+            locations) without opening it to the whole community. Public means
+            anyone with the link can view the event; RSVPing still requires
+            login.
           </Step>
           <Step n={6}>
+            <strong>Keeping something small.</strong> <Term>Private</Term> is
+            for a gathering you don't want to grow — a team's prayer night, a
+            dinner for a handful of people. A private event is hidden
+            everywhere: it never shows up in Explore, in search, or in anyone's
+            upcoming events just because they're in the group. People get in one
+            of two ways — you send them the event link, or you invite them from
+            the event's <Term>Invite</Term> screen, which puts it in their list.
+            Anyone who has the link can open it and RSVP, so share it with the
+            people you want there.
+          </Step>
+          <Step n={7}>
             <strong>Check-in at the door.</strong> On the day, open the event
             and tap <Term>Check in</Term> to run down the <Term>Going</Term>{" "}
             list, tapping each person — and each guest they brought — as they


### PR DESCRIPTION
## Why

A leader wanted to host a **Prayer Team night** and keep it to that team "so it doesn't get too big." The team isn't a group, so every existing option was wrong: Group Only / Community / Public are all too wide, and Specific Groups would mean inventing a group just to hold one event. They were about to use Partiful instead.

What they actually asked for: *"only if you have the link, or inviting certain people — so maybe a private mode."*

## What this adds

`visibility: "private"` — an **unlisted** event. It appears in no browse, no search, and nobody's upcoming events on group membership alone. The exclusion is the whole feature: being in the hosting group is worth nothing here.

Two ways in:
1. **The link** — every event already has a `shortId`.
2. **An invite** — the host invites specific people, and it shows up in their list.

**No new schema field.** Invitees already live in `eventInvites` (`by_meeting_recipient`), and the link already exists, so "private" is a visibility value plus two lookups.

## What private is *not*

It isn't sealed. Anyone the link is forwarded to can open it and RSVP — the same bargain as an unlisted video. **Distribution is the control.**

So `canAccessMeeting` returning true for any authenticated caller on a private event is deliberate, not a gap: reaching that check means the caller already holds the event id, which is only obtainable from the link or an invite. The helper says this out loud rather than implying a stronger guarantee than it provides. Flagging it explicitly because it's the one design call here worth disagreeing with.

## Groundwork (first commit)

The "who can see / RSVP to this event" rule was hand-copied into **six** places — `meetings/events.ts`, `meetings/explore.ts` (twice), `meetings/queries.ts`, `meetingRsvps.ts`, `meetings/attendance.ts`. The RSVP and attendance copies were byte-identical apart from the error verb. Adding a visibility case meant editing all six and hoping.

That's the same failure mode as the poll bug in #765, so it's fixed first, as its own behavior-preserving commit: `lib/meetingAudience.ts` is now the single definition, with two entry points because the callers genuinely differ — a pure predicate for filtering a page of events, and a DB-backed check for single-event actions that short-circuits so a public event costs zero reads.

The refactor commit passes the full suite untouched, so it can be reviewed independently of the feature.

## Review finding addressed (Codex P1)

The first pass had a real hole. `listByGroup` (the group page's upcoming events) and `listUpcomingForUser` scope purely by group membership and **never consulted `visibility` at all** — so an uninvited group member still got the private event, `shortId` and meeting link included. `listByGroup` doesn't even take a token, so it was exposed to unauthenticated callers too.

These never showed up in the "six copies" inventory because that came from grepping `visibility ===`, and a query that ignores the field entirely matches nothing. The dangerous call sites were the ones that never mentioned the thing being changed.

Fixed in 045e77d: both run through `withoutHiddenPrivateEvents`, and `listByGroup` gained an optional token so a host or invitee still sees their own private event on the group page.

Scoped deliberately to private events rather than applying the full audience rule to those two queries — they have never enforced group/community/public scoping, and a full gate would empty the group page for callers that pass no token. That's a **pre-existing gap worth tracking separately**, not something to change silently in a feature PR.

## Community-wide events

Can't be private — an unlisted event that fans out across a group type contradicts itself. The option is hidden in that context and a stale selection falls back to Community, mirroring how `groups` visibility is already handled.

## Testing

Sixteen tests in `__tests__/meetings-private-visibility.test.ts`, covering both the listing surfaces and the two ways in: uninvited group member sees nothing (in Explore, on the group page, and in upcoming events), invitee and host do, signed-out visitor sees nothing, ordinary group events are still listed, link access works, link-holder can RSVP, creation persists.

Four of them were **verified to fail when the guard is removed** — the private event leaks straight into the listing. That includes all three regression tests for the P1.

- `apps/convex`: 182 files, **3400 tests** passing · `tsc` clean
- `apps/mobile`: 241 suites, **2590 tests** passing · `tsc` clean
- `apps/web`: `tsc` clean

## Docs

`apps/web/src/pages/guides/Events.tsx` updated in the same PR — the visibility list now includes Private, plus a step explaining the keep-it-small use case and how the link/invite paths work.