### PR TITLE
fix(demo): seeded giving link points at a live guide instead of a Pushpay 404

### DIFF
--- a/apps/convex/__tests__/demo-community.test.ts
+++ b/apps/convex/__tests__/demo-community.test.ts
@@ -1418,7 +1418,11 @@ describe("demo v4: native Serve Day card, giving link, roster, member health", (
 
     expect(resource?.title).toBe("Partner with us");
     expect(resource?.showInInbox).toBe(true);
-    expect(resource?.linkUrl).toContain("pushpay.com");
+    // The placeholder must be a live Togather-owned page that explains it's a
+    // placeholder — never a third-party giving URL that can 404 (#780).
+    expect(resource?.linkUrl).toBe(
+      "https://togather.nyc/guides/create-your-community#giving",
+    );
     expect(resource?.isDemoSeed).toBe(true);
   });
 

--- a/apps/convex/functions/demo.ts
+++ b/apps/convex/functions/demo.ts
@@ -62,8 +62,16 @@ export const MAX_REAL_USERS = 10;
  * Placeholder "give" destination on the seeded "Partner with us" link. A church
  * points this at their real giving page (that edit is one of the Getting
  * Started missions); the link is removed on go-live if left unchanged.
+ *
+ * It deliberately targets our own guide — which explains that the link is a
+ * placeholder and how to replace it — rather than a third-party giving page we
+ * don't control and that can 404 (#780). Hardcoded to the production domain
+ * (not DOMAIN_CONFIG) because this value is stored on the row and later
+ * compared for equality to decide "did the church edit this?"; an
+ * environment-dependent value would make that comparison unreliable.
  */
