### PR TITLE
fix(rostering): two follow-ups from #401 review — unlink copy and team header flash

### DIFF
--- a/apps/mobile/features/scheduling/components/EventEditorScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventEditorScreen.tsx
@@ -648,8 +648,7 @@ function groupRolesByTeam(roles: EventRole[]): Array<{
 /**
  * A team's section: header (name + chat toggle + "Open chat" shortcut) and
  * its role assignment cards. Fetches the team via `getTeam` so it has the
- * `hasChannel` / `channelSlug` / `memberCount` fields the toggle and
- * shortcut both need.
+ * `hasChannel` / `channelSlug` fields the toggle and shortcut both need.
  */
 function TeamRoleGroup({
   groupId,
@@ -675,7 +674,6 @@ function TeamRoleGroup({
         name: string;
         hasChannel: boolean;
         channelSlug: string | null;
-        memberCount: number;
       }
     | undefined;
 
@@ -698,7 +696,6 @@ function TeamRoleGroup({
               teamId={team._id}
               teamName={team.name}
               hasChannel={team.hasChannel}
-              channelMemberCount={team.memberCount}
             />
             {team.hasChannel && team.channelSlug ? (
               <Pressable

--- a/apps/mobile/features/scheduling/components/EventEditorScreen.tsx
+++ b/apps/mobile/features/scheduling/components/EventEditorScreen.tsx
@@ -649,8 +649,10 @@ function groupRolesByTeam(roles: EventRole[]): Array<{
  * A team's section: header (name + chat toggle + "Open chat" shortcut) and
  * its role assignment cards. Fetches the team via `getTeam` so it has the
  * `hasChannel` / `channelSlug` fields the toggle and shortcut both need.
+ *
+ * Exported for tests only — the screen renders it internally.
  */
-function TeamRoleGroup({
+export function TeamRoleGroup({
   groupId,
   teamId,
   roles,
@@ -677,9 +679,10 @@ function TeamRoleGroup({
       }
     | undefined;
 
-  // Fall back to the role's embedded team-less name while `getTeam` resolves.
-  const fallbackName = roles[0]?.roleName ?? "Team";
-  const teamName = team?.name ?? fallbackName;
+  // Neutral placeholder while `getTeam` resolves — falling back to the first
+  // role's name made the header flash as if the team were called "Greeter"
+  // (issue #403).
+  const teamName = team?.name ?? "Team";
 
   return (
     <View style={styles.teamGroup}>

--- a/apps/mobile/features/scheduling/components/NeededRolesModal.tsx
+++ b/apps/mobile/features/scheduling/components/NeededRolesModal.tsx
@@ -46,7 +46,6 @@ type Team = {
   _id: Id<"teams">;
   name: string;
   hasChannel: boolean;
-  memberCount: number;
 };
 type Role = {
   _id: Id<"teamRoles">;
@@ -461,7 +460,6 @@ function TeamSection({
             teamId={team._id}
             teamName={team.name}
             hasChannel={team.hasChannel}
-            channelMemberCount={team.memberCount}
           />
           {totalNeeded > 0 ? (
             <Text

--- a/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
+++ b/apps/mobile/features/scheduling/components/RosterGridScreen.tsx
@@ -143,7 +143,6 @@ type RosterTeam = {
   teamId: Id<"teams">;
   teamName: string;
   hasChannel: boolean;
-  channelMemberCount: number;
   /** Whether the viewer is an explicit manager of this team (ADR-025). */
   isManagedByMe: boolean;
 };
@@ -243,7 +242,6 @@ type RoleRow =
       teamId: Id<"teams">;
       teamName: string;
       hasChannel: boolean;
-      channelMemberCount: number;
     }
   | { kind: "addTeam" };
 
@@ -960,7 +958,6 @@ export function RosterGridScreen() {
         teamId: team.teamId,
         teamName: team.teamName,
         hasChannel: team.hasChannel,
-        channelMemberCount: team.channelMemberCount,
       });
     }
     // Trailing "＋ Add team". Hidden whenever the grid is narrowed, so the rows
@@ -1991,7 +1988,6 @@ export function RosterGridScreen() {
                 teamId={r.teamId}
                 teamName={r.teamName}
                 hasChannel={r.hasChannel}
-                channelMemberCount={r.channelMemberCount}
               />
             </View>
           );

--- a/apps/mobile/features/scheduling/components/TeamChannelToggle.tsx
+++ b/apps/mobile/features/scheduling/components/TeamChannelToggle.tsx
@@ -27,16 +27,10 @@ export function TeamChannelToggle({
   teamId,
   teamName,
   hasChannel,
-  /**
-   * Auto-synced channel member count, used in the "turn off" confirm so the
-   * leader can see the human impact before unlinking.
-   */
-  channelMemberCount = 0,
 }: {
   teamId: Id<"teams">;
   teamName: string;
   hasChannel: boolean;
-  channelMemberCount?: number;
 }) {
   const { colors } = useTheme();
   const linkChannel = useAuthenticatedMutation(
@@ -74,9 +68,11 @@ export function TeamChannelToggle({
     if (hasChannel) {
       const ok = await confirmAsync({
         title: `Turn off chat for ${teamName}?`,
-        message: `The team's chat channel will be unlinked. ${channelMemberCount} auto-synced ${
-          channelMemberCount === 1 ? "member is" : "members are"
-        } removed from it; the channel itself stays in the inbox as a regular custom channel. You can turn chat back on later. This affects every event this team is on.`,
+        // No count here on purpose: `unlinkChannel` only purges rows with
+        // `syncSource: "event_plan"`, so the channel's total membership would
+        // overstate what actually gets removed (issue #402).
+        message:
+          "The team's chat channel will be unlinked. Auto-synced members will be removed from it; any permanent members you added stay, and the channel itself stays in the inbox as a regular custom channel. You can turn chat back on later. This affects every event this team is on.",
         confirmText: "Turn off",
         destructive: true,
       });
@@ -90,7 +86,7 @@ export function TeamChannelToggle({
       });
       if (ok) void performToggle(true);
     }
-  }, [busy, hasChannel, teamName, channelMemberCount, performToggle]);
+  }, [busy, hasChannel, teamName, performToggle]);
 
   const tint = hasChannel ? colors.success : colors.textTertiary;
   const bg = hasChannel ? colors.success + "22" : colors.border;

--- a/apps/mobile/features/scheduling/components/__tests__/TeamChannelToggle.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/TeamChannelToggle.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+
+// The toggle only needs RN + Ionicons; Convex, theming and the platform alert
+// helpers are stubbed so the module loads in isolation and we can assert on
+// the exact confirm copy the leader sees.
+jest.mock("@services/api/convex", () => ({
+  api: {
+    functions: {
+      scheduling: { teams: { linkChannel: "linkChannel", unlinkChannel: "unlinkChannel" } },
+    },
+  },
+  useAuthenticatedMutation: jest.fn(() => jest.fn()),
+}));
+jest.mock("@hooks/useTheme", () => ({
+  useTheme: () => ({
+    colors: { success: "#0a0", textTertiary: "#999", border: "#ccc" },
+  }),
+}));
+jest.mock("@/utils/platformAlert", () => ({
+  confirmAsync: jest.fn(() => Promise.resolve(false)),
+  notify: jest.fn(),
+}));
+
+import { TeamChannelToggle } from "../TeamChannelToggle";
+import { confirmAsync } from "@/utils/platformAlert";
+
+const mockConfirm = confirmAsync as jest.MockedFunction<typeof confirmAsync>;
+
+describe("TeamChannelToggle", () => {
+  beforeEach(() => {
+    mockConfirm.mockClear();
+  });
+
+  it("does not quote a member count when turning chat off", async () => {
+    const { getByLabelText } = render(
+      <TeamChannelToggle
+        teamId={"team-1" as never}
+        teamName="Hospitality"
+        hasChannel
+      />,
+    );
+
+    fireEvent.press(getByLabelText("Turn chat off for Hospitality"));
+
+    await waitFor(() => expect(mockConfirm).toHaveBeenCalled());
+    const { title, message } = mockConfirm.mock.calls[0][0];
+    expect(title).toBe("Turn off chat for Hospitality?");
+    // The channel's total membership includes permanent members, so quoting a
+    // number here would overstate what unlinking removes (issue #402).
+    expect(message).not.toMatch(/\d/);
+    expect(message).toContain("Auto-synced members will be removed");
+    expect(message).toContain("permanent members");
+  });
+
+  it("still explains what turning chat on does", async () => {
+    const { getByLabelText } = render(
+      <TeamChannelToggle
+        teamId={"team-1" as never}
+        teamName="Hospitality"
+        hasChannel={false}
+      />,
+    );
+
+    fireEvent.press(getByLabelText("Turn chat on for Hospitality"));
+
+    await waitFor(() => expect(mockConfirm).toHaveBeenCalled());
+    expect(mockConfirm.mock.calls[0][0].title).toBe(
+      "Turn on chat for Hospitality?",
+    );
+  });
+});

--- a/apps/mobile/features/scheduling/components/__tests__/TeamRoleGroup.test.tsx
+++ b/apps/mobile/features/scheduling/components/__tests__/TeamRoleGroup.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+// TeamRoleGroup lives in EventEditorScreen, which pulls in Convex, the router
+// and several heavy sibling components at import time. The group itself only
+// needs RN + Ionicons + the shared styles, so the heavy modules are stubbed.
+const mockUseAuthenticatedQuery = jest.fn();
+jest.mock("@services/api/convex", () => ({
+  api: { functions: { scheduling: { teams: { getTeam: "getTeam" } } } },
+  useAuthenticatedQuery: (...args: unknown[]) => mockUseAuthenticatedQuery(...args),
+  useAuthenticatedMutation: jest.fn(() => jest.fn()),
+  useAuthenticatedAction: jest.fn(() => jest.fn()),
+}));
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn(), canGoBack: () => false }),
+  useLocalSearchParams: () => ({ id: "plan-1" }),
+}));
+jest.mock("@hooks/useTheme", () => ({ useTheme: () => ({ colors: {} }) }));
+jest.mock("@hooks/useCommunityTheme", () => ({
+  useCommunityTheme: () => ({ primaryColor: "#2563EB" }),
+}));
+jest.mock("../NeededRolesModal", () => ({ NeededRolesModal: () => null }));
+jest.mock("../AssignSheet", () => ({ AssignSheet: () => null }));
+jest.mock("../TimesEditor", () => ({ TimesEditor: () => null }));
+jest.mock("../TeamChannelToggle", () => ({ TeamChannelToggle: () => null }));
+
+import { TeamRoleGroup } from "../EventEditorScreen";
+
+const ROLES = [
+  {
+    roleId: "role-1",
+    teamId: "team-1",
+    roleName: "Greeter",
+    needed: 2,
+    filled: 0,
+    open: 2,
+    assignments: [],
+  },
+] as any;
+
+function renderGroup() {
+  return render(
+    <TeamRoleGroup
+      groupId={"group-1" as never}
+      teamId={"team-1" as never}
+      roles={ROLES}
+      onAssign={jest.fn()}
+      onUnassign={jest.fn()}
+    />,
+  );
+}
+
+describe("TeamRoleGroup header", () => {
+  afterEach(() => {
+    mockUseAuthenticatedQuery.mockReset();
+  });
+
+  it("shows a neutral placeholder while getTeam is loading", () => {
+    mockUseAuthenticatedQuery.mockReturnValue(undefined);
+    const { getByText, queryAllByText } = renderGroup();
+
+    // Never the first role's name — that reads as if the team were called
+    // "Greeter" for a frame (issue #403). The role card still shows it.
+    expect(getByText("Team")).toBeTruthy();
+    expect(queryAllByText("Greeter")).toHaveLength(1);
+  });
+
+  it("shows the real team name once getTeam resolves", () => {
+    mockUseAuthenticatedQuery.mockReturnValue({
+      _id: "team-1",
+      name: "Hospitality",
+      hasChannel: false,
+      channelSlug: null,
+    });
+    const { getByText, queryByText } = renderGroup();
+
+    expect(getByText("Hospitality")).toBeTruthy();
+    expect(queryByText("Team")).toBeNull();
+  });
+});


### PR DESCRIPTION
Two small, related follow-ups from the same PR #401 review, both in scheduling/rostering. Two atomic commits.

## Commit 1 — don't quote a member count when unlinking team chat (#402)

The "Turn off chat for {team}?" confirm said *"{N} auto-synced members are removed"*, where `N` was `team.memberCount` — the channel's **total** active membership, including permanent/manually-added members. `unlinkChannel` itself is correct (`purgeSyncedMembers` only touches `syncSource: "event_plan"` rows), but the copy oversold the scope for any team with permanent members.

Took the generic-copy option rather than computing a second count — a extra round-trip for a confirm dialog isn't worth it. New message:

> The team's chat channel will be unlinked. Auto-synced members will be removed from it; any permanent members you added stay, and the channel itself stays in the inbox as a regular custom channel. You can turn chat back on later. This affects every event this team is on.

"Turn on" copy is unchanged.

With the count gone, `channelMemberCount` was dead, so it's removed rather than left dangling (CLAUDE.md: remove, don't deprecate) — the prop, its type, default and `useCallback` dep in `TeamChannelToggle`, plus the call sites and now-unused local type fields in `RosterGridScreen`, `NeededRolesModal` and `EventEditorScreen`. Verified zero remaining references repo-wide. The backend still returns those fields; only unused frontend plumbing went away.

## Commit 2 — stop flashing a role name as the team header (#403)

`TeamRoleGroup` fell back to `roles[0]?.roleName` while `getTeam` loaded, so the header briefly read like the team was named after its first role ("Greeter" instead of "Hospitality"). Now `const teamName = team?.name ?? "Team";`.

No skeleton introduced — there's no existing skeleton pattern for this case, and the header already renders an `ActivityIndicator` for the actions row while `team` is undefined.

## Test plan

Both tests written first and confirmed failing before their fix.

- [x] `TeamChannelToggle.test.tsx` — 2/2 passing (new)
- [x] `TeamRoleGroup.test.tsx` — 2/2 passing (new)
- [x] Full mobile suite: `Test Suites: 243 passed, 243 total` · `Tests: 9 skipped, 2609 passed, 2618 total`
- [x] ESLint on all six changed files: 0 errors (17 warnings, all pre-existing)
- [x] `npx tsc --noEmit`: 21 errors, **all pre-existing on `main`** (leader-tools test mocks, ServingTasksScreen, tasks helpers, useDevToolsEscapeHatch). Zero errors in any `features/scheduling/**` file.

## Two judgement calls to sanity-check

- `TeamRoleGroup` is now exported purely for testability. That mirrors `AvailabilityPicker`, which `RosterGridScreen` already exports solely for its test — but say the word if you'd rather keep the module surface minimal.
- Removing `memberCount` from `NeededRolesModal`'s local `Team` type and `EventEditorScreen`'s `getTeam` cast is dead-code cleanup, not strictly required by #402. Revert those two hunks if you'd prefer local types to keep mirroring the backend shape.

No native or dependency surface touched, so no device/OTA verification needed. No `apps/web` guide covers this confirm copy.

Fixes #402
Fixes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5)_