### PR TITLE
fix(rostering): anchor run sheet to the service that's actually live when auto-follow windows overlap

### DIFF
--- a/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
+++ b/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
@@ -343,10 +343,6 @@ export function PlanRunSheet({
     () => totalDurationSec(itemsBySegment.during),
     [itemsBySegment.during],
   );
-  const beforeTotalSec = useMemo(
-    () => totalDurationSec(itemsBySegment.before),
-    [itemsBySegment.before],
-  );
   const afterTotalSec = useMemo(
     () => totalDurationSec(itemsBySegment.after),
     [itemsBySegment.after],
@@ -365,14 +361,8 @@ export function PlanRunSheet({
   const [manualServiceIdx, setManualServiceIdx] = useState<number | null>(null);
   const autoServiceIdx = useMemo(
     () =>
-      pickActiveServiceIndex(
-        times,
-        now,
-        beforeTotalSec,
-        duringTotalSec,
-        afterTotalSec,
-      ),
-    [times, now, beforeTotalSec, duringTotalSec, afterTotalSec],
+      pickActiveServiceIndex(times, now, duringTotalSec, afterTotalSec),
+    [times, now, duringTotalSec, afterTotalSec],
   );
   // Guard the upper bound so a manual pick that outran a shrunk `times` falls
   // back to auto. (A reorder that keeps the length isn't tracked — editing

--- a/apps/mobile/features/scheduling/utils/__tests__/runSheetTiming.test.ts
+++ b/apps/mobile/features/scheduling/utils/__tests__/runSheetTiming.test.ts
@@ -80,71 +80,62 @@ describe("pickActiveServiceIndex", () => {
   const DURING = 60 * 60; // 1 hr in seconds
 
   it("picks the service whose window contains now", () => {
-    expect(pickActiveServiceIndex(times, at(9, 30), 0, DURING, 0)).toBe(0);
-    expect(pickActiveServiceIndex(times, at(11, 30), 0, DURING, 0)).toBe(1);
+    expect(pickActiveServiceIndex(times, at(9, 30), DURING, 0)).toBe(0);
+    expect(pickActiveServiceIndex(times, at(11, 30), DURING, 0)).toBe(1);
   });
 
   it("before any service, picks the soonest upcoming", () => {
-    expect(pickActiveServiceIndex(times, at(8), 0, DURING, 0)).toBe(0);
+    expect(pickActiveServiceIndex(times, at(8), DURING, 0)).toBe(0);
   });
 
   it("between services, picks the next upcoming", () => {
     // 10:30 is past the 9:00 window (ends 10:00) and before 11:00.
-    expect(pickActiveServiceIndex(times, at(10, 30), 0, DURING, 0)).toBe(1);
+    expect(pickActiveServiceIndex(times, at(10, 30), DURING, 0)).toBe(1);
   });
 
   it("after all services, picks the last", () => {
-    expect(pickActiveServiceIndex(times, at(13), 0, DURING, 0)).toBe(1);
-  });
-
-  it("counts a before pre-roll as part of the service window", () => {
-    // 30-min pre-roll → the 9:00 window opens at 8:30.
-    expect(pickActiveServiceIndex(times, at(8, 45), 30 * 60, DURING, 0)).toBe(0);
-    // ...but 8:15 is still ahead of it → soonest upcoming (still index 0).
-    expect(pickActiveServiceIndex(times, at(8, 15), 30 * 60, DURING, 0)).toBe(0);
+    expect(pickActiveServiceIndex(times, at(13), DURING, 0)).toBe(1);
   });
 
   it("returns the array index even when times are unordered", () => {
     const unordered = [{ startsAt: at(11) }, { startsAt: at(9) }];
     // 9:30 is inside the second element's window.
-    expect(pickActiveServiceIndex(unordered, at(9, 30), 0, DURING, 0)).toBe(1);
+    expect(pickActiveServiceIndex(unordered, at(9, 30), DURING, 0)).toBe(1);
   });
 
-  it("when windows overlap, the earlier-starting service wins", () => {
-    // 90-min "during" makes 9:00's window run to 10:30, overlapping 10:00's
-    // window [10:00, 11:30). At 10:15 both contain now → stay on the earlier
-    // one until its window closes; the later service's sheet mostly repeats
-    // pre-event items that aren't re-run between services.
+  it("an overlapping later service takes over the moment it starts", () => {
+    // 90-min "during" makes 9:00's window run to 10:30, overlapping 10:00's.
     const overlapping = [{ startsAt: at(9) }, { startsAt: at(10) }];
-    expect(pickActiveServiceIndex(overlapping, at(10, 15), 0, 90 * 60, 0)).toBe(
-      0,
-    );
+    // Just before 10:00 the earlier service is still the live one…
+    expect(pickActiveServiceIndex(overlapping, at(9, 59), 90 * 60, 0)).toBe(0);
+    // …but once 10:00 actually starts, the sheet follows it.
+    expect(pickActiveServiceIndex(overlapping, at(10, 15), 90 * 60, 0)).toBe(1);
   });
 
-  it("a long pre-roll on the next service never steals the live one", () => {
-    // Real-world shape: 10:00 and 12:00 services with a 2.5-hr "before"
-    // (call time, setup, checks). 12:00's window opens at 9:30 — while the
-    // 10:00 service is being set up and while it is live, the sheet must
-    // stay anchored to 10:00.
+  it("a not-yet-started later service never steals the live one", () => {
+    // Real-world shape: 10:00 and 12:00 services, 75 min during + 60 min
+    // after. Until 12:00 actually starts, the sheet stays anchored to 10:00 —
+    // including through 10:00's post-roll teardown.
     const services = [{ startsAt: at(10) }, { startsAt: at(12) }];
-    const BEFORE = 150 * 60; // 2.5 hr
-    const DUR = 75 * 60; // 75 min
-    // During 10:00's own pre-roll (9:45)…
-    expect(pickActiveServiceIndex(services, at(9, 45), BEFORE, DUR, 0)).toBe(0);
-    // …and mid-service (10:57) it stays on the 10:00 service.
-    expect(pickActiveServiceIndex(services, at(10, 57), BEFORE, DUR, 0)).toBe(0);
-    // Once 10:00's window closes (after 11:15), 12:00 takes over.
-    expect(pickActiveServiceIndex(services, at(11, 30), BEFORE, DUR, 0)).toBe(1);
+    const DUR = 75 * 60;
+    const AFTER = 60 * 60;
+    // Mid-service…
+    expect(pickActiveServiceIndex(services, at(10, 57), DUR, AFTER)).toBe(0);
+    // …and during 10:00's after-phase (during ends 11:15) it stays on 10:00.
+    expect(pickActiveServiceIndex(services, at(11, 45), DUR, AFTER)).toBe(0);
+    // At 12:05 the 10:00 window (ends 12:15) still contains now, but the
+    // noon service has started and is the live one — it must win.
+    expect(pickActiveServiceIndex(services, at(12, 5), DUR, AFTER)).toBe(1);
   });
 
   it("after all services with unordered times, picks the max-start index", () => {
     // Windows end by 12:00; 13:00 is past all → the latest service (11:00),
     // which is index 0 in this unordered array.
     const unordered = [{ startsAt: at(11) }, { startsAt: at(9) }];
-    expect(pickActiveServiceIndex(unordered, at(13), 0, DURING, 0)).toBe(0);
+    expect(pickActiveServiceIndex(unordered, at(13), DURING, 0)).toBe(0);
   });
 
   it("handles empty times", () => {
-    expect(pickActiveServiceIndex([], at(9), 0, DURING, 0)).toBe(0);
+    expect(pickActiveServiceIndex([], at(9), DURING, 0)).toBe(0);
   });
 });

--- a/apps/mobile/features/scheduling/utils/__tests__/runSheetTiming.test.ts
+++ b/apps/mobile/features/scheduling/utils/__tests__/runSheetTiming.test.ts
@@ -110,13 +110,31 @@ describe("pickActiveServiceIndex", () => {
     expect(pickActiveServiceIndex(unordered, at(9, 30), 0, DURING, 0)).toBe(1);
   });
 
-  it("when windows overlap, the later-starting service wins", () => {
+  it("when windows overlap, the earlier-starting service wins", () => {
     // 90-min "during" makes 9:00's window run to 10:30, overlapping 10:00's
-    // window [10:00, 11:30). At 10:15 both contain now → pick the later one.
+    // window [10:00, 11:30). At 10:15 both contain now → stay on the earlier
+    // one until its window closes; the later service's sheet mostly repeats
+    // pre-event items that aren't re-run between services.
     const overlapping = [{ startsAt: at(9) }, { startsAt: at(10) }];
     expect(pickActiveServiceIndex(overlapping, at(10, 15), 0, 90 * 60, 0)).toBe(
-      1,
+      0,
     );
+  });
+
+  it("a long pre-roll on the next service never steals the live one", () => {
+    // Real-world shape: 10:00 and 12:00 services with a 2.5-hr "before"
+    // (call time, setup, checks). 12:00's window opens at 9:30 — while the
+    // 10:00 service is being set up and while it is live, the sheet must
+    // stay anchored to 10:00.
+    const services = [{ startsAt: at(10) }, { startsAt: at(12) }];
+    const BEFORE = 150 * 60; // 2.5 hr
+    const DUR = 75 * 60; // 75 min
+    // During 10:00's own pre-roll (9:45)…
+    expect(pickActiveServiceIndex(services, at(9, 45), BEFORE, DUR, 0)).toBe(0);
+    // …and mid-service (10:57) it stays on the 10:00 service.
+    expect(pickActiveServiceIndex(services, at(10, 57), BEFORE, DUR, 0)).toBe(0);
+    // Once 10:00's window closes (after 11:15), 12:00 takes over.
+    expect(pickActiveServiceIndex(services, at(11, 30), BEFORE, DUR, 0)).toBe(1);
   });
 
   it("after all services with unordered times, picks the max-start index", () => {

--- a/apps/mobile/features/scheduling/utils/runSheetTiming.ts
+++ b/apps/mobile/features/scheduling/utils/runSheetTiming.ts
@@ -91,16 +91,16 @@ export function computeSegmentedClockTimes(
 /**
  * Pick which service a multi-service plan's run sheet should anchor to for a
  * given wall-clock `now`, so day-of the sheet re-bases to the service you're
- * actually in (and its live highlight tracks the right rows). Each service `i`
- * owns the window `[startsAt_i − before, startsAt_i + during + after]` — its
- * pre-roll leading in through its post-roll.
+ * actually in (and its live highlight tracks the right rows). A service is
+ * "live" from its start until its during + after phases run out.
  *
  * Selection order:
- *   1. a service whose window contains `now` (the one happening now — if two
- *      overlap, the EARLIER-starting wins: a later service's long pre-roll
- *      mostly repeats setup items that aren't re-run between services, so it
- *      must not steal the sheet while an earlier service is still live);
- *   2. else the soonest service still ahead of `now` (its window hasn't opened);
+ *   1. the latest-starting service that is live at `now` — a later service
+ *      takes the sheet the moment it actually starts, but never earlier: its
+ *      pre-roll mostly repeats setup items that aren't re-run between
+ *      services, so pre-roll alone must not steal the sheet from an earlier
+ *      service that's still live;
+ *   2. else the soonest service that hasn't started yet;
  *   3. else the last service (everything's already over).
  *
  * Returns an index into `times` (0 when empty). Durations are in seconds.
@@ -108,35 +108,29 @@ export function computeSegmentedClockTimes(
 export function pickActiveServiceIndex(
   times: Array<{ startsAt: number }>,
   now: number,
-  beforeSec: number,
   duringSec: number,
   afterSec: number,
 ): number {
   if (times.length === 0) return 0;
-  const beforeMs = Math.max(0, beforeSec) * 1000;
   const tailMs = (Math.max(0, duringSec) + Math.max(0, afterSec)) * 1000;
 
-  let containing = -1;
-  let nextUpcoming = -1;
+  let live = -1; // started, phases not yet run out — latest start wins
+  let upcoming = -1; // not started yet — earliest start wins
   let last = 0;
   for (let i = 0; i < times.length; i++) {
-    const winStart = times[i].startsAt - beforeMs;
-    const winEnd = times[i].startsAt + tailMs;
-    if (now >= winStart && now < winEnd) {
-      if (containing === -1 || times[i].startsAt < times[containing].startsAt) {
-        containing = i;
+    const startsAt = times[i].startsAt;
+    if (startsAt <= now) {
+      if (now < startsAt + tailMs && (live === -1 || startsAt > times[live].startsAt)) {
+        live = i;
       }
+    } else if (upcoming === -1 || startsAt < times[upcoming].startsAt) {
+      upcoming = i;
     }
-    if (winStart > now) {
-      if (nextUpcoming === -1 || times[i].startsAt < times[nextUpcoming].startsAt) {
-        nextUpcoming = i;
-      }
-    }
-    if (times[i].startsAt > times[last].startsAt) last = i;
+    if (startsAt > times[last].startsAt) last = i;
   }
 
-  if (containing !== -1) return containing;
-  if (nextUpcoming !== -1) return nextUpcoming;
+  if (live !== -1) return live;
+  if (upcoming !== -1) return upcoming;
   return last;
 }
 

--- a/apps/mobile/features/scheduling/utils/runSheetTiming.ts
+++ b/apps/mobile/features/scheduling/utils/runSheetTiming.ts
@@ -97,7 +97,9 @@ export function computeSegmentedClockTimes(
  *
  * Selection order:
  *   1. a service whose window contains `now` (the one happening now — if two
- *      overlap, the later-starting wins, since that's the one you're rolling into);
+ *      overlap, the EARLIER-starting wins: a later service's long pre-roll
+ *      mostly repeats setup items that aren't re-run between services, so it
+ *      must not steal the sheet while an earlier service is still live);
  *   2. else the soonest service still ahead of `now` (its window hasn't opened);
  *   3. else the last service (everything's already over).
  *
@@ -121,7 +123,7 @@ export function pickActiveServiceIndex(
     const winStart = times[i].startsAt - beforeMs;
     const winEnd = times[i].startsAt + tailMs;
     if (now >= winStart && now < winEnd) {
-      if (containing === -1 || times[i].startsAt > times[containing].startsAt) {
+      if (containing === -1 || times[i].startsAt < times[containing].startsAt) {
         containing = i;
       }
     }


### PR DESCRIPTION
## Problem

On a multi-service plan (e.g. 10 AM + 12 PM), the run sheet defaulted to the 12 PM service all morning — even when auto-following "Live" — forcing leaders to manually tap the 10 AM pill.

## Cause

`pickActiveServiceIndex` treated each service's auto-follow window as `[start − before, start + during + after]`. A long "Before Event" section (call time 7:30, setup, line/sound check) makes the 12 PM service's pre-roll window open mid-morning, overlapping the 10 AM service's entire live window — and the overlap tie-break picked the **later**-starting service.

## Fix

Selection now anchors to the service that's actually live: the **latest-starting service that has started** and whose during + after phases still contain `now`; else the soonest service that hasn't started; else the last one.

- A later service's pre-roll can never steal the sheet from an earlier service that's still live (the original bug).
- The moment a later service actually starts, it takes the sheet — even if the earlier service's post-roll window is still open (caught by Codex review: 10:00 + 75 min during + 60 min after kept the sheet on 10:00 at 12:05).
- `beforeSec` no longer affects selection under this rule, so the dead parameter was removed from `pickActiveServiceIndex`.

## Tests

- Rewrote the overlap tests: earlier service holds the sheet until the later one starts, then hands over.
- Regression tests for both reported shapes: the 2.5-hr pre-roll steal, and the post-roll 10:00/12:00 @ 12:05 handoff.
- Full mobile suite green (2,597 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J75sjErevGEvdzBAKCFLx8)_