### PR TITLE
fix(dm): show the recipient's name on expired DM requests instead of "Conversation"

### DIFF
--- a/apps/convex/__tests__/messaging/directMessages.test.ts
+++ b/apps/convex/__tests__/messaging/directMessages.test.ts
@@ -1247,6 +1247,60 @@ describe("former member display (expired 1:1 DM requests)", () => {
 
     await t.finishInProgressScheduledFunctions();
   });
+
+  test("does not expose a blocker's identity to the sender they blocked", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Blocked Former Member");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+      lastName: "Anderson",
+    });
+    const { userId: bId, accessToken: bToken } = await createUserInCommunity(
+      t,
+      communityId,
+      { firstName: "Bob", lastName: "Smith" },
+    );
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, communityId, recipientUserId: bId },
+    );
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: aToken,
+      channelId,
+      content: "hey",
+    });
+    await t.finishInProgressScheduledFunctions();
+
+    // Bob taps "Block & Report" on the cold DM request. This marks only Bob's
+    // member row declined + leftAt; the channel stays in Alice's inbox.
+    await t.mutation(
+      api.functions.messaging.directMessages.respondToChatRequest,
+      { token: bToken, channelId, response: "block", reportReason: "spam" },
+    );
+    await t.finishInProgressScheduledFunctions();
+
+    // Alice must NOT learn who blocked her — the file's own convention
+    // (`isBlockedEitherDirection` gating creation and the member/search
+    // listings) is that a block hides the other party in both directions.
+    const inbox = await t.query(
+      api.functions.messaging.directMessages.getDirectInbox,
+      { token: aToken, communityId },
+    );
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0].otherMembers).toHaveLength(0);
+    expect(inbox[0].formerMember).toBeNull();
+
+    const members = await t.query(
+      api.functions.messaging.directMessages.getAdHocChannelMembers,
+      { token: aToken, channelId },
+    );
+    expect(members).not.toBeNull();
+    expect(members!.otherMembers).toHaveLength(0);
+    expect(members!.formerMember).toBeNull();
+
+    await t.finishInProgressScheduledFunctions();
+  });
 });
 
 // ============================================================================

--- a/apps/convex/__tests__/messaging/directMessages.test.ts
+++ b/apps/convex/__tests__/messaging/directMessages.test.ts
@@ -1248,6 +1248,53 @@ describe("former member display (expired 1:1 DM requests)", () => {
     await t.finishInProgressScheduledFunctions();
   });
 
