### PR TITLE
fix(messaging): built-in channel enable mutations clear isEnabled=false

### DIFF
--- a/apps/convex/__tests__/messaging/channels.test.ts
+++ b/apps/convex/__tests__/messaging/channels.test.ts
@@ -3246,6 +3246,108 @@ describe("toggleMainChannel", () => {
     // Drain the scheduled clear so no jobs leak past the test.
     await t.finishAllScheduledFunctions(vi.runAllTimers);
   });
+
+  test("re-enables a General channel stuck at isEnabled:false with isArchived:false", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, groupId, accessToken } = await seedTestData(t);
+    const { accessToken: leaderToken } = await createLeaderUser(t, communityId, groupId);
+
+    const channelId = await t.mutation(api.functions.messaging.channels.createChannel, {
+      token: accessToken,
+      groupId,
+      channelType: "main",
+      name: "General",
+    });
+
+    // Only reachable via a manual DB edit or a migration, but the recovery
+    // screen treats it as disabled — so enable must actually recover it.
+    await t.run(async (ctx) => ctx.db.patch(channelId, { isEnabled: false }));
+
+    const result = await t.mutation(api.functions.messaging.channels.toggleMainChannel, {
+      token: leaderToken,
+      groupId,
+      enabled: true,
+    });
+    expect(result.status).toBe("enabled");
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const channel = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(channel?.isEnabled).toBe(true);
+    expect(channel?.isArchived).toBe(false);
+  });
+});
+
+describe("toggleLeadersChannel", () => {
+  test("re-enables a leaders channel stuck at isEnabled:false with isArchived:false", async () => {
+    const t = convexTest(schema, modules);
+    const { communityId, groupId } = await seedTestData(t);
+    const { accessToken: leaderToken } = await createLeaderUser(t, communityId, groupId);
+
+    const channelId = await t.mutation(api.functions.messaging.channels.createChannel, {
+      token: leaderToken,
+      groupId,
+      channelType: "leaders",
+      name: "Leaders",
+    });
+
+    await t.run(async (ctx) => ctx.db.patch(channelId, { isEnabled: false }));
+
+    const result = await t.mutation(
+      api.functions.messaging.channels.toggleLeadersChannel,
+      { token: leaderToken, groupId, enabled: true }
+    );
+    expect(result.status).toBe("enabled");
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const channel = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(channel?.isEnabled).toBe(true);
+    expect(channel?.isArchived).toBe(false);
+  });
+});
+
+describe("toggleReachOutChannel", () => {
+  test("re-enables a reach out channel stuck at isEnabled:false with isArchived:false", async () => {
+    const t = convexTest(schema, modules);
+    const { userId, communityId, groupId } = await seedTestData(t);
+    const { accessToken: leaderToken } = await createLeaderUser(t, communityId, groupId);
+
+    // Reach Out requires an enabled leaders channel.
+    await t.mutation(api.functions.messaging.channels.createChannel, {
+      token: leaderToken,
+      groupId,
+      channelType: "leaders",
+      name: "Leaders",
+    });
+
+    const channelId = await t.run(async (ctx) =>
+      ctx.db.insert("chatChannels", {
+        groupId,
+        slug: "reach-out",
+        channelType: "reach_out",
+        name: "Reach Out",
+        createdById: userId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        isEnabled: false,
+        memberCount: 0,
+      })
+    );
+
+    const result = await t.mutation(
+      api.functions.messaging.channels.toggleReachOutChannel,
+      { token: leaderToken, groupId, enabled: true }
+    );
+    expect(result.status).toBe("enabled");
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const channel = await t.run(async (ctx) => ctx.db.get(channelId));
+    expect(channel?.isEnabled).toBe(true);
+    expect(channel?.isArchived).toBe(false);
+  });
 });
 
 describe("toggleAnnouncementsChannel", () => {

--- a/apps/convex/functions/messaging/channels.ts
+++ b/apps/convex/functions/messaging/channels.ts
@@ -4205,8 +4205,11 @@ export const toggleLeadersChannel = mutation({
 
     // Check idempotency
     const isCurrentlyArchived = leadersChannel.isArchived === true;
+    // See toggleMainChannel: an unarchived channel left at `isEnabled: false`
+    // reads as disabled everywhere, so enable must clear it. Issue #463.
+    const isCurrentlyDisabled = leadersChannel.isEnabled === false;
 
-    if (args.enabled && !isCurrentlyArchived) {
+    if (args.enabled && !isCurrentlyArchived && !isCurrentlyDisabled) {
       // Already enabled, no-op
       return { channelId: leadersChannel._id, status: "already_enabled" };
     }
@@ -4223,6 +4226,7 @@ export const toggleLeadersChannel = mutation({
       await ctx.db.patch(leadersChannel._id, {
         isArchived: false,
         archivedAt: undefined,
+        isEnabled: true,
         updatedAt: now,
       });
 
@@ -4384,16 +4388,23 @@ export const toggleReachOutChannel = mutation({
     if (args.enabled) {
       let channelId: Id<"chatChannels">;
 
-      if (existingChannel && !existingChannel.isArchived) {
+      // See toggleMainChannel: an unarchived channel left at `isEnabled: false`
+      // reads as disabled everywhere, so enable must clear it. Issue #463.
+      if (
+        existingChannel &&
+        !existingChannel.isArchived &&
+        existingChannel.isEnabled !== false
+      ) {
         // Already enabled
         return { channelId: existingChannel._id, status: "already_enabled" };
       }
 
       if (existingChannel) {
-        // Unarchive existing channel
+        // Unarchive / un-disable existing channel
         await ctx.db.patch(existingChannel._id, {
           isArchived: false,
           archivedAt: undefined,
+          isEnabled: true,
           updatedAt: now,
         });
         channelId = existingChannel._id;
@@ -4917,8 +4928,13 @@ export const toggleMainChannel = mutation({
     }
 
     const isCurrentlyArchived = mainChannel.isArchived === true;
+    // Built-in toggles only ever flip `isArchived`, but a migration or manual DB
+    // edit can leave `isEnabled: false` on an unarchived channel — which readers
+    // treat as disabled. Enable must recover from that too, or the channel stays
+    // hidden with no in-app way back. See issue #463.
+    const isCurrentlyDisabled = mainChannel.isEnabled === false;
 
-    if (args.enabled && !isCurrentlyArchived) {
+    if (args.enabled && !isCurrentlyArchived && !isCurrentlyDisabled) {
       return { channelId: mainChannel._id, status: "already_enabled" as const };
     }
 
@@ -4930,6 +4946,7 @@ export const toggleMainChannel = mutation({
       await ctx.db.patch(mainChannel._id, {
         isArchived: false,
         archivedAt: undefined,
+        isEnabled: true,
         updatedAt: now,
       });
 


### PR DESCRIPTION
## Summary

The built-in group-channel enable mutations toggled only `isArchived`. On enable they short-circuited with `already_enabled` whenever `isArchived === false`, and never patched `isEnabled` back to `true`.

That left a state with no recovery path: a built-in channel at `isEnabled: false` + `isArchived: false` reads as disabled to the list and recovery screens (`!isArchived && isEnabled !== false`), but the enable mutation sees `isArchived === false`, returns `already_enabled`, and leaves it hidden from members forever.

## What changed

All three built-in enable paths now recover from `isEnabled: false` as well as `isArchived: true`:

- **`toggleMainChannel`** — added `isCurrentlyDisabled = mainChannel.isEnabled === false`; the `already_enabled` short-circuit now requires `!isCurrentlyArchived && !isCurrentlyDisabled`; the enable patch adds `isEnabled: true`
- **`toggleLeadersChannel`** — same guard change, unarchive patch adds `isEnabled: true`
- **`toggleReachOutChannel`** — `already_enabled` check is now `existingChannel && !existingChannel.isArchived && existingChannel.isEnabled !== false`; the existing-channel patch adds `isEnabled: true`

Disable paths, permission checks, membership fan-out and `reachOutConfig` handling are untouched.

`disabledByUserId` is deliberately **not** cleared — the built-in disable paths never set it, and clearing it is announcements-share-specific behavior (`restoreOwnAnnouncementsChannelLogic`). Keeping the change tight, as the issue asked.

## Test plan

Three new tests, one per mutation. `toggleLeadersChannel` and `toggleReachOutChannel` had no prior coverage in the repo, so those describe blocks are new.

Red first — all three failed with `AssertionError: expected 'already_enabled' to be 'enabled'`, exactly the gap in the issue:
```
 Test Files  1 failed (1)
      Tests  3 failed | 142 skipped (145)
```

Green after:
```
 Test Files  1 passed (1)
      Tests  3 passed | 142 skipped (145)
```

Full Convex suite:
```
 Test Files  182 passed (182)
      Tests  3411 passed (3411)
   Duration  170.62s
```

`npx tsc --noEmit` in `apps/convex` is clean. (`npx convex typecheck` errors with `ENOENT: scandir 'convex/'` — the CLI expects a `convex/` subdirectory but functions live in `apps/convex/functions/`. Unrelated to this change, but worth knowing since CI runs that command.)

## Note for review

The `reach_out` enable precondition still gates only on `leadersChannel.isArchived`, so a leaders channel stuck at `isEnabled: false` would not block enabling Reach Out. Same latent class of bug — flagged rather than fixed, since the issue asked to keep this tight.

Fixes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5)_