### PR TITLE
fix(chat): long-press a nested channel row opens the group's expand/collapse sheet

### DIFF
--- a/apps/mobile/features/chat/components/GroupedInboxItem.tsx
+++ b/apps/mobile/features/chat/components/GroupedInboxItem.tsx
@@ -869,6 +869,13 @@ function GroupedInboxItemInner({
         <Pressable
           key={channel._id}
           onPress={() => handleChannelPress(channel)}
+          // The expand/collapse sheet is GROUP-scoped, so a nested channel row
+          // opens the same sheet as its cluster header — long-pressing anywhere
+          // in the cluster behaves identically (issue #781).
+          onLongPress={handleLongPress}
+          delayLongPress={300}
+          // @ts-expect-error - onContextMenu is a web-only prop
+          onContextMenu={handleContextMenu}
           style={({ pressed }) => [
             styles.waRow,
             { backgroundColor: colors.surface },
@@ -1135,6 +1142,11 @@ function GroupedInboxItemInner({
             {/* Sub-channel card */}
             <Pressable
               onPress={() => handleChannelPress(channel)}
+              // Same group-scoped sheet as the main row above (issue #781).
+              onLongPress={handleLongPress}
+              delayLongPress={300}
+              // @ts-expect-error - onContextMenu is a web-only prop
+              onContextMenu={handleContextMenu}
               style={({ pressed }) => [
                 styles.subChannelCard,
                 { backgroundColor: colors.surfaceSecondary, borderColor: "transparent" },

--- a/apps/mobile/features/chat/components/__tests__/GroupedInboxItem.longPress.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/GroupedInboxItem.longPress.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * GroupedInboxItem — long-press parity between a cluster's rows (issue #781).
+ *
+ * The expand/collapse action sheet is GROUP-scoped, so every row of a group's
+ * cluster — the parent row and each nested channel row — must open the same
+ * sheet. Before the fix only the parent row had `onLongPress`, so long-pressing
+ * a nested channel row did nothing and the gesture felt broken.
+ *
+ * Asserted in BOTH shell states: the flag-off cluster (sub-channel cards) and
+ * the flag-on whatsapp cluster (flat sub-rows) render different trees.
+ */
+import React from "react";
+import { ActionSheetIOS } from "react-native";
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { GroupedInboxItem } from "../GroupedInboxItem";
+import { useWhatsappShell } from "@hooks/useWhatsappShell";
+
+jest.mock("@hooks/useWhatsappShell", () => ({
+  useWhatsappShell: jest.fn(() => false),
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock("@providers/AuthProvider", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+
+jest.mock("@hooks/useCommunityTheme", () => ({
+  useCommunityTheme: () => ({ primaryColor: "#25D366" }),
+}));
+
+jest.mock("../../hooks/usePrefetchChannel", () => ({
+  useAwaitPrefetch: () => jest.fn(async () => {}),
+  useTriggerPrefetch: () => jest.fn(),
+}));
+
+const GROUP = {
+  _id: "group-1" as any,
+  name: "Worship Team",
+  preview: undefined,
+  groupTypeId: "type-1" as any,
+  groupTypeName: "Team",
+  groupTypeSlug: "team",
+  isAnnouncementGroup: false,
+};
+
+const channel = (id: string, name: string, channelType: string) => ({
+  _id: id as any,
+  slug: name.toLowerCase(),
+  channelType,
+  name,
+  lastMessagePreview: `hello from ${name}`,
+  lastMessageAt: 1_700_000_000_000,
+  lastMessageSenderName: "Sam",
+  lastMessageSenderId: "user-2" as any,
+  unreadCount: 0,
+});
+
+const CHANNELS = [
+  channel("channel-1", "General", "main"),
+  channel("channel-2", "Prayer", "custom"),
+];
+
+function renderItem(onToggleExpand: () => void) {
+  return render(
+    <GroupedInboxItem
+      group={GROUP}
+      channels={CHANNELS}
+      userRole="member"
+      isExpanded
+      onToggleExpand={onToggleExpand}
+      onToggleCollapse={jest.fn()}
+    />
+  );
+}
+
+describe("GroupedInboxItem long-press (issue #781)", () => {
+  // The real implementation reaches for the native ActionSheetManager, which
+  // doesn't exist under jest — stub it and assert on the options instead.
+  const showActionSheet = jest
+    .spyOn(ActionSheetIOS, "showActionSheetWithOptions")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useWhatsappShell as jest.Mock).mockReturnValue(false);
+  });
+
+  describe.each([
+    ["flag-off cluster", false],
+    ["whatsapp-shell cluster", true],
+  ])("%s", (_label, shellEnabled) => {
+    beforeEach(() => {
+      (useWhatsappShell as jest.Mock).mockReturnValue(shellEnabled);
+    });
+
+    it("opens the group's expand/collapse sheet from the parent row", () => {
+      const onToggleExpand = jest.fn();
+      renderItem(onToggleExpand);
+
+      fireEvent(screen.getByText("Worship Team"), "longPress");
+
+      expect(showActionSheet).toHaveBeenCalledTimes(1);
+      expect(showActionSheet.mock.calls[0][0].options).toEqual([
+        "Cancel",
+        "Collapse",
+      ]);
+    });
+
+    it("opens the same sheet from a nested channel row", () => {
+      const onToggleExpand = jest.fn();
+      renderItem(onToggleExpand);
+
+      fireEvent(screen.getByText("Prayer"), "longPress");
+
+      expect(showActionSheet).toHaveBeenCalledTimes(1);
+      expect(showActionSheet.mock.calls[0][0].options).toEqual([
+        "Cancel",
+        "Collapse",
+      ]);
+
+      // Confirming the action toggles the parent GROUP, not the channel.
+      showActionSheet.mock.calls[0][1](1);
+      expect(onToggleExpand).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

In the Chats list, long-pressing a group parent row opened an action sheet with Cancel + Expand/Collapse. Long-pressing a channel row nested under that group did nothing.

`handleLongPress` and `handleContextMenu` are `useCallback`s in the component body, so the nested rows were already in scope and had full access to them — only the parent rows wired them up. There are **two** nested-row variants, both of which had `onPress` only:

- the whatsapp-shell flat sub-row
- the flag-off sub-channel card

Both now get `onLongPress={handleLongPress}`, `delayLongPress={300}` and `onContextMenu={handleContextMenu}` — the same trio the parent rows already use. The action is group-scoped, so a nested row simply acts on its parent group; no new per-channel actions were invented.

## Test plan

- [x] New test file `GroupedInboxItem.longPress.test.tsx` — written first, failed 2/4 (both nested-row cases) before the fix, passes 4/4 after
- [x] Full mobile suite: `Test Suites: 242 passed, 242 total` · `Tests: 9 skipped, 2609 passed, 2618 total`
- [x] `npx tsc --noEmit` clean; `eslint` clean on both files
- [ ] Manual: long-press a nested channel row on a device — jest can only assert this at the handler level, so a real touch-gesture check is worth doing before merge

## Pre-existing issue found, deliberately NOT fixed here

Under the `whatsapp-shell` flag the action sheet is effectively vestigial on **every** row, parent included: `handleLongPress` toggles `isExpanded`/`onToggleExpand`, but the flag-on cluster computes its sub-rows from the cap/mute ranking and gates visibility on `isCollapsed`/`onToggleCollapse` (the explicit chevron added 2026-07-30, which exists precisely because the long-press sheet "could not be found"). So with the flag on, the sheet opens and labels off state that nothing renders from.

Repointing the sheet at `onToggleCollapse` is a product/design decision and out of scope for #781, so it's left alone — CLAUDE.md says ask first. The flag defaults to **off**, so on today's live path (`isExpanded` genuinely drives sub-row visibility) this fix is fully functional. Someone should decide separately whether to retarget the sheet or drop the long-press sheet entirely now that the chevron exists.

No dependency, `package.json`, lockfile, `runtimeVersion` or `native-deps.json` changes — the diff is JSX props on two existing `Pressable`s plus a test, so no native-safety surface is touched.

Fixes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5)_