+  test("resolves the departed member from the membership snapshot, not their live profile", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Former Member Snapshot");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "David",
+      lastName: "Walker",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, communityId, recipientUserId: bId },
+    );
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: aToken,
+      channelId,
+      content: "yo",
+    });
+    await t.finishInProgressScheduledFunctions();
+
+    await expirePendingRequest(t, channelId, bId);
+
+    // David edits his profile AFTER leaving. Active members in getDirectInbox
+    // are rendered from the denormalized member row, so a departed person must
+    // not get a fresher identity than one who is still there — and edits made
+    // after leaving must not keep streaming to the other party.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(bId, { firstName: "Renamed", lastName: "Person" });
+    });
+
+    const inbox = await t.query(
+      api.functions.messaging.directMessages.getDirectInbox,
+      { token: aToken, communityId },
+    );
+    expect(inbox[0].formerMember?.displayName).toBe("David Walker");
+
+    const members = await t.query(
+      api.functions.messaging.directMessages.getAdHocChannelMembers,
+      { token: aToken, channelId },
+    );
+    expect(members!.formerMember?.displayName).toBe("David Walker");
+
+    await t.finishInProgressScheduledFunctions();
+  });
+
   test("does not expose a blocker's identity to the sender they blocked", async () => {
     const t = convexTest(schema, modules);
     const communityId = await createCommunity(t, "Blocked Former Member");

--- a/apps/convex/__tests__/messaging/directMessages.test.ts
+++ b/apps/convex/__tests__/messaging/directMessages.test.ts
@@ -1066,6 +1066,190 @@ describe("getDirectInbox", () => {
 });
 
 // ============================================================================
+// Former-member display name (issue #426)
+// ============================================================================
+
+/**
+ * Backdate a member row past the 30-day pending TTL and run the expiry cron,
+ * which marks it `declined` + `leftAt` — the state that used to blank out the
+ * sender's inbox row.
+ */
+async function expirePendingRequest(
+  t: ReturnType<typeof convexTest>,
+  channelId: Id<"chatChannels">,
+  userId: Id<"users">,
+) {
+  const row = await getMember(t, channelId, userId);
+  const rowId = row!._id;
+  await t.run(async (ctx) => {
+    await ctx.db.patch(rowId, {
+      joinedAt: Date.now() - 31 * 24 * 60 * 60 * 1000,
+    });
+  });
+  await t.mutation(
+    internal.functions.messaging.directMessages.expireOldChatRequests,
+    {},
+  );
+}
+
+describe("former member display (expired 1:1 DM requests)", () => {
+  test("getDirectInbox keeps the recipient's name after their request expires", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Former Member Inbox");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+      lastName: "Anderson",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "David",
+      lastName: "Walker",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, communityId, recipientUserId: bId },
+    );
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: aToken,
+      channelId,
+      content: "yo",
+    });
+    await t.finishInProgressScheduledFunctions();
+
+    await expirePendingRequest(t, channelId, bId);
+
+    const inbox = await t.query(
+      api.functions.messaging.directMessages.getDirectInbox,
+      { token: aToken, communityId },
+    );
+    expect(inbox).toHaveLength(1);
+    // The recipient left, so they are NOT an active member...
+    expect(inbox[0].otherMembers).toHaveLength(0);
+    // ...but their identity is still available for display.
+    expect(inbox[0].formerMember).not.toBeNull();
+    expect(inbox[0].formerMember?.userId).toBe(bId);
+    expect(inbox[0].formerMember?.displayName).toBe("David Walker");
+
+    await t.finishInProgressScheduledFunctions();
+  });
+
+  test("getDirectInbox leaves formerMember null while the recipient is still pending", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Pending Member Inbox");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "David",
+      lastName: "Walker",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, communityId, recipientUserId: bId },
+    );
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: aToken,
+      channelId,
+      content: "yo",
+    });
+    await t.finishInProgressScheduledFunctions();
+
+    const inbox = await t.query(
+      api.functions.messaging.directMessages.getDirectInbox,
+      { token: aToken, communityId },
+    );
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0].otherMembers.map((m) => m.userId)).toEqual([bId]);
+    expect(inbox[0].formerMember).toBeNull();
+
+    await t.finishInProgressScheduledFunctions();
+  });
+
+  test("getDirectInbox does not resolve former members for group_dm rows", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Former Member Group");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "David",
+      lastName: "Walker",
+    });
+    const { userId: cId } = await createUserInCommunity(t, communityId, {
+      firstName: "Carol",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createGroupChat,
+      {
+        token: aToken,
+        communityId,
+        recipientUserIds: [bId, cId],
+        name: "Planning",
+      },
+    );
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: aToken,
+      channelId,
+      content: "hi all",
+    });
+    await t.finishInProgressScheduledFunctions();
+
+    await expirePendingRequest(t, channelId, bId);
+
+    const inbox = await t.query(
+      api.functions.messaging.directMessages.getDirectInbox,
+      { token: aToken, communityId },
+    );
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0].channelType).toBe("group_dm");
+    expect(inbox[0].otherMembers.map((m) => m.userId)).toEqual([cId]);
+    // "Someone left" is legitimately different in a group chat — no
+    // resurrection of departed members there.
+    expect(inbox[0].formerMember).toBeNull();
+
+    await t.finishInProgressScheduledFunctions();
+  });
+
+  test("getAdHocChannelMembers keeps the recipient's name after their request expires", async () => {
+    const t = convexTest(schema, modules);
+    const communityId = await createCommunity(t, "Former Member Header");
+    const { accessToken: aToken } = await createUserInCommunity(t, communityId, {
+      firstName: "Alice",
+    });
+    const { userId: bId } = await createUserInCommunity(t, communityId, {
+      firstName: "David",
+      lastName: "Walker",
+    });
+
+    const { channelId } = await t.mutation(
+      api.functions.messaging.directMessages.createOrGetDirectChannel,
+      { token: aToken, communityId, recipientUserId: bId },
+    );
+    await t.mutation(api.functions.messaging.messages.sendMessage, {
+      token: aToken,
+      channelId,
+      content: "yo",
+    });
+    await t.finishInProgressScheduledFunctions();
+
+    await expirePendingRequest(t, channelId, bId);
+
+    const members = await t.query(
+      api.functions.messaging.directMessages.getAdHocChannelMembers,
+      { token: aToken, channelId },
+    );
+    expect(members).not.toBeNull();
+    expect(members!.otherMembers).toHaveLength(0);
+    expect(members!.formerMember?.userId).toBe(bId);
+    expect(members!.formerMember?.displayName).toBe("David Walker");
+
+    await t.finishInProgressScheduledFunctions();
+  });
+});
+
+// ============================================================================
 // expireOldChatRequests cron
 // ============================================================================
 

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -1345,6 +1345,56 @@ export const listCommunityMembersForNewChat = query({
   },
 });
 
