### PR TITLE
feat(rostering): song title on run sheet rows + leader manual confirm

### DIFF
--- a/apps/convex/__tests__/scheduling/assignments.test.ts
+++ b/apps/convex/__tests__/scheduling/assignments.test.ts
@@ -38,6 +38,19 @@ async function setupSchedulingWorld() {
 
 const DAY = 86400000;
 
+/** Count *pending* scheduler jobs whose function name contains `needle`. */
+async function pendingJobsNamed(
+  t: ReturnType<typeof convexTest>,
+  needle: string,
+): Promise<number> {
+  return t.run(async (ctx) => {
+    const jobs = await ctx.db.system.query("_scheduled_functions").collect();
+    return jobs.filter(
+      (j) => j.state.kind === "pending" && String(j.name).includes(needle),
+    ).length;
+  });
+}
+
 /** Create a draft event for a given day offset and return its planId. */
 async function makeEvent(
   t: ReturnType<typeof import("convex-test").convexTest>,
@@ -1205,5 +1218,103 @@ describe("confirmAssignment (leader manual confirm)", () => {
     const assignment = await t.run((ctx) => ctx.db.get(assignmentId));
     expect(assignment?.status).toBe("confirmed");
     expect(assignment?.declineNote).toBeUndefined();
+  });
+
+  it("lets a community admin confirm", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+    const assignmentId = await assignMember(t, world, leaderToken, planId);
+
+    const adminToken = (await generateTokens(world.communityAdminId))
+      .accessToken;
+    const res = await t.mutation(
+      api.functions.scheduling.assignments.confirmAssignment,
+      { token: adminToken, assignmentId },
+    );
+    expect(res.status).toBe("confirmed");
+  });
+
+  it("lets a team manager confirm on their own team", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+    const assignmentId = await assignMember(t, world, leaderToken, planId);
+
+    // Zeb is a plain group member until the leader makes him a manager of
+    // the assignment's team.
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: world.teamId,
+      userId: world.staleGroupMemberId,
+    });
+
+    const managerToken = (await generateTokens(world.staleGroupMemberId))
+      .accessToken;
+    const res = await t.mutation(
+      api.functions.scheduling.assignments.confirmAssignment,
+      { token: managerToken, assignmentId },
+    );
+    expect(res.status).toBe("confirmed");
+  });
+
+  it("rejects a manager of a DIFFERENT team (gate is scoped to the assignment's team)", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+    const assignmentId = await assignMember(t, world, leaderToken, planId);
+
+    // Zeb manages a second team in the same group — that must NOT grant
+    // authority over world.teamId's assignments.
+    const { teamId: otherTeamId } = await t.mutation(
+      api.functions.scheduling.teams.createServingTeam,
+      {
+        token: leaderToken,
+        groupId: world.groupId,
+        name: "Production",
+        withChannel: false,
+      },
+    );
+    await t.mutation(api.functions.scheduling.teams.addTeamManager, {
+      token: leaderToken,
+      teamId: otherTeamId,
+      userId: world.staleGroupMemberId,
+    });
+
+    const managerToken = (await generateTokens(world.staleGroupMemberId))
+      .accessToken;
+    await expect(
+      t.mutation(api.functions.scheduling.assignments.confirmAssignment, {
+        token: managerToken,
+        assignmentId,
+      }),
+    ).rejects.toThrow(ConvexError);
+
+    const assignment = await t.run((ctx) => ctx.db.get(assignmentId));
+    expect(assignment?.status).not.toBe("confirmed");
+  });
+
+  it("schedules both channel reconciles and does NOT notify leaders", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+    const assignmentId = await assignMember(t, world, leaderToken, planId);
+    // Drain the reconciles enqueued by assignRole so the counts below are
+    // attributable to confirmAssignment alone.
+    await t.finishInProgressScheduledFunctions();
+
+    await t.mutation(api.functions.scheduling.assignments.confirmAssignment, {
+      token: leaderToken,
+      assignmentId,
+    });
+
+    // The declined → confirmed override relies on these reconciles to re-add
+    // the volunteer to derived team-channel membership.
+    expect(await pendingJobsNamed(t, "reconcileTeamChannel")).toBe(1);
+    expect(
+      await pendingJobsNamed(t, "reconcileCrossTeamChannelsForSource"),
+    ).toBe(1);
+    // Deliberate: the scheduler acted themselves, so no leader notification.
+    expect(await pendingJobsNamed(t, "notifyLeadersOfResponse")).toBe(0);
   });
 });

