### PR TITLE
test(rostering): fix flaky confirmAssignment reconcile-count assertion

### DIFF
--- a/apps/convex/__tests__/scheduling/assignments.test.ts
+++ b/apps/convex/__tests__/scheduling/assignments.test.ts
@@ -1298,10 +1298,25 @@ describe("confirmAssignment (leader manual confirm)", () => {
     const { t, world } = await setupSchedulingWorld();
     const leaderToken = (await generateTokens(world.groupLeaderId)).accessToken;
     const planId = await makeEvent(t, world, leaderToken, 7);
-    const assignmentId = await assignMember(t, world, leaderToken, planId);
-    // Drain the reconciles enqueued by assignRole so the counts below are
-    // attributable to confirmAssignment alone.
-    await t.finishInProgressScheduledFunctions();
+    // Seed the assignment directly (bypassing `assignRole`) so the ONLY
+    // reconcile jobs in the queue are the ones the confirm schedules — the
+    // assertion stays deterministic regardless of convex-test's runAfter(0)
+    // timing. Same pattern as deletion.test.ts; a drain is not enough,
+    // because finishInProgressScheduledFunctions skips still-pending jobs.
+    const assignmentId = await t.run(async (ctx) => {
+      const plan = await ctx.db.get(planId);
+      return ctx.db.insert("roleAssignments", {
+        planId,
+        teamId: world.teamId,
+        roleId: world.roleId,
+        userId: world.channelMemberId,
+        eventDate: plan!.eventDate,
+        status: "unconfirmed",
+        assignedById: world.groupLeaderId,
+        assignedAt: Date.now(),
+      });
+    });
+    expect(await pendingJobsNamed(t, "reconcileTeamChannel")).toBe(0);
 
     await t.mutation(api.functions.scheduling.assignments.confirmAssignment, {
       token: leaderToken,


### PR DESCRIPTION
Fixes the post-merge main failure introduced by #773's "schedules both channel reconciles and does NOT notify leaders" test.

## Root cause

The test drained the scheduler with `finishInProgressScheduledFunctions()` after `assignRole`, but that call only finishes jobs that have already **started** — a still-`pending` `runAfter(0)` reconcile from `assignRole` survives the drain. Under CI load on main that job hadn't started yet, so the assertion counted 2 pending `reconcileTeamChannel` jobs instead of 1. It passed on the PR branch and locally by timing luck.

## Fix

Adopt the repo's existing pattern from `deletion.test.ts` (which documents this exact hazard): seed the `roleAssignments` row directly via `ctx.db.insert`, bypassing `assignRole`, so the only jobs in the queue are the ones `confirmAssignment` itself schedules. A `.toBe(0)` guard before the mutation pins the empty-queue precondition.

## Verification

Suite run 6 consecutive times locally: 35/35 pass every run. No product code touched — test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J75sjErevGEvdzBAKCFLx8

---
_Generated by [Claude Code](https://claude.ai/code/session_01J75sjErevGEvdzBAKCFLx8)_