+/** Display-only identity of a 1:1 DM counterpart who is no longer a member. */
+type FormerDirectMember = {
+  userId: Id<"users">;
+  displayName: string;
+  profilePhoto: string | null;
+};
+
+/**
+ * Resolve the name/photo of the other participant in a 1:1 `dm` whose
+ * membership has ended — most commonly because the 30-day `expireOldChatRequests`
+ * cron silently marked their never-answered request `declined` + `leftAt`.
+ *
+ * WHY: the sender's thread stays in their inbox, but every active-member lookup
+ * filters on `leftAt === undefined`, so the row lost its name and rendered as a
+ * blank "Conversation" (issue #426).
+ *
+ * DISPLAY ONLY. Callers must keep this OUT of `otherMembers` and any member
+ * list, count, or fan-out — the person really did leave, and must not be
+ * treated as active anywhere. Only call this for `channelType === "dm"` and
+ * only when there is no active other member.
+ */
+async function resolveFormerDirectMember(
+  ctx: QueryCtx,
+  channelId: Id<"chatChannels">,
+  callerId: Id<"users">,
+): Promise<FormerDirectMember | null> {
+  const rows = await ctx.db
+    .query("chatChannelMembers")
+    .withIndex("by_channel", (q) => q.eq("channelId", channelId))
+    .collect();
+  const departed = rows
+    .filter((m) => m.userId !== callerId && m.leftAt !== undefined)
+    .sort((a, b) => (b.leftAt ?? 0) - (a.leftAt ?? 0))[0];
+  if (!departed) return null;
+
+  // Prefer the live user doc — the denormalized row values go stale when the
+  // user edits their profile — and fall back to the row for a deleted user.
+  const user = await ctx.db.get(departed.userId);
+  const displayName =
+    (user ? getDisplayName(user.firstName, user.lastName) : "") ||
+    departed.displayName ||
+    "Member";
+  return {
+    userId: departed.userId,
+    displayName,
+    profilePhoto:
+      getMediaUrl(user?.profilePhoto ?? departed.profilePhoto) ?? null,
+  };
+}
+
 /**
  * List the caller's accepted ad-hoc channels (DMs and group_dms) within a
  * specific community. Powers the "Direct messages" section of the inbox.
@@ -1383,6 +1433,8 @@ export const getAdHocChannelMembers = query({
       profilePhoto: string | null;
       notificationsDisabled: boolean;
     }>;
+    /** See `resolveFormerDirectMember` — 1:1 display fallback, never a member. */
+    formerMember: FormerDirectMember | null;
   } | null> => {
     const userId = await requireAuth(ctx, args.token);
     const channel = await ctx.db.get(args.channelId);
@@ -1438,11 +1490,18 @@ export const getAdHocChannelMembers = query({
       })
       .filter((x): x is NonNullable<typeof x> => x !== null);
 
+    const channelType = channel.channelType as "dm" | "group_dm";
+    const formerMember =
+      channelType === "dm" && otherMembers.length === 0
+        ? await resolveFormerDirectMember(ctx, args.channelId, userId)
+        : null;
+
     return {
-      channelType: channel.channelType as "dm" | "group_dm",
+      channelType,
       channelName: channel.name ?? "",
       memberCount: memberRows.length,
       otherMembers,
+      formerMember,
     };
   },
 });
@@ -1473,6 +1532,8 @@ export const getDirectInbox = query({
         profilePhoto: string | null;
         notificationsDisabled: boolean;
       }>;
+      /** See `resolveFormerDirectMember` — 1:1 display fallback, never a member. */
+      formerMember: FormerDirectMember | null;
       lastMessageAt: number | null;
       lastMessagePreview: string | null;
       lastMessageSenderName: string | null;
@@ -1541,6 +1602,14 @@ export const getDirectInbox = query({
           notificationsDisabled: rowNotifsDisabled.has(m.userId),
         }));
 
+      // A 1:1 whose counterpart left (expired request, decline, block) has no
+      // active other member — keep their name/photo for the row's display so
+      // it doesn't degrade into a nameless "Conversation".
+      const formerMember =
+        channelType === "dm" && otherMembers.length === 0
+          ? await resolveFormerDirectMember(ctx, channel._id, userId)
+          : null;
+
       // Read state → unread count.
       const readState = await ctx.db
         .query("chatReadState")