-export const DEMO_GIVING_URL = "https://pushpay.com/g/togatherdemo";
+export const DEMO_GIVING_URL =
+  "https://togather.nyc/guides/create-your-community#giving";
 
 /** Fallback service times when a campus doesn't specify any. */
 const DEFAULT_SERVICE_TIMES = [
@@ -2762,7 +2770,7 @@ export const purgeDemoSeedUsers = internalMutation({
       }
 
       // Delete the demo-only "Partner with us" giving link ONLY if it still
-      // points at the placeholder Pushpay URL. If the church edited it (the
+      // points at the placeholder guide URL. If the church edited it (the
       // "Make giving yours" mission), it's their real giving link now — keep it
       // even though isDemoSeed is still set (groupResources.update doesn't
       // clear the flag).

--- a/apps/web/src/components/ScrollToTop.tsx
+++ b/apps/web/src/components/ScrollToTop.tsx
@@ -5,13 +5,25 @@ import { useLocation } from 'react-router-dom';
  * Scrolls to top of page on route change.
  * This ensures that when navigating between pages (e.g., from footer to legal pages),
  * the new page starts at the top instead of preserving the previous scroll position.
+ *
+ * A URL with a hash is the exception: scroll to that section instead, so links
+ * into a specific part of a guide land there (the seeded "Partner with us"
+ * demo link points at /guides/create-your-community#giving). The browser can't
+ * do it for us — the target doesn't exist yet when the SPA first paints.
  */
 export function ScrollToTop() {
-  const { pathname } = useLocation();
+  const { pathname, hash } = useLocation();
 
   useEffect(() => {
+    if (hash) {
+      const target = document.getElementById(hash.slice(1));
+      if (target) {
+        target.scrollIntoView();
+        return;
+      }
+    }
     window.scrollTo(0, 0);
-  }, [pathname]);
+  }, [pathname, hash]);
 
   return null;
 }

--- a/apps/web/src/pages/guides/CreateCommunity.tsx
+++ b/apps/web/src/pages/guides/CreateCommunity.tsx
@@ -17,6 +17,7 @@ import { appLinks } from "../../guides/appLinks";
 const toc: TocItem[] = [
   { id: "switcher", label: "Open the community switcher" },
   { id: "demo", label: "Start in demo mode" },
+  { id: "giving", label: "The giving link is a placeholder" },
   { id: "team", label: "Explore it with your team" },
   { id: "go-live", label: "Go live: $1 per active member" },
   { id: "self-host", label: "Prefer to run it yourself?" },
@@ -123,6 +124,28 @@ export function CreateCommunity() {
           they're ready for the real thing.
         </Callout>
         <DeepLink href={appLinks.demo}>Create your community</DeepLink>
+      </Section>
+
+      {/* The seeded "Partner with us" chip links straight to this section —
+          see DEMO_GIVING_URL in apps/convex/functions/demo.ts. */}
+      <Section id="giving" title="The giving link is a placeholder">
+        <P>
+          Your demo seeds a <Term>Partner with us</Term> giving link on the
+          announcements group — the chip at the top of Chats. It points at this
+          guide on purpose: it's a placeholder, because we don't yet know where
+          your church receives gifts.
+        </P>
+        <P>
+          Make it yours from the announcements group → <Term>ⓘ Info</Term> →{" "}
+          <Term>Toolbar Settings</Term>, and point it at your giving page.
+          That's one of the Getting Started missions tracked on the Go Live
+          screen.
+        </P>
+        <Callout tone="note" title="Leave it and it disappears">
+          If you never edit the link, we delete it when you go live rather than
+          leave a placeholder in your community. Edit it and it's yours to
+          keep.
+        </Callout>
       </Section>
 
       <Section id="team" title="Explore it with your team">


### PR DESCRIPTION
## Summary

The demo seed inserts a "Partner with us" `groupResources` row using `DEMO_GIVING_URL`, which was `https://pushpay.com/g/togatherdemo`. That URL returns 404 with no redirect, so every demo community that hasn't gone live shows a chip in the Chats inbox that lands on a Pushpay error page.

`DEMO_GIVING_URL` now points at `https://togather.nyc/guides/create-your-community#giving` — an existing live guide that already documented this giving link. No new page or route was invented.

## What changed

- **`apps/convex/functions/demo.ts`** — new constant value, plus a JSDoc explaining why it's hardcoded to the production domain rather than built from `DOMAIN_CONFIG`: the value is persisted on the `groupResources` row and later compared for equality by the go-live purge, so an env-dependent value would make that comparison unreliable. Also fixed the now-stale "placeholder Pushpay URL" comment above the purge.
- **`apps/convex/__tests__/demo-community.test.ts`** — `toContain("pushpay.com")` → an exact `toBe(...)` on the new URL. Written before the constant change (TDD); confirmed red, then green.
- **`apps/web/src/pages/guides/CreateCommunity.tsx`** — a short `<Section id="giving">` plus TOC entry saying the giving link is a placeholder, how to repoint it (announcements group → ⓘ Info → Toolbar Settings, matching the `update_giving` mission copy verbatim), and that it's deleted on go-live if untouched.
- **`apps/web/src/components/ScrollToTop.tsx`** — now honors a URL hash. Without this the `#giving` fragment was dead on arrival: `ScrollToTop` unconditionally scrolled to top on mount. Also fixes in-page TOC deep links generally.

The resource **title** stays "Partner with us" — the `update_giving` mission instruction, the go-live purge and the guide prose all reference that exact string, and the chip opens `linkUrl` directly, so placeholder copy on the row would never be seen. The destination page carries the explanation instead.

## Test plan

- [x] `npx convex typecheck`: `✔ Typecheck passed: tsc --noEmit completed with exit code 0.`
- [x] `pnpm test` in `apps/convex`: `Test Files 182 passed (182)` · `Tests 3408 passed (3408)`
- [x] `pnpm type-check` and `pnpm lint` in `apps/web`: clean
- [x] `pnpm build` in `apps/web`: `✓ built in 1.97s`, 19 route HTML files + 18 OG cards
- [x] Repo-wide grep for `pushpay`: zero remaining references
- [ ] **Confirm https://togather.nyc/guides/create-your-community#giving loads in production** — see below

## One thing a human must check

The sandbox egress proxy denies `togather.nyc` by policy (`CONNECT tunnel failed, response 403`), so **HTTP 200 could not be verified from here**. Static evidence gathered instead: the route is registered in `apps/web/src/routes.tsx`, `apps/web/public/_redirects` is `/* /index.html 200`, `/guides/` is in the link-preview worker's `LANDING_PAGE_PREFIXES`, and `apps/mobile/app/__tests__/native-intent.test.ts` already asserts `/guides/*` universal links bounce to the browser. Please eyeball the live URL before merging.

Fixes #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5)_