### PR TITLE
fix(run-sheet): an untimed service is still a service you can be in

### DIFF
--- a/apps/mobile/features/scheduling/utils/__tests__/runSheetTiming.test.ts
+++ b/apps/mobile/features/scheduling/utils/__tests__/runSheetTiming.test.ts
@@ -197,11 +197,33 @@ describe("pickActiveServiceIndex", () => {
     expect(pickActiveServiceIndex([], at(9), 0, DURING, 0)).toBe(0);
   });
 
-  it("falls back to the soonest service when durations are all zero", () => {
-    // A plan with no durations entered yet has no window at all — it must
-    // still land somewhere sane rather than always on the last service.
-    expect(pickActiveServiceIndex(times, at(8), 0, 0, 0)).toBe(0);
-    expect(pickActiveServiceIndex(times, at(10), 0, 0, 0)).toBe(1);
-    expect(pickActiveServiceIndex(times, at(13), 0, 0, 0)).toBe(1);
+  it("an untimed service still holds the sheet until the next one starts", () => {
+    // No `during` durations entered yet. A zero-length core would make "is a
+    // service in progress?" unanswerable and silently disable the in-progress
+    // rule — so an untimed service runs until the next service starts.
+    expect(pickActiveServiceIndex(times, at(8), 0, 0, 0)).toBe(0); // ahead of both
+    expect(pickActiveServiceIndex(times, at(10), 0, 0, 0)).toBe(0); // in the 9:00
+    expect(pickActiveServiceIndex(times, at(11, 30), 0, 0, 0)).toBe(1); // in the 11:00
+    expect(pickActiveServiceIndex(times, at(13), 0, 0, 0)).toBe(1); // all over
+  });
+
+  it("an untimed service is not stolen by a long pre-roll either", () => {
+    // The reported bug's twin: a plan that has its 2h30m before block filled in
+    // but hasn't timed the service body. Without the untimed-core rule the
+    // in-progress check can never fire and the noon pre-roll takes the sheet
+    // from 9:30 AM — the original bug, unchanged.
+    const sunday = [{ startsAt: at(10) }, { startsAt: at(12) }];
+    const BEFORE = 150 * 60;
+    expect(pickActiveServiceIndex(sunday, at(9, 30), BEFORE, 0, 0)).toBe(0);
+    expect(pickActiveServiceIndex(sunday, at(10, 15), BEFORE, 0, 0)).toBe(0);
+    expect(pickActiveServiceIndex(sunday, at(11, 30), BEFORE, 0, 0)).toBe(0);
+    expect(pickActiveServiceIndex(sunday, at(12, 30), BEFORE, 0, 0)).toBe(1);
+  });
+
+  it("a single untimed service still resolves to itself", () => {
+    const one = [{ startsAt: at(10) }];
+    for (const t of [at(6), at(9, 30), at(10, 30), at(23)]) {
+      expect(pickActiveServiceIndex(one, t, 30 * 60, 0, 0)).toBe(0);
+    }
   });
 });