@@ -1556,6 +1625,7 @@ export const getDirectInbox = query({
         channelName: channel.name,
         memberCount: channel.memberCount,
         otherMembers,
+        formerMember,
         lastMessageAt: channel.lastMessageAt ?? null,
         lastMessagePreview: channel.lastMessagePreview ?? null,
         lastMessageSenderName: channel.lastMessageSenderName ?? null,

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -15,7 +15,7 @@
 import { v, ConvexError } from "convex/values";
 import { query, mutation, internalMutation } from "../../_generated/server";
 import type { QueryCtx } from "../../_generated/server";
-import type { Id } from "../../_generated/dataModel";
+import type { Doc, Id } from "../../_generated/dataModel";
 import { requireAuth } from "../../lib/auth";
 import { checkRateLimit } from "../../lib/rateLimit";
 import { getDisplayName, getMediaUrl, normalizePhone } from "../../lib/utils";
@@ -1370,17 +1370,16 @@ type FormerDirectMember = {
  * (`respondToChatRequest` with `response: "block"`) also ends the membership,
  * so without this guard the blocker's identity would be handed straight back
  * to the person they blocked.
+ *
+ * `memberRows` is the channel's FULL member list, departed rows included —
+ * callers already hold it, so it is passed in rather than re-queried.
  */
 async function resolveFormerDirectMember(
   ctx: QueryCtx,
-  channelId: Id<"chatChannels">,
+  memberRows: Array<Doc<"chatChannelMembers">>,
   callerId: Id<"users">,
 ): Promise<FormerDirectMember | null> {
-  const rows = await ctx.db
-    .query("chatChannelMembers")
-    .withIndex("by_channel", (q) => q.eq("channelId", channelId))
-    .collect();
-  const departed = rows
+  const departed = memberRows
     .filter((m) => m.userId !== callerId && m.leftAt !== undefined)
     .sort((a, b) => (b.leftAt ?? 0) - (a.leftAt ?? 0))[0];
   if (!departed) return null;
@@ -1396,18 +1395,16 @@ async function resolveFormerDirectMember(
     return null;
   }
 
-  // Prefer the live user doc — the denormalized row values go stale when the
-  // user edits their profile — and fall back to the row for a deleted user.
-  const user = await ctx.db.get(departed.userId);
-  const displayName =
-    (user ? getDisplayName(user.firstName, user.lastName) : "") ||
-    departed.displayName ||
-    "Member";
+  // Read the denormalized member row, NOT the live user doc. Active members in
+  // `getDirectInbox` are rendered from the row too, so resolving a departed
+  // person from their user doc would give someone who left a *fresher* identity
+  // than someone still in the thread. It also keeps this a snapshot of who they
+  // were while the thread was live: profile edits they make afterwards stop
+  // propagating to a counterpart they no longer share a channel with.
   return {
     userId: departed.userId,
-    displayName,
-    profilePhoto:
-      getMediaUrl(user?.profilePhoto ?? departed.profilePhoto) ?? null,
+    displayName: departed.displayName || "Member",
+    profilePhoto: getMediaUrl(departed.profilePhoto) ?? null,
   };
 }
 
@@ -1472,11 +1469,13 @@ export const getAdHocChannelMembers = query({
       return null;
     }
 
-    const memberRows = await ctx.db
+    // Collected unfiltered so `resolveFormerDirectMember` can reuse the rows;
+    // active members are filtered out of it in memory.
+    const allMemberRows = await ctx.db
       .query("chatChannelMembers")
       .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
-      .filter((q) => q.eq(q.field("leftAt"), undefined))
       .collect();
+    const memberRows = allMemberRows.filter((m) => m.leftAt === undefined);
 
     const others = memberRows.filter((m) => m.userId !== userId);
     // Resolve profilePhoto + displayName from each user doc — denormalized
@@ -1509,7 +1508,7 @@ export const getAdHocChannelMembers = query({
     const channelType = channel.channelType as "dm" | "group_dm";
     const formerMember =
       channelType === "dm" && otherMembers.length === 0
-        ? await resolveFormerDirectMember(ctx, args.channelId, userId)
+        ? await resolveFormerDirectMember(ctx, allMemberRows, userId)
         : null;
 
     return {
@@ -1593,11 +1592,16 @@ export const getDirectInbox = query({
       // surfacing the chat to a recipient who hasn't responded — that recipient
       // shows in the member list with their pending state, but for inbox
       // display we only need name+photo).
-      const otherMemberRows = await ctx.db
+      //
+      // Collected unfiltered so `resolveFormerDirectMember` can reuse the rows;
+      // active members are filtered out of it in memory.
+      const allMemberRows = await ctx.db
         .query("chatChannelMembers")
         .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
-        .filter((q) => q.eq(q.field("leftAt"), undefined))
         .collect();
+      const otherMemberRows = allMemberRows.filter(
+        (m) => m.leftAt === undefined,
+      );
       const otherMemberIds = otherMemberRows
         .filter((m) => m.userId !== userId)
         .map((m) => m.userId);
@@ -1623,7 +1627,7 @@ export const getDirectInbox = query({
       // it doesn't degrade into a nameless "Conversation".
       const formerMember =
         channelType === "dm" && otherMembers.length === 0
-          ? await resolveFormerDirectMember(ctx, channel._id, userId)
+          ? await resolveFormerDirectMember(ctx, allMemberRows, userId)
           : null;
 
       // Read state → unread count.

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -1365,6 +1365,11 @@ type FormerDirectMember = {
  * list, count, or fan-out — the person really did leave, and must not be
  * treated as active anywhere. Only call this for `channelType === "dm"` and
  * only when there is no active other member.
+ *
+ * Returns null when either party has blocked the other: "Block & Report"
+ * (`respondToChatRequest` with `response: "block"`) also ends the membership,
+ * so without this guard the blocker's identity would be handed straight back
+ * to the person they blocked.
  */
 async function resolveFormerDirectMember(
   ctx: QueryCtx,
@@ -1379,6 +1384,17 @@ async function resolveFormerDirectMember(
     .filter((m) => m.userId !== callerId && m.leftAt !== undefined)
     .sort((a, b) => (b.leftAt ?? 0) - (a.leftAt ?? 0))[0];
   if (!departed) return null;
+
+  // A block hides each party from the other everywhere else in this file —
+  // channel creation refuses with a generic error rather than leak who
+  // (`isBlockedEitherDirection` above), and both the new-chat member list and
+  // user search filter blocked users out. A declined-by-block membership looks
+  // exactly like an expired one, so this display fallback has to make the same
+  // check or it becomes the one place the blocker's name (and live photo)
+  // reaches the sender they blocked.
+  if (await isBlockedEitherDirection(ctx, callerId, departed.userId)) {
+    return null;
+  }
 
   // Prefer the live user doc — the denormalized row values go stale when the
   // user edits their profile — and fall back to the row for a deleted user.

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -2347,7 +2347,8 @@ interface DirectMessageRowProps {
 }
 
 
-function DirectMessageRow({ row, primaryColor, colors, whatsappShellEnabled }: DirectMessageRowProps) {
+/** Exported for direct rendering in tests; the screen renders it internally. */
+export function DirectMessageRow({ row, primaryColor, colors, whatsappShellEnabled }: DirectMessageRowProps) {
   const router = useRouter();
 
   // Display name: for 1:1, the other member; for group_dm, the channel name

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -45,6 +45,7 @@ import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 import { GroupedInboxItem } from "./GroupedInboxItem";
 import { selectMainChannel } from "../utils/selectMainChannel";
+import { adHocDisplayMembers } from "../utils/adHocDisplayMembers";
 import { useExpandedGroups } from "../hooks/useExpandedGroups";
 import { useInboxGroupCollapse } from "../../../stores/inboxGroupCollapse";
 import { useInboxCache } from "../../../stores/inboxCache";
@@ -2311,6 +2312,12 @@ type DirectInboxRowData = {
     profilePhoto: string | null;
     notificationsDisabled: boolean;
   }>;
+  /** 1:1 counterpart who left (e.g. expired request) — display only. */
+  formerMember: {
+    userId: Id<"users">;
+    displayName: string;
+    profilePhoto: string | null;
+  } | null;
   lastMessageAt: number | null;
   lastMessagePreview: string | null;
   lastMessageSenderName: string | null;
@@ -2350,11 +2357,14 @@ function DirectMessageRow({ row, primaryColor, colors, whatsappShellEnabled }: D
   // the product surface drops "group" language; multi-recipient threads are
   // just chats with more people.
   const isOneOnOne = row.channelType === "dm";
+  // A 1:1 whose counterpart left (expired request) has no active other member;
+  // fall back to their stored identity so the row keeps its name and photo.
+  const displayMembers = adHocDisplayMembers(row.otherMembers, row.formerMember);
   const headerName = isOneOnOne
-    ? row.otherMembers[0]?.displayName ?? "Conversation"
+    ? displayMembers[0]?.displayName ?? "Conversation"
     : row.channelName.trim().length > 0
       ? row.channelName
-      : row.otherMembers
+      : displayMembers
           .slice(0, 3)
           .map((m) => m.displayName.split(" ")[0])
           .filter(Boolean)
@@ -2362,8 +2372,8 @@ function DirectMessageRow({ row, primaryColor, colors, whatsappShellEnabled }: D
 
   // Stack avatars when this is a true multi-member group_dm with at least two
   // visible others. The cluster scales 2/3/4+ — see `StackedMemberAvatars`.
-  const useStackedAvatars = !isOneOnOne && row.otherMembers.length >= 2;
-  const primaryAvatar = row.otherMembers[0];
+  const useStackedAvatars = !isOneOnOne && displayMembers.length >= 2;
+  const primaryAvatar = displayMembers[0];
 
   // Compose preview line.
   const preview = row.lastMessagePreview ?? "No messages yet";
@@ -2393,7 +2403,7 @@ function DirectMessageRow({ row, primaryColor, colors, whatsappShellEnabled }: D
         <View style={styles.waAvatarSlot}>
           {useStackedAvatars ? (
             <StackedMemberAvatars
-              members={row.otherMembers.map((m) => ({
+              members={displayMembers.map((m) => ({
                 name: m.displayName,
                 imageUrl: m.profilePhoto,
               }))}
@@ -2445,7 +2455,7 @@ function DirectMessageRow({ row, primaryColor, colors, whatsappShellEnabled }: D
     <Pressable onPress={onPress} style={styles.dmRow}>
       {useStackedAvatars ? (
         <StackedMemberAvatars
-          members={row.otherMembers.map((m) => ({
+          members={displayMembers.map((m) => ({
             name: m.displayName,
             imageUrl: m.profilePhoto,
           }))}

--- a/apps/mobile/features/chat/components/ChatInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInfoScreen.tsx
@@ -10,10 +10,10 @@
  *     `searchUsersInSharedCommunities`
  *   - "Leave chat" destructive action
  *
- * The screen sources its member list from `getDirectInbox`'s row for this
- * channel — that endpoint already returns the member set the client is
- * authorised to see (excludes blocked / left rows). We pair it with
- * `getChannel` for canonical metadata (channelType, name, isAdHoc).
+ * The screen sources its member list from `getAdHocChannelMembers` — that
+ * endpoint already returns the member set the client is authorised to see
+ * (excludes blocked / left rows). We pair it with `getChannel` for canonical
+ * metadata (channelType, name, isAdHoc).
  */
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -47,6 +47,7 @@ import {
 import type { Id } from "@services/api/convex";
 import { StackedMemberAvatars } from "./StackedMemberAvatars";
 import { useAdHocChannelManagement } from "../hooks/useAdHocChannelManagement";
+import { adHocDisplayMembers } from "../utils/adHocDisplayMembers";
 
 type Props = {
   channelId: Id<"chatChannels">;
@@ -106,8 +107,17 @@ export function ChatInfoScreen({ channelId }: Props) {
       channelName: channelMembers.channelName,
       memberCount: channelMembers.memberCount,
       otherMembers: channelMembers.otherMembers,
+      formerMember: channelMembers.formerMember,
     };
   }, [channelMembers, channelId]);
+
+  // Names/avatars only. A 1:1 counterpart who left (e.g. an expired request)
+  // is NOT in `otherMembers`, so the member list below still excludes them —
+  // they must not look like someone you can message or remove.
+  const displayMembers = useMemo(
+    () => adHocDisplayMembers(inboxRow?.otherMembers ?? [], inboxRow?.formerMember),
+    [inboxRow],
+  );
 
   const isGroupDm = channel?.channelType === "group_dm";
   const isAdHoc = channel?.isAdHoc === true;
@@ -153,27 +163,27 @@ export function ChatInfoScreen({ channelId }: Props) {
 
   const otherAvatars = useMemo(
     () =>
-      (inboxRow?.otherMembers ?? []).map((m) => ({
+      displayMembers.map((m) => ({
         name: m.displayName,
         imageUrl: m.profilePhoto,
       })),
-    [inboxRow],
+    [displayMembers],
   );
 
   const channelName = useMemo(() => {
     if (!channel) return "";
     if (channel.channelType === "dm") {
-      return inboxRow?.otherMembers[0]?.displayName ?? "Conversation";
+      return displayMembers[0]?.displayName ?? "Conversation";
     }
     if (channel.name && channel.name.trim().length > 0) return channel.name;
     return (
-      (inboxRow?.otherMembers ?? [])
+      displayMembers
         .slice(0, 3)
         .map((m) => m.displayName.split(" ")[0])
         .filter(Boolean)
         .join(", ") || "Chat"
     );
-  }, [channel, inboxRow]);
+  }, [channel, displayMembers]);
 
   // ---- UI state ----
   const [renameVisible, setRenameVisible] = useState(false);

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -60,6 +60,7 @@ import { useTypingIndicators } from "../hooks/useTypingIndicators";
 import { useSendMessage } from "../hooks/useConvexSendMessage";
 import { useParentMessage } from "../hooks/useParentMessage";
 import { isOptimisticMessageId, resolveReplyPreview } from "../utils/replyPreview";
+import { adHocDisplayMembers } from "../utils/adHocDisplayMembers";
 import { BlockedUsersProvider, useBlockedUsersContext } from "../context/BlockedUsersContext";
 import { useMutation, useAction } from "@services/api/convex";
 import { useGroupCache } from "@/stores/groupCache";
@@ -1136,12 +1137,18 @@ const ConvexChatRoomScreenInner: React.FC = () => {
   // object on every Convex push, but if the underlying data hasn't changed,
   // downstream consumers (StackedMemberAvatars, ChatRoomHeader) shouldn't
   // see a new prop reference. Key on the userId+photo+name tuple.
-  const adHocOtherMembersKey = (adHocChannelMembers?.otherMembers ?? [])
+  // `formerMember` keeps a 1:1 header named after its counterpart once they've
+  // left (e.g. an expired request) instead of a blank "Conversation".
+  const adHocDisplayedMembers = adHocDisplayMembers(
+    adHocChannelMembers?.otherMembers ?? [],
+    adHocChannelMembers?.formerMember,
+  );
+  const adHocOtherMembersKey = adHocDisplayedMembers
     .map((m) => `${m.userId}|${m.profilePhoto ?? ""}|${m.displayName}`)
     .join("\n");
   const adHocOtherMembers = useMemo(
     () =>
-      (adHocChannelMembers?.otherMembers ?? []).map((m) => ({
+      adHocDisplayedMembers.map((m) => ({
         name: m.displayName,
         imageUrl: m.profilePhoto,
       })),

--- a/apps/mobile/features/chat/components/__tests__/ChatInboxScreen.formerMember.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/ChatInboxScreen.formerMember.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * DirectMessageRow — the 1:1 inbox row must keep a name when the counterpart
+ * is gone (issue #426).
+ *
+ * The 30-day `expireOldChatRequests` cron marks a never-answered request
+ * `declined` + `leftAt`, which empties `otherMembers` for the SENDER too, so
+ * their row used to degrade to a nameless "Conversation". The backend now
+ * returns the departed person separately as `formerMember`; this asserts the
+ * row actually renders it.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { DirectMessageRow } from "../ChatInboxScreen";
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn(), replace: jest.fn() }),
+}));
+
+type RowProps = React.ComponentProps<typeof DirectMessageRow>;
+type Row = RowProps["row"];
+
+const colors: RowProps["colors"] = {
+  text: "#000000",
+  textSecondary: "#333333",
+  textTertiary: "#666666",
+  surface: "#ffffff",
+  surfaceSecondary: "#eeeeee",
+};
+
+const baseRow: Row = {
+  channelId: "channel-1" as Row["channelId"],
+  channelType: "dm",
+  channelName: "",
+  memberCount: 2,
+  otherMembers: [],
+  formerMember: null,
+  lastMessageAt: 1_700_000_000_000,
+  lastMessagePreview: "hey",
+  lastMessageSenderName: "Alice",
+  lastMessageSenderId: null,
+  lastMessageSenderNotificationsDisabled: false,
+  unreadCount: 0,
+  isMuted: false,
+};
+
+const renderRow = (row: Row, whatsappShellEnabled = false) =>
+  render(
+    <DirectMessageRow
+      row={row}
+      primaryColor="#25D366"
+      colors={colors}
+      whatsappShellEnabled={whatsappShellEnabled}
+    />,
+  );
+
+const formerMember: NonNullable<Row["formerMember"]> = {
+  userId: "user-2" as NonNullable<Row["formerMember"]>["userId"],
+  displayName: "David Walker",
+  profilePhoto: null,
+};
+
+describe("DirectMessageRow — departed 1:1 counterpart", () => {
+  test("renders the active member's name while they are still in the chat", () => {
+    renderRow({
+      ...baseRow,
+      otherMembers: [
+        {
+          userId: "user-2" as Row["otherMembers"][number]["userId"],
+          displayName: "David Walker",
+          profilePhoto: null,
+          notificationsDisabled: false,
+        },
+      ],
+    });
+
+    expect(screen.getByText("David Walker")).toBeTruthy();
+    expect(screen.queryByText("Conversation")).toBeNull();
+  });
+
+  test.each([
+    ["flag off", false],
+    ["flag on", true],
+  ])(
+    "renders the departed member's name instead of 'Conversation' (%s)",
+    (_label, whatsappShellEnabled) => {
+      renderRow({ ...baseRow, formerMember }, whatsappShellEnabled as boolean);
+
+      expect(screen.getByText("David Walker")).toBeTruthy();
+      expect(screen.queryByText("Conversation")).toBeNull();
+    },
+  );
+
+  test("still falls back to 'Conversation' when nobody can be resolved", () => {
+    // e.g. the counterpart blocked the caller — the backend withholds them
+    // rather than naming the blocker.
+    renderRow(baseRow);
+
+    expect(screen.getByText("Conversation")).toBeTruthy();
+  });
+});

--- a/apps/mobile/features/chat/utils/__tests__/adHocDisplayMembers.test.ts
+++ b/apps/mobile/features/chat/utils/__tests__/adHocDisplayMembers.test.ts
@@ -1,0 +1,36 @@
+import { adHocDisplayMembers } from "../adHocDisplayMembers";
+
+const active = {
+  userId: "u1" as never,
+  displayName: "Carol Chen",
+  profilePhoto: "https://example.com/carol.jpg",
+  notificationsDisabled: true,
+};
+
+const former = {
+  userId: "u2" as never,
+  displayName: "David Walker Jr.",
+  profilePhoto: "https://example.com/david.jpg",
+};
+
+describe("adHocDisplayMembers", () => {
+  it("returns the active members untouched when there are any", () => {
+    expect(adHocDisplayMembers([active], former)).toEqual([active]);
+  });
+
+  it("falls back to the former member when nobody is active", () => {
+    expect(adHocDisplayMembers([], former)).toEqual([
+      {
+        userId: former.userId,
+        displayName: "David Walker Jr.",
+        profilePhoto: former.profilePhoto,
+        // Someone who left is not a notification target — never badge them.
+        notificationsDisabled: false,
+      },
+    ]);
+  });
+
+  it("returns an empty list when there is no active and no former member", () => {
+    expect(adHocDisplayMembers([], null)).toEqual([]);
+  });
+});

--- a/apps/mobile/features/chat/utils/adHocDisplayMembers.ts
+++ b/apps/mobile/features/chat/utils/adHocDisplayMembers.ts
@@ -1,0 +1,45 @@
+/**
+ * Display members for an ad-hoc channel (1:1 DM / group chat).
+ *
+ * A 1:1 DM whose counterpart is gone — most often because the 30-day
+ * `expireOldChatRequests` cron silently marked their never-answered request
+ * `declined` + `leftAt` — has no active other member, so the inbox row, chat
+ * header and chat-info title all degraded to a nameless "Conversation" with a
+ * blank avatar (issue #426). The backend still knows who they are and returns
+ * them as `formerMember`; this folds that into the list the UI *renders*.
+ *
+ * Display only: `formerMember` is deliberately not part of `otherMembers`, so
+ * membership lists, counts and message fan-out keep excluding people who left.
+ * Use this for names and avatars — never to decide who is in a channel.
+ */
+
+import type { Id } from "@services/api/convex";
+
+type ActiveMember = {
+  userId: Id<"users">;
+  displayName: string;
+  profilePhoto: string | null;
+  notificationsDisabled: boolean;
+};
+
+type FormerMember = {
+  userId: Id<"users">;
+  displayName: string;
+  profilePhoto: string | null;
+};
+
+export function adHocDisplayMembers(
+  otherMembers: readonly ActiveMember[],
+  formerMember: FormerMember | null | undefined,
+): readonly ActiveMember[] {
+  if (otherMembers.length > 0) return otherMembers;
+  if (!formerMember) return [];
+  return [
+    {
+      ...formerMember,
+      // Someone who left this chat is not a notification target, so the
+      // "notifications off" avatar badge would be misleading noise.
+      notificationsDisabled: false,
+    },
+  ];
+}

--- a/apps/mobile/features/chat/utils/index.ts
+++ b/apps/mobile/features/chat/utils/index.ts
@@ -3,6 +3,7 @@ export { formatMessageDate } from "./formatMessageDate";
 export { formatChatDate } from "./formatChatDate";
 export { sortChatRooms } from "./sortChatRooms";
 export { decodeEmoji } from "./decodeEmoji";
+export { adHocDisplayMembers } from "./adHocDisplayMembers";
 export {
   detectPlatformFromUrl,
   getExternalChatInfo,


### PR DESCRIPTION
## Summary

When a pending 1:1 DM request expires via the 30-day auto-decline cron, it's marked `requestState: "declined"` + `leftAt: now`. `getDirectInbox` builds `otherMembers` only from members with `leftAt === undefined`, so the recipient drops out, the list is empty, and the sender's inbox falls back to a generic "Conversation" with a blank avatar — even though the membership row still holds `displayName` and the user doc still exists.

This takes **option 1** from the issue: resolve the name for left/declined members in 1:1 DM inbox rows. Smallest change, keeps the thread and its history visible. Options 2 (hide the threads) and 3 (rework expiry semantics) lose history or change cron behavior.

## How this cannot leak into membership semantics

This was the main risk, so it's worth being explicit:

- **`otherMembers` is unchanged** — still strictly `leftAt === undefined`.
- The resolved identity ships in a **separate `formerMember` field**, populated only when `channelType === "dm"` **and** `otherMembers.length === 0`.
- It's a bare `{userId, displayName, profilePhoto}` — no `notificationsDisabled`, no request state, no join time — so it can't be mistaken for a member row.
- **Nothing that decides membership reads it.** Message fan-out (`messages.ts`, `polls.ts`), `memberCount`, ownership transfer and `removeAdHocMember` all query `chatChannelMembers` directly and are untouched.
- On the client, `ChatInfoScreen`'s `members` array (the one carrying the Remove action and `isInviter`) still maps `inboxRow.otherMembers`; only `channelName` and `otherAvatars` use the resolved list.
- The helper forces `notificationsDisabled: false` for a former member, so they never get a "notifications off" badge implying they'd otherwise be notified.
- `group_dm` and regular group channels are untouched — there's a test asserting `formerMember` is null for a `group_dm` with a departed member while the remaining pending member still shows in `otherMembers`.

## Header and info screens

Both covered, as the issue asked:

- `ChatRoomHeader.tsx:56/61` needed **no change** — its `otherMembers` prop is a pure display type (`{name, imageUrl}`), and `ConvexChatRoomScreen` now hands it the resolved list, so its `?? "Conversation"` simply stops firing.
- `ChatInfoScreen.tsx:166` needed a matching change and got one. Also fixed a stale header comment there that claimed the screen sources members from `getDirectInbox`.

## Files

Backend: `messaging/directMessages.ts` (new `resolveFormerDirectMember()` + `formerMember` on `getDirectInbox` and `getAdHocChannelMembers`), `__tests__/messaging/directMessages.test.ts` (4 new tests).

Mobile: new `features/chat/utils/adHocDisplayMembers.ts` + its test + barrel export; `ChatInboxScreen.tsx`, `ConvexChatRoomScreen.tsx`, `ChatInfoScreen.tsx`.

## Test plan

Red first — `formerMember` was `undefined` on both queries:
```
 Test Files  1 failed (1)
      Tests  4 failed | 46 skipped (50)
```
Mobile util test red too (module not found).

Green after:
```
 Test Files  182 passed (182)
      Tests  3412 passed (3412)

Test Suites: 242 passed, 242 total
Tests:       9 skipped, 2608 passed, 2617 total
```
`apps/convex npx tsc --noEmit` clean. `apps/mobile npx tsc --noEmit` has pre-existing errors on `main` (MessageInput `Timeout`, AudioPlayer implicit any, ServingTasksScreen, several test files) — none in any touched file.

## Notes

- The issue's optional "Request declined" note on the row is **not** implemented — adding a badge is a design call and wasn't part of the decision.
- No device verification. JS/data-only, no dependency or native-view impact, so native-safety rules don't bite — but the visual result on staging (`hushed-lemur-239`, the "David Walker Jr." / "Olusegun Olujide" threads from the issue) is worth an eyeball after deploy.
- A former member is chosen as the most-recently-left non-caller row. For a 1:1 there's only ever one counterpart, so the sort is defensive; if a `dm` channel ever historically gained a third party, it picks the latest departure.

Fixes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5)_