--- a/apps/convex/__tests__/scheduling/assignments.test.ts
+++ b/apps/convex/__tests__/scheduling/assignments.test.ts
@@ -1097,3 +1097,113 @@ describe("inviteAndAssign", () => {
     ).rejects.toThrow(ConvexError);
   });
 });
+
+describe("confirmAssignment (leader manual confirm)", () => {
+  /** Assign the plain channel member to the role and return the assignmentId. */
+  async function assignMember(
+    t: ReturnType<typeof import("convex-test").convexTest>,
+    world: SchedulingWorld,
+    leaderToken: string,
+    planId: Id<"eventPlans">,
+  ): Promise<Id<"roleAssignments">> {
+    const { assignmentId } = await t.mutation(
+      api.functions.scheduling.assignments.assignRole,
+      {
+        token: leaderToken,
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelMemberId,
+      },
+    );
+    return assignmentId;
+  }
+
+  it("lets a scheduler confirm someone else's unconfirmed assignment", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+    const assignmentId = await assignMember(t, world, leaderToken, planId);
+
+    const res = await t.mutation(
+      api.functions.scheduling.assignments.confirmAssignment,
+      { token: leaderToken, assignmentId },
+    );
+    expect(res.status).toBe("confirmed");
+
+    const assignment = await t.run((ctx) => ctx.db.get(assignmentId));
+    expect(assignment?.status).toBe("confirmed");
+    expect(assignment?.respondedAt).toBeTypeOf("number");
+  });
+
+  it("rejects a group member who is not a scheduler with a ConvexError", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+    const assignmentId = await assignMember(t, world, leaderToken, planId);
+
+    // A plain group member (not a channel admin/moderator, group leader, or
+    // community admin) cannot confirm on someone else's behalf.
+    const memberToken = (await generateTokens(world.staleGroupMemberId))
+      .accessToken;
+    await expect(
+      t.mutation(api.functions.scheduling.assignments.confirmAssignment, {
+        token: memberToken,
+        assignmentId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("no-ops on an already-confirmed assignment", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+    const assignmentId = await assignMember(t, world, leaderToken, planId);
+
+    // The volunteer confirms it themselves first.
+    const memberToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: memberToken,
+      assignmentId,
+      status: "confirmed",
+    });
+    const before = await t.run((ctx) => ctx.db.get(assignmentId));
+
+    const res = await t.mutation(
+      api.functions.scheduling.assignments.confirmAssignment,
+      { token: leaderToken, assignmentId },
+    );
+    expect(res.status).toBe("confirmed");
+
+    // True no-op: nothing on the row changed, not even respondedAt.
+    const after = await t.run((ctx) => ctx.db.get(assignmentId));
+    expect(after).toEqual(before);
+  });
+
+  it("confirming a declined assignment clears the decline note", async () => {
+    const { t, world } = await setupSchedulingWorld();
+    const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
+    const planId = await makeEvent(t, world, leaderToken, 7);
+    const assignmentId = await assignMember(t, world, leaderToken, planId);
+
+    const memberToken = (await generateTokens(world.channelMemberId))
+      .accessToken;
+    await t.mutation(api.functions.scheduling.assignments.respondToAssignment, {
+      token: memberToken,
+      assignmentId,
+      status: "declined",
+      declineNote: "Out of town",
+    });
+
+    // Leader override — e.g. the volunteer changed their mind in person.
+    await t.mutation(api.functions.scheduling.assignments.confirmAssignment, {
+      token: leaderToken,
+      assignmentId,
+    });
+
+    const assignment = await t.run((ctx) => ctx.db.get(assignmentId));
+    expect(assignment?.status).toBe("confirmed");
+    expect(assignment?.declineNote).toBeUndefined();
+  });
+});