--- a/apps/mobile/features/scheduling/utils/runSheetTiming.ts
+++ b/apps/mobile/features/scheduling/utils/runSheetTiming.ts
@@ -97,8 +97,16 @@ export function computeSegmentedClockTimes(
  * Each service `i` has three phases on the clock:
  *   - **pre-roll** `[startsAt − before, startsAt)` — call time, set-up, line
  *     check, soundcheck, platform briefing;
- *   - **core**     `[startsAt, startsAt + during)` — the service itself;
- *   - **post-roll**`[core end, core end + after)` — teardown, debrief.
+ *   - **core**     `[startsAt, coreEnd)` — the service itself;
+ *   - **post-roll**`[coreEnd, coreEnd + after)` — teardown, debrief.
+ *
+ * `coreEnd` is `startsAt + during` — EXCEPT when the plan carries no `during`
+ * durations at all (a sheet whose before block is filled in but whose service
+ * body isn't timed yet). A zero `during` makes the core empty, which would make
+ * "is a service in progress?" unanswerable and silently disable rule 1 below —
+ * the exact failure this function exists to prevent. With no timing to go on,
+ * a service instead holds the sheet until the NEXT service starts, which is the
+ * only other honest reading of "which service am I in?".
  *
  * Selection order, most specific first:
  *   1. **In progress** — a service whose CORE contains `now`. If several do (a
@@ -148,7 +156,18 @@ export function pickActiveServiceIndex(
 
   for (let i = 0; i < times.length; i++) {
     const start = times[i].startsAt;
-    const coreEnd = start + duringMs;
+    // An untimed service (no `during` durations entered) runs until the next
+    // service starts — see the note above. `times` isn't guaranteed sorted, so
+    // find the soonest start strictly after this one. The last service of the
+    // day has no successor and keeps an empty core; rule 5 catches it.
+    let coreEnd = start + duringMs;
+    if (duringMs === 0) {
+      let nextStart = Infinity;
+      for (const t of times) {
+        if (t.startsAt > start && t.startsAt < nextStart) nextStart = t.startsAt;
+      }
+      coreEnd = nextStart === Infinity ? start : nextStart;
+    }
 
     if (now >= start && now < coreEnd) {
       if (inProgress === -1 || start > times[inProgress].startsAt) inProgress = i;


### PR DESCRIPTION
Follow-up to #777, from an adversarial review of that diff. Closes the one
high-severity hole it found.

## The hole

#777 made **"a service whose core window contains `now`"** outrank the next
service's pre-roll. The core window is `[startsAt, startsAt + during)`, and
`during` is `totalDurationSec(itemsBySegment.during)` — the sum of the plan's
during-segment durations.

That sum is **zero** on a plan whose before block is filled in but whose service
body hasn't been timed yet. A zero-length core can never contain anything, so
rule 1 silently never fired and the plan fell straight through to rule 2 — the
next service's pre-roll — which is the original bug, unchanged:

```
pickActiveServiceIndex([10:00, 12:00], now=10:15, before=150m, during=0, after=0)
  → 1 (12 PM)      ← #777 shipped; identical to the pre-#777 behaviour
```

So the fix was conditional on data the sheet may not have yet, and nothing in
the code or the tests said so. That's the half-built sheet a team is arguably
*most* likely to be holding.

## The fix

An untimed service now runs until the **next** service starts. With no durations
to go on, that is the only other honest reading of "which service am I in?", and
it puts the in-progress rule back in charge:

```
pickActiveServiceIndex([10:00, 12:00], now=10:15, before=150m, during=0, after=0)
  → 0 (10 AM)      ← this PR
```

`times` isn't guaranteed sorted, so the successor is found by scanning for the
soonest start strictly after this one. The last service of the day has no
successor and keeps an empty core; the everything's-over fallback catches it
exactly as before.

## Scope of the behaviour change — measured, not asserted

Same brute-force sweep as #777: 5,376 plan shapes (gaps 60–420 min × before
0–180 × during 0–120 × after 0–45 × 1–3 services), minute-by-minute across 24
hours, compared against the **pre-#777** rule.

```
NON-overlapping (unaffected by the original bug): 3608 shapes, 328 with any behaviour change
   of those, 328 are untimed plans (during=0) and 0 are timed plans
```

**Zero timed plans change.** Production's `Sunday Service` (10-min before block)
and `MH Service` (150/86/0) are untouched by this commit — `MH Service` is fixed
by #777 and stays fixed.

Degenerate inputs still return in-range indices without throwing (`NaN`
durations, negatives, duplicate `startsAt`, empty `times`).

## Tests

Three added, 23 total in the file:

- an untimed multi-service plan resolves to the service you're in at each point
  of the day, not the next one
- **an untimed plan with a 2h30m before block is not stolen by the noon pre-roll**
  — the regression test for this exact hole
- a single untimed service still resolves to itself in every phase

The previous `"falls back to the soonest service when durations are all zero"`
test asserted the old fall-through (`10:00 → the 11:00 service`) and is replaced
by one asserting the corrected behaviour, with the reasoning inline.

Full mobile suite: **241 suites / 2605 tests green**.

## Review findings deliberately NOT changed

Two lower-severity findings from the same review are intentional and now called
out rather than fixed:

- **A service that overruns its planned `during` hands over at the planned end.**
  The handover point is the plan's own number. That is the documented
  between-services rule (next up wins once its pre-roll opens) and the run
  sheet's totals are the only signal available; making it elastic would need a
  real "service has ended" input.
- **A post-roll never outranks the next service's open pre-roll.** Same rule,
  same reason — once you're resetting the room for noon, the 10 AM sheet is the
  wrong document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HoLzEExN76fCWtxxKdSUy
