### PR TITLE
fix(github): point the issue-chooser contact link at a real support address

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question or general feedback
-    url: https://github.com/togathernyc/togather/discussions
-    about: For questions, ideas, or general conversation — start a discussion instead.
+    url: mailto:togather@supa.media
+    about: For questions, ideas, or general conversation — email us and we'll get back to you.


### PR DESCRIPTION
## Summary

`.github/ISSUE_TEMPLATE/config.yml` offered "Question or general feedback" as a link to GitHub Discussions, but Discussions is disabled on this repo (`has_discussions: false`), so that link 404s. Since `blank_issues_enabled: false` makes the template chooser the only web entry point for filing, the one link offered for questions went nowhere.

This points the contact entry at `mailto:togather@supa.media` and updates the `about` copy to match.

## Why this address, and why `mailto:`

`togather@supa.media` is already the product's documented contact address — `SECURITY.md` uses it, and `apps/mobile/app/(landing)/support/index.tsx` renders it as the "Email Support" card on the in-app Support screen. So this follows existing precedent rather than inventing a new channel.

A `mailto:` also removes the failure mode that caused this bug in the first place: there is no URL to rot.

Enabling Discussions instead would also fix it, but that's a repository setting and the owner's call — not something a code change should assume.

## Test plan

- [x] `yaml.safe_load` parses the file; `blank_issues_enabled` is still `False` and the contact entry carries exactly `name` / `url` / `about`
- [ ] Visual check of https://github.com/togathernyc/togather/issues/new/choose after merge — confirm the contact link renders and opens a mail client

## Notes for review

- `togather@supa.media` is currently framed in `SECURITY.md` as the *security* reporting address ("Do NOT open a public GitHub issue for security vulnerabilities"). Pointing general questions there mixes support traffic into that inbox. The in-app Support screen already does this, so this PR follows suit — but if you want the two separated, that needs a second address and a `SECURITY.md` update, which is outside this issue.
- `apps/web/src/pages/ReportIssue.tsx` (route `/issue`) is arguably a nicer destination, but the sandbox proxy blocks `togather.nyc`, so a 200 could not be verified from here. Left alone deliberately.

Fixes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5)_