--- a/apps/convex/functions/scheduling/assignments.ts
+++ b/apps/convex/functions/scheduling/assignments.ts
@@ -875,6 +875,71 @@ export const respondToAssignment = mutation({
 });
 
 /**
+ * Leader/manager manual confirm — mark someone ELSE's assignment `confirmed`.
+ *
+ * Why: volunteers often confirm verbally or in person ("yes, I'll be there
+ * Sunday") without ever tapping the request. This lets the scheduler record
+ * that answer on the roster, including overriding a `declined` row (the
+ * decline note is cleared) when the volunteer changed their mind offline.
+ * Deliberately does NOT notify leaders (`notifyLeadersOfResponse`) — the
+ * leader is the one acting.
+ *
+ * Auth: same gate as `unassign` — `requirePlanTeamScheduler`, scoped to the
+ * assignment's own team.
+ */
+export const confirmAssignment = mutation({
+  args: {
+    token: v.string(),
+    assignmentId: v.id("roleAssignments"),
+  },
+  handler: async (ctx, args) => {
+    const callerId = await requireAuth(ctx, args.token);
+
+    const assignment = await ctx.db.get(args.assignmentId);
+    if (!assignment) {
+      throw new ConvexError("Assignment not found");
+    }
+    // Scoped to the assignment's own team, so a manager can confirm their
+    // team's cells but not another team's.
+    await requirePlanTeamScheduler(
+      ctx,
+      assignment.planId,
+      assignment.teamId,
+      callerId,
+    );
+
+    // Already confirmed — nothing to record.
+    if (assignment.status === "confirmed") {
+      return { assignmentId: args.assignmentId, status: "confirmed" as const };
+    }
+
+    await ctx.db.patch(args.assignmentId, {
+      status: "confirmed",
+      declineNote: undefined,
+      respondedAt: Date.now(),
+    });
+
+    // Same uniform channel-sync trigger as `respondToAssignment`: a confirm
+    // has no membership effect on the team channel itself, but a declined →
+    // confirmed override can re-add the user to derived membership, and
+    // reconciling on every status change keeps the trigger cheap and uniform.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.scheduling.teamChannelSync.reconcileTeamChannel,
+      { teamId: assignment.teamId },
+    );
+    await ctx.scheduler.runAfter(
+      0,
+      internal.functions.scheduling.teamChannelSync
+        .reconcileCrossTeamChannelsForSource,
+      { sourceTeamId: assignment.teamId },
+    );
+
+    return { assignmentId: args.assignmentId, status: "confirmed" as const };
+  },
+});
+
+/**
  * Distinct users who have previously *confirmed* the given role, most
  * recent first. Powers the assign-UI "previously filled by" quicklink
  * (ADR-023 — a derived query in place of a qualification table).

--- a/apps/convex/functions/scheduling/index.ts
+++ b/apps/convex/functions/scheduling/index.ts
@@ -98,6 +98,7 @@ export {
   inviteAndAssign,
   unassign,
   respondToAssignment,
+  confirmAssignment,
   previousFillers,
   publishEvent,
 } from "./assignments";

--- a/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
+++ b/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
@@ -43,6 +43,7 @@ import {
   runSheetItemMatchesViewer,
   segmentHasContentForViewer,
 } from "@features/scheduling/utils/runSheetViewerFilter";
+import { songMetaLine } from "@features/scheduling/utils/songRehearsal";
 import { ServiceTimeSelector } from "@features/scheduling/components/ServiceTimeSelector";
 import { renderTextWithLinks } from "../utils/runSheetLinks";
 import { assigneeLabels } from "../utils/runSheetUtils";
@@ -83,6 +84,12 @@ export type RunSheetItem = {
   durationSec: number;
   notes: Array<{ category: string; content: string }>;
   songDetails: { key?: string; bpm?: number } | null;
+  /**
+   * Joined library song (ADR-027); carries the defaults songDetails overrides.
+   * Optional because run sheets cached offline before this field shipped
+   * rehydrate without it.
+   */
+  song?: { title?: string; defaultKey?: string; bpm?: number } | null;
   assignments: Array<{
     roleId: Id<"teamRoles">;
     roleName: string;
@@ -817,6 +824,7 @@ function ReadOnlyRow({
 }) {
   const isHeader = item.type === "header";
   const duration = formatDuration(item.durationSec);
+  const songMeta = item.type === "song" ? songMetaLine(item) : null;
 
   if (isHeader) {
     // Collapsible section header — tap the chevron/title to fold its rows.
@@ -895,10 +903,9 @@ function ReadOnlyRow({
             />
           ) : null}
         </Pressable>
-        {item.type === "song" && item.songDetails?.key ? (
+        {songMeta ? (
           <Text style={[styles.meta, { color: colors.textSecondary }]}>
-            Key {item.songDetails.key}
-            {item.songDetails.bpm ? ` · ${item.songDetails.bpm} BPM` : ""}
+            {songMeta}
           </Text>
         ) : null}
         {item.assignments.length > 0 ? (

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -411,6 +411,11 @@ export function RosterGridScreen() {
   const unassign = useAuthenticatedMutation(
     api.functions.scheduling.assignments.unassign,
   );
+  // Leader manual confirm — records a verbal/in-person "yes" on the roster
+  // without waiting for the volunteer to tap their request.
+  const confirmAssignment = useAuthenticatedMutation(
+    api.functions.scheduling.assignments.confirmAssignment,
+  );
   // Set how many of a role are needed for a plan (the AssignSheet stepper).
   // `setNeededRoles` REPLACES the plan's whole needed-roles set, so the handler
   // below rebuilds the full array from `roleCells` and changes only one count.
@@ -668,6 +673,17 @@ export function RosterGridScreen() {
       }
     },
     [unassign, surfaceError],
+  );
+
+  const handleConfirm = useCallback(
+    async (assignmentId: Id<"roleAssignments">) => {
+      try {
+        await confirmAssignment({ assignmentId });
+      } catch (e) {
+        surfaceError("Couldn't confirm", e);
+      }
+    },
+    [confirmAssignment, surfaceError],
   );
 
   /** A single time-label when the event has exactly one time, else undefined. */
@@ -2459,6 +2475,7 @@ export function RosterGridScreen() {
             cell={roleCells[`${roleCellModal.role.roleId}:${roleCellModal.event._id}`]}
             colors={colors}
             docked
+            onConfirm={handleConfirm}
             onRemove={handleUnassign}
             onAddSomeone={(cell) => {
               const role = roleCellModal.role;
@@ -2503,6 +2520,7 @@ export function RosterGridScreen() {
             cell={memberCellModal.member.cells[memberCellModal.event._id as string]}
             colors={colors}
             docked
+            onConfirm={handleConfirm}
             onRemove={handleUnassign}
             onAddRole={() => {
               const m = memberCellModal.member;
@@ -2583,6 +2601,7 @@ export function RosterGridScreen() {
           event={roleCellModal.event}
           cell={roleCells[`${roleCellModal.role.roleId}:${roleCellModal.event._id}`]}
           colors={colors}
+          onConfirm={handleConfirm}
           onRemove={handleUnassign}
           onAddSomeone={(cell) => {
             const role = roleCellModal.role;
@@ -2626,6 +2645,7 @@ export function RosterGridScreen() {
           event={memberCellModal.event}
           cell={memberCellModal.member.cells[memberCellModal.event._id as string]}
           colors={colors}
+          onConfirm={handleConfirm}
           onRemove={handleUnassign}
           onAddRole={() => {
             const m = memberCellModal.member;
@@ -3100,6 +3120,7 @@ function RoleCellPopover({
   cell,
   colors,
   docked = false,
+  onConfirm,
   onRemove,
   onAddSomeone,
   onShowHistory,
@@ -3110,6 +3131,7 @@ function RoleCellPopover({
   cell: RoleCell | undefined;
   colors: Colors;
   docked?: boolean;
+  onConfirm: (id: Id<"roleAssignments">) => void;
   onRemove: (id: Id<"roleAssignments">) => void;
   onAddSomeone: (cell: RoleCell) => void;
   onShowHistory: () => void;
@@ -3176,6 +3198,18 @@ function RoleCellPopover({
                   {resending === (o.assignmentId as string)
                     ? "Sending…"
                     : "Send request"}
+                </Text>
+              </TouchableOpacity>
+            ) : null}
+            {o.status !== "confirmed" ? (
+              <TouchableOpacity
+                onPress={() => onConfirm(o.assignmentId)}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel={`Confirm ${o.userName}`}
+              >
+                <Text style={[styles.removeText, { color: colors.success }]}>
+                  Confirm
                 </Text>
               </TouchableOpacity>
             ) : null}
@@ -3350,6 +3384,7 @@ function MemberCellPopover({
   cell,
   colors,
   docked = false,
+  onConfirm,
   onRemove,
   onAddRole,
   onClose,
@@ -3359,6 +3394,7 @@ function MemberCellPopover({
   cell: MemberCell | undefined;
   colors: Colors;
   docked?: boolean;
+  onConfirm: (id: Id<"roleAssignments">) => void;
   onRemove: (id: Id<"roleAssignments">) => void;
   onAddRole: () => void;
   onClose: () => void;
@@ -3384,6 +3420,18 @@ function MemberCellPopover({
             <Text style={[styles.occupantName, { color: colors.text }]} numberOfLines={1}>
               {a.roleName}
             </Text>
+            {a.status !== "confirmed" ? (
+              <TouchableOpacity
+                onPress={() => onConfirm(a.assignmentId)}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel={`Confirm ${member.userName} as ${a.roleName}`}
+              >
+                <Text style={[styles.removeText, { color: colors.success }]}>
+                  Confirm
+                </Text>
+              </TouchableOpacity>
+            ) : null}
             <TouchableOpacity onPress={() => onRemove(a.assignmentId)} hitSlop={8}>
               <Text style={[styles.removeText, { color: colors.destructive }]}>Remove</Text>
             </TouchableOpacity>

--- a/apps/mobile/features/scheduling/utils/__tests__/songRehearsal.test.ts
+++ b/apps/mobile/features/scheduling/utils/__tests__/songRehearsal.test.ts
@@ -1,4 +1,4 @@
-import { effectiveKey, effectiveBpm } from "../songRehearsal";
+import { effectiveKey, effectiveBpm, songMetaLine } from "../songRehearsal";
 
 describe("effectiveKey", () => {
   it("prefers the per-occurrence override over the song default", () => {
@@ -75,5 +75,62 @@ describe("effectiveBpm", () => {
   it("returns undefined for a free-typed item with no song", () => {
     const item = { songDetails: null };
     expect(effectiveBpm(item)).toBeUndefined();
+  });
+});
+
+describe("songMetaLine", () => {
+  it("shows the song title with resolved key and BPM", () => {
+    const item = {
+      title: "New item",
+      songDetails: { key: "G" },
+      song: { _id: "s1", title: "Way Maker", defaultKey: "C", bpm: 68 },
+    };
+    expect(songMetaLine(item)).toBe("Way Maker · Key G · 68 BPM");
+  });
+
+  it("falls back to the library song's default key and BPM", () => {
+    const item = {
+      title: "New item",
+      songDetails: null,
+      song: { _id: "s1", title: "Way Maker", defaultKey: "E", bpm: 68 },
+    };
+    expect(songMetaLine(item)).toBe("Way Maker · Key E · 68 BPM");
+  });
+
+  it("omits the song title when the row title already matches it", () => {
+    const item = {
+      title: "Way Maker",
+      songDetails: { key: "G", bpm: 70 },
+      song: { _id: "s1", title: "Way Maker" },
+    };
+    expect(songMetaLine(item)).toBe("Key G · 70 BPM");
+  });
+
+  it("treats the title match case- and whitespace-insensitively", () => {
+    const item = {
+      title: "  way maker ",
+      songDetails: { key: "G" },
+      song: { _id: "s1", title: "Way Maker" },
+    };
+    expect(songMetaLine(item)).toBe("Key G");
+  });
+
+  it("shows only the song title when no key or BPM resolves", () => {
+    const item = {
+      title: "Worship set",
+      songDetails: null,
+      song: { _id: "s1", title: "Way Maker" },
+    };
+    expect(songMetaLine(item)).toBe("Way Maker");
+  });
+
+  it("keeps the legacy override-only line for items without a linked song", () => {
+    const item = { title: "Opener", songDetails: { key: "A", bpm: 120 } };
+    expect(songMetaLine(item)).toBe("Key A · 120 BPM");
+  });
+
+  it("returns null when there is nothing to show", () => {
+    const item = { title: "Welcome", songDetails: null };
+    expect(songMetaLine(item)).toBeNull();
   });
 });

--- a/apps/mobile/features/scheduling/utils/songRehearsal.ts
+++ b/apps/mobile/features/scheduling/utils/songRehearsal.ts
@@ -37,3 +37,29 @@ export function effectiveKey(item: SongRehearsalItem): string | undefined {
 export function effectiveBpm(item: SongRehearsalItem): number | undefined {
   return resolveSongBpm(item.songDetails, item.song);
 }
+
+/**
+ * One-line song summary for a run sheet row: "Way Maker · Key G · 68 BPM".
+ *
+ * The linked song's title leads the line so importing a song is visible even
+ * when the row keeps its own segment title (e.g. the default "New item") —
+ * but it's dropped when the row title already says the same thing, to avoid
+ * printing the title twice. Returns null when there's nothing to show.
+ */
+export function songMetaLine(
+  item: SongRehearsalItem & { title?: string },
+): string | null {
+  const parts: string[] = [];
+  const songTitle = item.song?.title?.trim();
+  if (
+    songTitle &&
+    songTitle.toLowerCase() !== (item.title ?? "").trim().toLowerCase()
+  ) {
+    parts.push(songTitle);
+  }
+  const key = effectiveKey(item);
+  if (key) parts.push(`Key ${key}`);
+  const bpm = effectiveBpm(item);
+  if (bpm) parts.push(`${bpm} BPM`);
+  return parts.length > 0 ? parts.join(" · ") : null;
+}

--- a/apps/web/src/pages/guides/EventPlans.tsx
+++ b/apps/web/src/pages/guides/EventPlans.tsx
@@ -390,7 +390,12 @@ export function EventPlans() {
           pings just that one person, so after you assign or reassign a single
           volunteer you can request them on their own instead of re-sending to the
           whole plan. (On a still-draft plan you publish first, which is what
-          sends the initial requests.) Choose{" "}
+          sends the initial requests.) There's also a <Term>Confirm</Term> next
+          to anyone not yet confirmed: when a volunteer tells you in person or
+          over text that they'll be there, tap it to record their yes on the
+          roster yourself — the cell goes green and their confirm-or-decline
+          nudges stop, no app response needed. It works on a declined slot too,
+          for the volunteer who changed their mind after declining. Choose{" "}
           <Term>Request history</Term> on the same popover to see the full trail
           for that slot: who was asked, when, and how many times, alongside
           whether they've since confirmed, declined, or been removed — and{" "}


### PR DESCRIPTION
Two roster/run-sheet fixes requested by David Walker Jr.:

## 1. Song imports are now visible on run sheet segments

Importing a song into a run sheet segment was invisible in the native run sheet view: the row kept its segment title (often the default "New item"), and the subtext only rendered a per-service key/BPM *override* — ignoring both the song's title and its library defaults, so a linked song with no override showed nothing at all.

- New `songMetaLine()` helper next to the existing `effectiveKey`/`effectiveBpm` adapters: leads with the linked song's title (skipped when the row title already matches) and resolves Key/BPM through the ADR-027 override layering. Rows now read e.g. **"Way Maker · Key G · 68 BPM"**.
- `NativeRunSheetView`'s local item type now declares the joined `song` the `listItems` query has been sending all along (optional — pre-existing offline caches rehydrate without it).
- Covers both the leader-tools run sheet and the serving run sheet (shared component).

## 2. Leaders/managers can manually confirm a roster assignment

Volunteers often say yes verbally or over text without tapping their confirm request, leaving the slot amber and reminder nudges firing. The only status-writing path (`respondToAssignment`) is strictly self-service.

- New `confirmAssignment` mutation, gated by `requirePlanTeamScheduler` (same team-scoped gate as `unassign`): group leaders, community admins, and that team's managers can mark someone confirmed. Works on a declined row too (clears the decline note); schedules the same team-channel reconciles as a self-response; deliberately skips `notifyLeadersOfResponse`.
- **Confirm** action on the roster grid's role and member cell popovers for any occupant not yet confirmed.
- Event Plans guide updated (roster grid section) per the guides-sync rule.

## Tests

- 7 new unit tests for `songMetaLine` (17 passing in the suite).
- 4 new backend tests for `confirmAssignment` (leader can confirm, non-scheduler rejected, already-confirmed no-op, declined → confirmed clears note); 39 passing across the assignments/permissions suites.
- Typecheck clean for all touched files (remaining mobile errors are pre-existing on main, verified against the clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J75sjErevGEvdzBAKCFLx8

---
_Generated by [Claude Code](https://claude.ai/code/session_01J75sjErevGEvdzBAKCFLx8)_