### PR TITLE
fix(serving): flush the serving-task queue app-wide, not only on the Tasks screen

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -23,6 +23,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { AuthProvider } from "@providers/AuthProvider";
 import { AuthErrorBoundary } from "@providers/AuthErrorBoundary";
 import { KnicksModeSync } from "@providers/KnicksModeSync";
+import { ServingTaskQueueSync } from "@providers/ServingTaskQueueSync";
 import { EnvironmentProvider, useEnvironment } from "@providers/EnvironmentProvider";
 import { ImageViewerProvider } from "@providers/ImageViewerProvider";
 import { NotificationProvider } from "@providers/NotificationProvider";
@@ -237,6 +238,9 @@ function AppLayout() {
         <AuthProvider>
           <AuthErrorBoundary>
           <KnicksModeSync />
+          {/* Drains the persisted offline serving-task queue on reconnect /
+              foreground, regardless of which screen is mounted. */}
+          <ServingTaskQueueSync />
           <PostHogProvider>
             <ImageViewerProvider>
             <ChatPrefetchProvider>

--- a/apps/mobile/features/serving/components/ServingTasksScreen.tsx
+++ b/apps/mobile/features/serving/components/ServingTasksScreen.tsx
@@ -36,7 +36,7 @@
  * in place, without leaving serving mode for the rostering grid. See the
  * "Author" section comment below for the offline decision (online-only).
  */
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -277,8 +277,8 @@ type EligiblePlan = {
 /**
  * Parent for the Tasks tab. Owns nothing plan-specific: it resolves the list of
  * plans the user is serving (`getServingEligibility`) and renders one
- * `ServingTasksPlanSection` per plan, plus the SINGLE global offline flush loop
- * (see below). All per-plan data/handlers live in the child section.
+ * `ServingTasksPlanSection` per plan. All per-plan data/handlers live in the
+ * child section.
  */
 export function ServingTasksScreen() {
   const { colors } = useTheme();
@@ -303,79 +303,11 @@ export function ServingTasksScreen() {
   // Today's plans, or the single upcoming plan opened early for preview.
   const plans = useServingPlans(eligibility);
 
-  // --- Global offline flush loop ---------------------------------------------
-  // Replays queued (offline) completions when back online. The queue is GLOBAL
-  // across every plan, so this must run exactly once — it lives here in the
-  // parent rather than in each per-plan section, which would race to drain the
-  // same queue. The per-plan RECONCILE (dropping entries the plan's live server
-  // data already reflects) stays in the child, scoped to that plan's data.
-  const { isEffectivelyOffline } = useConnectionStatus();
-  const queuePending = useServingTaskQueue((s) => s.pending);
-  const dequeueCompletion = useServingTaskQueue((s) => s.dequeue);
-  const toggleSharedTeamTask = useAuthenticatedMutation(
-    api.functions.scheduling.eventTasks.toggleSharedTeamTask,
-  );
-  const toggleTaskCompletion = useAuthenticatedMutation(
-    api.functions.scheduling.eventTasks.toggleTaskCompletion,
-  );
-  const togglePersonalTask = useAuthenticatedMutation(
-    api.functions.scheduling.eventTasks.togglePersonalTask,
-  );
-
-  // Replay queued completions when back online. All three toggle mutations take
-  // an explicit `completed` and are idempotent, so replay is always safe.
-  const flushingRef = useRef(false);
-  const flushQueue = useCallback(async () => {
-    if (flushingRef.current) return;
-    flushingRef.current = true;
-    try {
-      for (const op of useServingTaskQueue.getState().all()) {
-        try {
-          if (op.kind === "personal") {
-            await togglePersonalTask({
-              taskId: op.taskId as Id<"personalServingTasks">,
-              completed: op.completed,
-            });
-          } else if (op.kind === "template") {
-            await toggleTaskCompletion({
-              taskId: op.taskId as Id<"eventTasks">,
-              timeLabel: op.timeLabel,
-              completed: op.completed,
-            });
-          } else {
-            await toggleSharedTeamTask({
-              planId: op.planId as Id<"eventPlans">,
-              taskId: op.taskId as Id<"eventTasks">,
-              completed: op.completed,
-            });
-          }
-          // Only drop it if the desired state hasn't changed since we
-          // snapshotted `all()` — the user may have gone offline mid-flush and
-          // re-toggled this task, in which case `enqueue` replaced the entry and
-          // we must keep the newer intent for the next flush.
-          const current = useServingTaskQueue.getState().pending[op.id];
-          if (current && current.completed === op.completed) {
-            dequeueCompletion(op.id);
-          }
-        } catch {
-          // Leave it queued; the next reconnect (or screen mount) retries.
-        }
-      }
-    } finally {
-      flushingRef.current = false;
-    }
-  }, [
-    togglePersonalTask,
-    toggleTaskCompletion,
-    toggleSharedTeamTask,
-    dequeueCompletion,
-  ]);
-
-  useEffect(() => {
-    if (isEffectivelyOffline) return;
-    if (Object.keys(queuePending).length === 0) return;
-    void flushQueue();
-  }, [isEffectivelyOffline, queuePending, flushQueue]);
+  // Draining the offline completion queue is NOT this screen's job — it runs
+  // app-wide in `providers/ServingTaskQueueSync.tsx`, so a volunteer who ticks
+  // tasks offline and walks away syncs the moment signal returns (issue #557).
+  // The per-plan RECONCILE (dropping entries the plan's live server data
+  // already reflects) does stay in the child, scoped to that plan's data.
 
   if (!isServingMode) {
     return (
@@ -436,8 +368,8 @@ export function ServingTasksScreen() {
  * / Crew / All-teams section switcher, and all the per-plan data, offline cache,
  * mutations and handlers. Every hook here is scoped to `plan.planId`, so
  * completing a task offline enqueues under the CORRECT plan. Rendered once per
- * eligible plan by `ServingTasksScreen`; the global offline flush loop lives in
- * the parent — only the per-plan reconcile lives here.
+ * eligible plan by `ServingTasksScreen`; the offline flush loop lives app-wide
+ * in `providers/ServingTaskQueueSync.tsx` — only the per-plan reconcile is here.
  */
 function ServingTasksPlanSection({ plan, wa }: { plan: EligiblePlan; wa: boolean }) {
   const { colors, isDark } = useTheme();

--- a/apps/mobile/providers/ServingTaskQueueSync.tsx
+++ b/apps/mobile/providers/ServingTaskQueueSync.tsx
@@ -1,0 +1,120 @@
+/**
+ * ServingTaskQueueSync - Drains the persisted serving-task completion queue
+ * app-wide.
+ *
+ * The queue (`stores/servingTaskQueue.ts`) survives app restarts, but the flush
+ * used to live in `ServingTasksScreen`, so completions checked off offline only
+ * synced while the Tasks tab happened to be mounted. A volunteer who ticked
+ * tasks offline and then walked to another tab (or backgrounded the app) kept
+ * their work queued until they reopened Tasks online. Mounting the flush at the
+ * app root — next to `KnicksModeSync`, the same headless render-nothing pattern
+ * — makes sync depend on connectivity alone, not on navigation.
+ *
+ * Two triggers, both needed:
+ *   - connectivity returns (or a new entry is queued) while we're rendered;
+ *   - the app returns to the foreground, which covers signal that came back
+ *     while the app was backgrounded and NetInfo never told us mid-session.
+ *
+ * Replay is safe because all three backing mutations take an explicit
+ * `completed` boolean and are idempotent (see ADR-028), so an entry that gets
+ * sent twice converges to the same server state.
+ *
+ * Renders nothing.
+ */
+import { useCallback, useEffect, useRef } from "react";
+import { AppState } from "react-native";
+import { useAuthenticatedMutation, api } from "@services/api/convex";
+import type { Id } from "@services/api/convex";
+import { useConnectionStatus } from "@providers/ConnectionProvider";
+import { useServingTaskQueue } from "@/stores/servingTaskQueue";
+
+export function ServingTaskQueueSync() {
+  const { isEffectivelyOffline } = useConnectionStatus();
+  const queuePending = useServingTaskQueue((s) => s.pending);
+  const dequeueCompletion = useServingTaskQueue((s) => s.dequeue);
+  const toggleSharedTeamTask = useAuthenticatedMutation(
+    api.functions.scheduling.eventTasks.toggleSharedTeamTask,
+  );
+  const toggleTaskCompletion = useAuthenticatedMutation(
+    api.functions.scheduling.eventTasks.toggleTaskCompletion,
+  );
+  const togglePersonalTask = useAuthenticatedMutation(
+    api.functions.scheduling.eventTasks.togglePersonalTask,
+  );
+
+  // Re-entrancy guard: the two triggers can fire at once (foregrounding often
+  // coincides with reconnecting), and a Convex mutation in flight must not be
+  // duplicated by a second pass over the same queue.
+  const flushingRef = useRef(false);
+  const flushQueue = useCallback(async () => {
+    if (flushingRef.current) return;
+    flushingRef.current = true;
+    try {
+      for (const op of useServingTaskQueue.getState().all()) {
+        try {
+          if (op.kind === "personal") {
+            await togglePersonalTask({
+              taskId: op.taskId as Id<"personalServingTasks">,
+              completed: op.completed,
+            });
+          } else if (op.kind === "template") {
+            await toggleTaskCompletion({
+              taskId: op.taskId as Id<"eventTasks">,
+              timeLabel: op.timeLabel,
+              completed: op.completed,
+            });
+          } else {
+            await toggleSharedTeamTask({
+              planId: op.planId as Id<"eventPlans">,
+              taskId: op.taskId as Id<"eventTasks">,
+              completed: op.completed,
+            });
+          }
+          // Only drop it if the desired state hasn't changed since we
+          // snapshotted `all()` — the user may have gone offline mid-flush and
+          // re-toggled this task, in which case `enqueue` replaced the entry and
+          // we must keep the newer intent for the next flush.
+          const current = useServingTaskQueue.getState().pending[op.id];
+          if (current && current.completed === op.completed) {
+            dequeueCompletion(op.id);
+          }
+        } catch {
+          // Leave it queued; the next reconnect or foreground retries it.
+        }
+      }
+    } finally {
+      flushingRef.current = false;
+    }
+  }, [
+    togglePersonalTask,
+    toggleTaskCompletion,
+    toggleSharedTeamTask,
+    dequeueCompletion,
+  ]);
+
+  // Reconnect (and newly-queued entries, including the entries AsyncStorage
+  // rehydrates on cold start).
+  useEffect(() => {
+    if (isEffectivelyOffline) return;
+    if (Object.keys(queuePending).length === 0) return;
+    void flushQueue();
+  }, [isEffectivelyOffline, queuePending, flushQueue]);
+
+  // Foreground. Read connectivity through a ref: the listener is registered
+  // once per `flushQueue` identity, so a captured `isEffectivelyOffline` would
+  // go stale. If it's stale-offline, NetInfo corrects it within moments and the
+  // effect above flushes instead.
+  const offlineRef = useRef(isEffectivelyOffline);
+  offlineRef.current = isEffectivelyOffline;
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState !== "active") return;
+      if (offlineRef.current) return;
+      if (useServingTaskQueue.getState().all().length === 0) return;
+      void flushQueue();
+    });
+    return () => subscription.remove();
+  }, [flushQueue]);
+
+  return null;
+}

--- a/apps/mobile/providers/ServingTaskQueueSync.web.tsx
+++ b/apps/mobile/providers/ServingTaskQueueSync.web.tsx
@@ -1,0 +1,9 @@
+/**
+ * ServingTaskQueueSync (Web) - No-op
+ *
+ * Offline write queueing is native-only (`stores/servingTaskQueue.web.ts` is
+ * itself a no-op stub), so there is nothing to flush on web.
+ */
+export function ServingTaskQueueSync() {
+  return null;
+}

--- a/apps/mobile/providers/__tests__/ServingTaskQueueSync.test.tsx
+++ b/apps/mobile/providers/__tests__/ServingTaskQueueSync.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * Tests for ServingTaskQueueSync — the app-wide flusher for the persisted
+ * serving-task completion queue.
+ *
+ * The point of this component (issue #557) is that the flush is NOT tied to the
+ * Tasks screen: every test here renders the flusher on its own, with no serving
+ * screen mounted at all.
+ */
+import React from "react";
+import { render, waitFor, act } from "@testing-library/react-native";
+import { AppState } from "react-native";
+import type { AppStateStatus, NativeEventSubscription } from "react-native";
+import { ServingTaskQueueSync } from "../ServingTaskQueueSync";
+
+// --- Connectivity ------------------------------------------------------------
+let mockIsEffectivelyOffline = false;
+jest.mock("@providers/ConnectionProvider", () => ({
+  useConnectionStatus: () => ({
+    isEffectivelyOffline: mockIsEffectivelyOffline,
+  }),
+}));
+
+// --- The persisted queue -----------------------------------------------------
+interface Entry {
+  id: string;
+  planId: string;
+  kind: "template" | "personal" | "shared";
+  taskId: string;
+  timeLabel?: string;
+  completed: boolean;
+  queuedAt: number;
+}
+let mockPending: Record<string, Entry> = {};
+const mockDequeue = jest.fn((id: string) => {
+  const next = { ...mockPending };
+  delete next[id];
+  mockPending = next;
+});
+const mockQueueState = {
+  get pending() {
+    return mockPending;
+  },
+  dequeue: mockDequeue,
+  all: () => Object.values(mockPending),
+};
+jest.mock("@/stores/servingTaskQueue", () => {
+  const hook = (sel: (s: typeof mockQueueState) => unknown) => sel(mockQueueState);
+  (hook as unknown as { getState: () => typeof mockQueueState }).getState = () =>
+    mockQueueState;
+  return { useServingTaskQueue: hook };
+});
+
+// --- Convex mutations --------------------------------------------------------
+const mockToggleTaskCompletion = jest.fn();
+const mockTogglePersonalTask = jest.fn();
+const mockToggleSharedTeamTask = jest.fn();
+jest.mock("@services/api/convex", () => ({
+  api: {
+    functions: {
+      scheduling: {
+        eventTasks: {
+          toggleTaskCompletion: "toggleTaskCompletion",
+          togglePersonalTask: "togglePersonalTask",
+          toggleSharedTeamTask: "toggleSharedTeamTask",
+        },
+      },
+    },
+  },
+  useAuthenticatedMutation: (ref: string) => {
+    if (ref === "toggleTaskCompletion") return mockToggleTaskCompletion;
+    if (ref === "togglePersonalTask") return mockTogglePersonalTask;
+    return mockToggleSharedTeamTask;
+  },
+}));
+
+function entry(overrides: Partial<Entry> & Pick<Entry, "id">): Entry {
+  return {
+    planId: "plan-1",
+    kind: "personal",
+    taskId: "task-1",
+    completed: true,
+    queuedAt: 1,
+    ...overrides,
+  };
+}
+
+/** Seeds the queue with the given entries, keyed by id. */
+function seedQueue(...entries: Entry[]) {
+  mockPending = Object.fromEntries(entries.map((e) => [e.id, e]));
+}
+
+let appStateHandler: ((state: AppStateStatus) => void) | null = null;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsEffectivelyOffline = false;
+  mockPending = {};
+  appStateHandler = null;
+  mockToggleTaskCompletion.mockResolvedValue(undefined);
+  mockTogglePersonalTask.mockResolvedValue(undefined);
+  mockToggleSharedTeamTask.mockResolvedValue(undefined);
+  jest
+    .spyOn(AppState, "addEventListener")
+    .mockImplementation((event, handler) => {
+      if (event === "change") appStateHandler = handler;
+      return { remove: jest.fn() } as unknown as NativeEventSubscription;
+    });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("ServingTaskQueueSync", () => {
+  it("flushes queued completions with no serving screen mounted", async () => {
+    seedQueue(
+      entry({ id: "personal:p1", kind: "personal", taskId: "p1", completed: true }),
+      entry({
+        id: "template:t1:9AM",
+        kind: "template",
+        taskId: "t1",
+        timeLabel: "9AM",
+        completed: false,
+      }),
+      entry({ id: "shared:s1", kind: "shared", taskId: "s1", completed: true }),
+    );
+
+    render(<ServingTaskQueueSync />);
+
+    await waitFor(() => expect(mockDequeue).toHaveBeenCalledTimes(3));
+    expect(mockTogglePersonalTask).toHaveBeenCalledWith({
+      taskId: "p1",
+      completed: true,
+    });
+    expect(mockToggleTaskCompletion).toHaveBeenCalledWith({
+      taskId: "t1",
+      timeLabel: "9AM",
+      completed: false,
+    });
+    expect(mockToggleSharedTeamTask).toHaveBeenCalledWith({
+      planId: "plan-1",
+      taskId: "s1",
+      completed: true,
+    });
+  });
+
+  it("does not send anything while offline", async () => {
+    mockIsEffectivelyOffline = true;
+    seedQueue(entry({ id: "personal:p1", taskId: "p1" }));
+
+    render(<ServingTaskQueueSync />);
+
+    await act(async () => {});
+    expect(mockTogglePersonalTask).not.toHaveBeenCalled();
+    expect(mockDequeue).not.toHaveBeenCalled();
+  });
+
+  it("flushes when connectivity returns", async () => {
+    mockIsEffectivelyOffline = true;
+    seedQueue(entry({ id: "personal:p1", taskId: "p1" }));
+
+    const { rerender } = render(<ServingTaskQueueSync />);
+    await act(async () => {});
+    expect(mockTogglePersonalTask).not.toHaveBeenCalled();
+
+    mockIsEffectivelyOffline = false;
+    rerender(<ServingTaskQueueSync />);
+
+    await waitFor(() => expect(mockTogglePersonalTask).toHaveBeenCalledTimes(1));
+  });
+
+  it("flushes when the app returns to the foreground", async () => {
+    // Signal came back while the app was backgrounded, so no connectivity
+    // transition happens while we're rendered — foregrounding is the trigger.
+    render(<ServingTaskQueueSync />);
+    await act(async () => {});
+    expect(mockTogglePersonalTask).not.toHaveBeenCalled();
+
+    seedQueue(entry({ id: "personal:p1", taskId: "p1" }));
+    await act(async () => {
+      appStateHandler?.("active");
+    });
+
+    await waitFor(() => expect(mockTogglePersonalTask).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not flush on foreground while offline", async () => {
+    mockIsEffectivelyOffline = true;
+    seedQueue(entry({ id: "personal:p1", taskId: "p1" }));
+
+    render(<ServingTaskQueueSync />);
+    await act(async () => {
+      appStateHandler?.("active");
+    });
+
+    expect(mockTogglePersonalTask).not.toHaveBeenCalled();
+  });
+
+  it("never sends the same entry twice when two triggers overlap", async () => {
+    seedQueue(entry({ id: "personal:p1", taskId: "p1" }));
+    let resolveSend: (() => void) | undefined;
+    mockTogglePersonalTask.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSend = () => resolve();
+        }),
+    );
+
+    const { rerender } = render(<ServingTaskQueueSync />);
+    await waitFor(() => expect(mockTogglePersonalTask).toHaveBeenCalledTimes(1));
+
+    // A second trigger (foreground + a re-render) lands mid-flight.
+    await act(async () => {
+      appStateHandler?.("active");
+      rerender(<ServingTaskQueueSync />);
+    });
+    expect(mockTogglePersonalTask).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSend?.();
+    });
+    await waitFor(() => expect(mockDequeue).toHaveBeenCalledTimes(1));
+  });
+
+  it("leaves an entry queued when its mutation fails, and retries later", async () => {
+    seedQueue(entry({ id: "personal:p1", taskId: "p1" }));
+    mockTogglePersonalTask.mockRejectedValueOnce(new Error("server exploded"));
+
+    const { rerender } = render(<ServingTaskQueueSync />);
+    await waitFor(() => expect(mockTogglePersonalTask).toHaveBeenCalledTimes(1));
+    expect(mockDequeue).not.toHaveBeenCalled();
+    expect(mockPending["personal:p1"]).toBeDefined();
+
+    // A later trigger retries it — a failed send must not strand the entry.
+    await act(async () => {
+      appStateHandler?.("active");
+      rerender(<ServingTaskQueueSync />);
+    });
+    await waitFor(() => expect(mockDequeue).toHaveBeenCalledWith("personal:p1"));
+  });
+
+  it("keeps a newer intent queued when the task is re-toggled mid-flush", async () => {
+    seedQueue(entry({ id: "personal:p1", taskId: "p1", completed: true }));
+    let resolveSend: (() => void) | undefined;
+    mockTogglePersonalTask.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSend = () => resolve();
+        }),
+    );
+
+    render(<ServingTaskQueueSync />);
+    await waitFor(() => expect(mockTogglePersonalTask).toHaveBeenCalledTimes(1));
+
+    // User goes offline again mid-flush and unchecks the task.
+    mockPending = {
+      "personal:p1": entry({ id: "personal:p1", taskId: "p1", completed: false }),
+    };
+    await act(async () => {
+      resolveSend?.();
+    });
+
+    await act(async () => {});
+    expect(mockDequeue).not.toHaveBeenCalled();
+    expect(mockPending["personal:p1"].completed).toBe(false);
+  });
+});

--- a/docs/architecture/decisions/ADR-028-offline-support.md
+++ b/docs/architecture/decisions/ADR-028-offline-support.md
@@ -151,7 +151,13 @@ Only two features queue writes offline; everything else fails.
   offline and regaining signal.
 - **Last-write-wins**, keyed by a stable `completionId`, storing the *desired*
   `completed` boolean per task.
-- Flushed on reconnect by `ServingTasksScreen`.
+- Flushed **app-wide** by `apps/mobile/providers/ServingTaskQueueSync.tsx`, a
+  headless component mounted at the app root: it replays the queue when
+  connectivity returns and when the app is foregrounded, so completions sync
+  regardless of which screen is mounted (issue #557). A single re-entrancy guard
+  keeps the two triggers from overlapping; an entry only leaves the queue once
+  its mutation succeeds AND its desired state hasn't been superseded, so a
+  failed send is retried on the next trigger rather than lost or double-applied.
 - Safe to replay because the three backing mutations —
   `toggleTaskCompletion`, `togglePersonalTask`, `toggleSharedTeamTask` in
   `apps/convex/functions/scheduling/eventTasks.ts` — each take an **explicit


### PR DESCRIPTION
## The bug, confirmed first

`ServingTasksScreen.tsx` owned the *only* flush — a `useEffect` on `isEffectivelyOffline` + `queuePending` inside the screen component. Mount the Tasks tab and a flush was possible; leave it and the persisted queue sat there until the next mount, even while online. The queue store (`stores/servingTaskQueue.ts`) has no flusher of its own.

## What drives the flush now

A headless `<ServingTaskQueueSync />` mounted at the app root in `_layout.tsx`, next to `<KnicksModeSync />` (inside `ConnectionProvider` → `AuthProvider` → `AuthErrorBoundary`).

On pattern choice: the repo has **no** app-wide queue-flush precedent to mirror — the sibling chat-send queue (`features/chat/hooks/useConvexSendMessage.ts`) is in-memory and equally screen-scoped, and ADR-028 says so explicitly. That one is left alone. What this *does* match is the repo's existing headless app-root sync component (`providers/KnicksModeSync.tsx` — renders `null`, no context, mounted in `_layout.tsx`) and the `AppState` "change" → `active` listener already used by `OTAUpdateProvider` / `AuthProvider` / `ConnectionProvider`. No new mechanism, no new dependency.

Two triggers:
1. `isEffectivelyOffline` flips false, or `pending` changes — this also covers cold start, since AsyncStorage rehydration mutates `pending` and re-fires the effect.
2. `AppState` → `active`, the case NetInfo can't report (signal returned while the app was backgrounded).

## The four queue failure modes

- **Double-flush of one item** — impossible from concurrent triggers (guard below); on a genuine re-send, the three mutations take an explicit `completed` and are idempotent, so a duplicate converges to the same server state. Test: *"never sends the same entry twice when two triggers overlap"*.
- **Concurrent flush from two triggers** — a single `flushingRef` re-entrancy guard makes the second call return immediately (foregrounding and reconnecting often coincide). Preserved from the original code.
- **Retry storm while offline** — both triggers are gated on `isEffectivelyOffline`; the foreground trigger reads it through a ref, since the listener would otherwise capture a stale value. Nothing is sent while offline, so no storm and no mutation stuck in the Convex client's outbound queue. If the ref is briefly stale-offline after foregrounding, NetInfo corrects within moments and trigger 1 fires. Tests: *"does not send anything while offline"*, *"does not flush on foreground while offline"*.
- **Permanently-failed items** — an entry is dequeued only after its mutation resolves **and** the store still holds the same desired state. A rejection is caught per item, the loop continues, and the entry stays queued for the next reconnect or foreground — where before, retrying required re-mounting the Tasks tab. Tests: *"leaves an entry queued when its mutation fails, and retries later"*, *"keeps a newer intent queued when the task is re-toggled mid-flush"*.

## Files

- `providers/ServingTaskQueueSync.tsx` (new) — the flusher, moved verbatim from the screen plus the foreground trigger
- `providers/ServingTaskQueueSync.web.tsx` (new) — no-op stub; the offline-support skill requires a `.web` stub for every offline module, and the queue store already has one
- `providers/__tests__/ServingTaskQueueSync.test.tsx` (new) — 8 tests, none of which render any serving screen
- `app/_layout.tsx` — mounts the component
- `features/serving/components/ServingTasksScreen.tsx` — flush block deleted (68 lines), now-unused `useRef` import removed, three doc comments corrected. Keeps only the overlay, enqueue and per-plan reconcile.
- `docs/architecture/decisions/ADR-028-offline-support.md` — the write-queue section said "Flushed on reconnect by `ServingTasksScreen`"; now documents the app-wide flusher and its guarantees

## Test plan

Red first (before the module existed):
```
Cannot find module '../ServingTaskQueueSync'
Test Suites: 1 failed, 1 total
```
Green after, stable across 3 consecutive runs:
```
Tests:       8 passed, 8 total
```
Full mobile suite:
```
Test Suites: 242 passed, 242 total
Tests:       9 skipped, 2614 passed, 2623 total
```
`npx tsc --noEmit`: 21 errors, **all pre-existing** — diffed against a stashed working tree, same 21 in the same files. The only delta is a line number (`ServingTasksScreen.tsx` 1057 → 989, from the 68 deleted lines). The three new/changed files contribute zero.

- [ ] **Device check — the one thing tests can't cover.** Queue completions offline on the Tasks tab, navigate away or background the app, restore signal, confirm the completions land *without* reopening Tasks. `__simulateOffline()` is exposed on global in DEV.

## Two notes

- **Naming**: the issue suggested `ServingTaskQueueSyncProvider`; this uses `ServingTaskQueueSync` to match `KnicksModeSync`, since it renders null and provides no context. Trivial to rename if you'd rather match the issue's wording.
- **Pre-existing edge, unchanged and not introduced here**: if a mutation is issued and the device drops offline mid-flight, the Convex client may never settle that promise, leaving `flushingRef` true for the app session (further flushes no-op until relaunch). The offline gate makes this narrow; fixing it means a timeout/abort design, which is a product-ish call and out of scope for this bug fix.

Fixes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHhjtpTUgrVqstSKo15cd5)_