### PR TITLE
fix(events): a leader can no longer move a community-wide event's date

### DIFF
--- a/apps/convex/__tests__/communityWideEvents-override-lockout.test.ts
+++ b/apps/convex/__tests__/communityWideEvents-override-lockout.test.ts
@@ -1,0 +1,546 @@
+/**
+ * Community-Wide Event Override Lockout Tests
+ *
+ * Regression cover for the incident where a group leader moved a past
+ * community-wide occurrence onto a future date. The edit flipped the child's
+ * `isOverridden` latch, and because every admin cascade skips overridden
+ * children — and nothing ever cleared the flag — the community admin was
+ * permanently locked out of repairing the date while the mutation still
+ * reported success.
+ *
+ * Covers:
+ *  - leaders can no longer change the date of a community-wide child at all
+ *  - admins keep date control through both `meetings.update` and the CWE update
+ *  - the CWE cascade reports what it skipped instead of silently succeeding
+ *  - `resetChildToCommunityDefault` un-latches a child and re-syncs it
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/communityWideEvents-override-lockout.test.ts
+ */
+
+import { vi, expect, test, describe, beforeEach, afterEach } from "vitest";
+
+// Mock the jose library to bypass JWT verification in tests
+vi.mock("jose", () => ({
+  jwtVerify: vi.fn(async (token: string) => {
+    const match = token.match(/^test-token-(.+)$/);
+    if (!match) throw new Error("Invalid token");
+    return { payload: { userId: match[1], type: "access" } };
+  }),
+  SignJWT: vi.fn(() => ({
+    setProtectedHeader: vi.fn().mockReturnThis(),
+    setIssuedAt: vi.fn().mockReturnThis(),
+    setExpirationTime: vi.fn().mockReturnThis(),
+    sign: vi.fn().mockResolvedValue("mock-signed-token"),
+  })),
+  decodeJwt: vi.fn((token: string) => {
+    const match = token.match(/^test-token-(.+)$/);
+    if (!match) return null;
+    return { userId: match[1], type: "access" };
+  }),
+}));
+
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { modules } from "../test.setup";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+// "Now" sits between PAST_DATE and FUTURE_DATE so the series has one past and
+// one future occurrence — the shape of the real incident.
+const NOW = new Date("2026-08-10T12:00:00Z").getTime();
+const PAST_DATE = new Date("2026-06-01T18:00:00Z").getTime();
+const FUTURE_DATE = new Date("2026-09-01T18:00:00Z").getTime();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+interface Setup {
+  communityId: Id<"communities">;
+  groupTypeId: Id<"groupTypes">;
+  adminId: Id<"users">;
+  leaderId: Id<"users">;
+  adminToken: string;
+  leaderToken: string;
+  groupId1: Id<"groups">;
+  groupId2: Id<"groups">;
+  groupId3: Id<"groups">;
+}
+
+async function setupTestData(t: ReturnType<typeof convexTest>): Promise<Setup> {
+  return await t.run(async (ctx) => {
+    const ts = NOW;
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Test Community",
+      slug: "test-community",
+      isPublic: true,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Dinner Parties",
+      slug: "dinner-parties",
+      isActive: true,
+      createdAt: ts,
+      displayOrder: 1,
+    });
+
+    // roles: 3 = admin, status: 1 = active
+    const adminId = await ctx.db.insert("users", {
+      firstName: "Admin",
+      lastName: "User",
+      email: "admin@test.com",
+      phone: "+12025551001",
+      phoneVerified: true,
+      isActive: true,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    await ctx.db.insert("userCommunities", {
+      userId: adminId,
+      communityId,
+      roles: 3,
+      status: 1,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    // roles: 1 = plain member; group leadership is granted per group below
+    const leaderId = await ctx.db.insert("users", {
+      firstName: "Group",
+      lastName: "Leader",
+      email: "leader@test.com",
+      phone: "+12025551002",
+      phoneVerified: true,
+      isActive: true,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    await ctx.db.insert("userCommunities", {
+      userId: leaderId,
+      communityId,
+      roles: 1,
+      status: 1,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    const makeGroup = async (name: string) =>
+      await ctx.db.insert("groups", {
+        communityId,
+        groupTypeId,
+        name,
+        description: name,
+        isArchived: false,
+        isPublic: true,
+        createdAt: ts,
+        updatedAt: ts,
+      });
+
+    const groupId1 = await makeGroup("Group Alpha");
+    const groupId2 = await makeGroup("Group Beta");
+    const groupId3 = await makeGroup("Group Gamma");
+
+    // The leader leads Alpha only.
+    await ctx.db.insert("groupMembers", {
+      groupId: groupId1,
+      userId: leaderId,
+      role: "leader",
+      joinedAt: ts,
+      notificationsEnabled: true,
+    });
+
+    return {
+      communityId,
+      groupTypeId,
+      adminId,
+      leaderId,
+      adminToken: `test-token-${adminId}`,
+      leaderToken: `test-token-${leaderId}`,
+      groupId1,
+      groupId2,
+      groupId3,
+    };
+  });
+}
+
+/** Create the two-occurrence community-wide series used by most tests. */
+async function createSeries(t: ReturnType<typeof convexTest>, s: Setup) {
+  return await t.mutation(api.functions.communityWideEvents.createSeries, {
+    token: s.adminToken,
+    communityId: s.communityId,
+    groupTypeId: s.groupTypeId,
+    seriesName: "Weekly Dinner",
+    dates: [PAST_DATE, FUTURE_DATE],
+    title: "Weekly Dinner",
+    meetingType: 1,
+  });
+}
+
+/** The child meeting for `groupId` on the occurrence scheduled at `date`. */
+async function childMeeting(
+  t: ReturnType<typeof convexTest>,
+  groupId: Id<"groups">,
+  date: number
+) {
+  return await t.run(async (ctx) => {
+    const all = await ctx.db.query("meetings").collect();
+    return all.find((m) => m.groupId === groupId && m.scheduledAt === date)!;
+  });
+}
+
+async function getMeeting(t: ReturnType<typeof convexTest>, id: Id<"meetings">) {
+  return await t.run(async (ctx) => await ctx.db.get(id));
+}
+
+async function parentFor(t: ReturnType<typeof convexTest>, date: number) {
+  return await t.run(async (ctx) => {
+    const cwes = await ctx.db.query("communityWideEvents").collect();
+    return cwes.find((c) => c.scheduledAt === date)!;
+  });
+}
+
+// ============================================================================
+// Leaders cannot move a community-wide event's date
+// ============================================================================
+
+describe("meetings.update — community-wide date ownership", () => {
+  test("group leader cannot change the date of a community-wide child", async () => {
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+
+    const pastAlpha = await childMeeting(t, s.groupId1, PAST_DATE);
+
+    await expect(
+      t.mutation(api.functions.meetings.index.update, {
+        token: s.leaderToken,
+        meetingId: pastAlpha._id,
+        scheduledAt: FUTURE_DATE,
+      })
+    ).rejects.toThrow(/community admin/i);
+
+    // The date must be untouched, and the failed edit must not have latched
+    // the override flag — otherwise the admin is locked out by a rejected edit.
+    const after = await getMeeting(t, pastAlpha._id);
+    expect(after?.scheduledAt).toBe(PAST_DATE);
+    expect(after?.isOverridden).toBe(false);
+  });
+
+  test("the block also applies to the series-wide scope", async () => {
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+
+    const pastAlpha = await childMeeting(t, s.groupId1, PAST_DATE);
+
+    await expect(
+      t.mutation(api.functions.meetings.index.update, {
+        token: s.leaderToken,
+        meetingId: pastAlpha._id,
+        scheduledAt: FUTURE_DATE,
+        scope: "all_in_series",
+      })
+    ).rejects.toThrow(/community admin/i);
+
+    expect((await getMeeting(t, pastAlpha._id))?.scheduledAt).toBe(PAST_DATE);
+  });
+
+  test("leader can still edit non-date fields, which latches the override", async () => {
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+
+    const futureAlpha = await childMeeting(t, s.groupId1, FUTURE_DATE);
+
+    await t.mutation(api.functions.meetings.index.update, {
+      token: s.leaderToken,
+      meetingId: futureAlpha._id,
+      note: "Bring a side dish",
+    });
+
+    const after = await getMeeting(t, futureAlpha._id);
+    expect(after?.note).toBe("Bring a side dish");
+    expect(after?.isOverridden).toBe(true);
+    expect(after?.scheduledAt).toBe(FUTURE_DATE);
+  });
+
+  test("resubmitting the unchanged date alongside another field is allowed", async () => {
+    // The edit form always sends `scheduledAt`, so a leader saving a note edit
+    // posts the existing date back. That must not read as a date change.
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+
+    const futureAlpha = await childMeeting(t, s.groupId1, FUTURE_DATE);
+
+    await t.mutation(api.functions.meetings.index.update, {
+      token: s.leaderToken,
+      meetingId: futureAlpha._id,
+      scheduledAt: FUTURE_DATE,
+      note: "Bring a side dish",
+    });
+
+    const after = await getMeeting(t, futureAlpha._id);
+    expect(after?.note).toBe("Bring a side dish");
+    expect(after?.scheduledAt).toBe(FUTURE_DATE);
+  });
+
+  test("community admin can still change a community-wide child's date", async () => {
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+
+    const futureAlpha = await childMeeting(t, s.groupId1, FUTURE_DATE);
+    const newDate = FUTURE_DATE + 24 * 60 * 60 * 1000;
+
+    await t.mutation(api.functions.meetings.index.update, {
+      token: s.adminToken,
+      meetingId: futureAlpha._id,
+      scheduledAt: newDate,
+    });
+
+    expect((await getMeeting(t, futureAlpha._id))?.scheduledAt).toBe(newDate);
+  });
+
+  test("leaders keep full date control over ordinary group events", async () => {
+    // The restriction is scoped to community-wide children only — a normal
+    // group event a leader owns must stay freely editable.
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+
+    const meetingId = await t.run(async (ctx) =>
+      await ctx.db.insert("meetings", {
+        groupId: s.groupId1,
+        title: "Alpha Game Night",
+        shortId: "alpha01",
+        scheduledAt: FUTURE_DATE,
+        meetingType: 1,
+        status: "scheduled",
+        createdById: s.leaderId,
+        createdAt: NOW,
+        visibility: "community",
+        communityId: s.communityId,
+      })
+    );
+
+    const newDate = FUTURE_DATE + 24 * 60 * 60 * 1000;
+    await t.mutation(api.functions.meetings.index.update, {
+      token: s.leaderToken,
+      meetingId,
+      scheduledAt: newDate,
+    });
+
+    expect((await getMeeting(t, meetingId))?.scheduledAt).toBe(newDate);
+  });
+});
+
+// ============================================================================
+// The cascade reports what it skipped
+// ============================================================================
+
+describe("communityWideEvents.update — skipped children are reported", () => {
+  test("returns the count and group names of overridden children it skipped", async () => {
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+
+    // Leader customizes Alpha's future copy, latching the override.
+    const futureAlpha = await childMeeting(t, s.groupId1, FUTURE_DATE);
+    await t.mutation(api.functions.meetings.index.update, {
+      token: s.leaderToken,
+      meetingId: futureAlpha._id,
+      note: "Alpha does its own thing",
+    });
+
+    const futureParent = await parentFor(t, FUTURE_DATE);
+    const result = await t.mutation(api.functions.communityWideEvents.update, {
+      token: s.adminToken,
+      communityWideEventId: futureParent._id,
+      title: "Renamed Dinner",
+    });
+
+    expect(result.meetingsUpdated).toBe(2);
+    expect(result.meetingsSkipped).toBe(1);
+    expect(result.skippedGroupNames).toEqual(["Group Alpha"]);
+  });
+
+  test("reports nothing skipped when no child is overridden", async () => {
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+
+    const futureParent = await parentFor(t, FUTURE_DATE);
+    const result = await t.mutation(api.functions.communityWideEvents.update, {
+      token: s.adminToken,
+      communityWideEventId: futureParent._id,
+      title: "Renamed Dinner",
+    });
+
+    expect(result.meetingsUpdated).toBe(3);
+    expect(result.meetingsSkipped).toBe(0);
+    expect(result.skippedGroupNames).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Resetting a child back to the community default
+// ============================================================================
+
+describe("communityWideEvents.resetChildToCommunityDefault", () => {
+  /** Latch Alpha's past copy onto a divergent date, the way the incident did. */
+  async function corruptAlphaPastCopy(
+    t: ReturnType<typeof convexTest>,
+    s: Setup
+  ) {
+    const pastAlpha = await childMeeting(t, s.groupId1, PAST_DATE);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(pastAlpha._id, {
+        scheduledAt: FUTURE_DATE,
+        title: "Moved By Leader",
+        note: "leader note",
+        isOverridden: true,
+      });
+    });
+    return pastAlpha._id;
+  }
+
+  test("clears the override and re-syncs the child to its parent", async () => {
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+    const meetingId = await corruptAlphaPastCopy(t, s);
+
+    await t.mutation(
+      api.functions.communityWideEvents.resetChildToCommunityDefault,
+      { token: s.adminToken, meetingId }
+    );
+
+    const parent = await parentFor(t, PAST_DATE);
+    const after = await getMeeting(t, meetingId);
+    expect(after?.isOverridden).toBe(false);
+    expect(after?.scheduledAt).toBe(parent.scheduledAt);
+    expect(after?.title).toBe(parent.title);
+    expect(after?.note).toBe(parent.note);
+  });
+
+  test("a reset child is reachable by the admin cascade again", async () => {
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+    const meetingId = await corruptAlphaPastCopy(t, s);
+
+    await t.mutation(
+      api.functions.communityWideEvents.resetChildToCommunityDefault,
+      { token: s.adminToken, meetingId }
+    );
+
+    const pastParent = await parentFor(t, PAST_DATE);
+    const result = await t.mutation(api.functions.communityWideEvents.update, {
+      token: s.adminToken,
+      communityWideEventId: pastParent._id,
+      title: "Repaired Title",
+    });
+
+    expect(result.meetingsSkipped).toBe(0);
+    expect((await getMeeting(t, meetingId))?.title).toBe("Repaired Title");
+  });
+
+  test("re-syncs reminder timing to the parent's date", async () => {
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+    const meetingId = await corruptAlphaPastCopy(t, s);
+
+    await t.mutation(
+      api.functions.communityWideEvents.resetChildToCommunityDefault,
+      { token: s.adminToken, meetingId }
+    );
+
+    const parent = await parentFor(t, PAST_DATE);
+    const after = await getMeeting(t, meetingId);
+    // Reminder/confirmation windows must follow the restored date, not the
+    // date the leader moved the event to.
+    expect(after?.reminderAt).toBeLessThan(parent.scheduledAt);
+    expect(after?.attendanceConfirmationAt).toBeGreaterThan(parent.scheduledAt);
+    // The restored occurrence is in the past, so nothing may re-fire for it.
+    expect(after?.reminderSent).toBe(true);
+    expect(after?.attendanceConfirmationSent).toBe(true);
+    expect(after?.reminderJobId).toBeUndefined();
+    expect(after?.attendanceConfirmationJobId).toBeUndefined();
+  });
+
+  test("a group leader cannot reset a child", async () => {
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+    const meetingId = await corruptAlphaPastCopy(t, s);
+
+    await expect(
+      t.mutation(
+        api.functions.communityWideEvents.resetChildToCommunityDefault,
+        { token: s.leaderToken, meetingId }
+      )
+    ).rejects.toThrow();
+
+    expect((await getMeeting(t, meetingId))?.isOverridden).toBe(true);
+  });
+
+  test("the internal CLI variant performs the same reset", async () => {
+    // Backend deploys land before the mobile OTA carrying the button, so the
+    // CLI path is the on-call fix. It must match the in-app one exactly.
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+    const meetingId = await corruptAlphaPastCopy(t, s);
+
+    await t.mutation(
+      internal.functions.communityWideEvents
+        .resetChildToCommunityDefaultInternal,
+      { meetingId }
+    );
+
+    const parent = await parentFor(t, PAST_DATE);
+    const after = await getMeeting(t, meetingId);
+    expect(after?.isOverridden).toBe(false);
+    expect(after?.scheduledAt).toBe(parent.scheduledAt);
+    expect(after?.title).toBe(parent.title);
+  });
+
+  test("rejects a meeting that is not a community-wide child", async () => {
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+
+    const meetingId = await t.run(async (ctx) =>
+      await ctx.db.insert("meetings", {
+        groupId: s.groupId1,
+        title: "Standalone",
+        shortId: "solo001",
+        scheduledAt: FUTURE_DATE,
+        meetingType: 1,
+        status: "scheduled",
+        createdById: s.adminId,
+        createdAt: NOW,
+        visibility: "community",
+        communityId: s.communityId,
+      })
+    );
+
+    await expect(
+      t.mutation(
+        api.functions.communityWideEvents.resetChildToCommunityDefault,
+        { token: s.adminToken, meetingId }
+      )
+    ).rejects.toThrow(/community-wide/i);
+  });
+});

--- a/apps/convex/__tests__/communityWideEvents-override-lockout.test.ts
+++ b/apps/convex/__tests__/communityWideEvents-override-lockout.test.ts
@@ -375,6 +375,70 @@ describe("communityWideEvents.update — skipped children are reported", () => {
     expect(result.skippedGroupNames).toEqual(["Group Alpha"]);
   });
 
+  test("counts overridden children on future occurrences under all_in_series", async () => {
+    // The cascade reaches future occurrences too, so an override living only
+    // on a later date is skipped just the same. Reporting 0 here would hand
+    // the admin the exact silent success this change exists to remove.
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+
+    const laterDate = FUTURE_DATE + 7 * 24 * 60 * 60 * 1000;
+    await t.mutation(api.functions.communityWideEvents.createSeries, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      groupTypeId: s.groupTypeId,
+      seriesName: "Weekly Dinner",
+      dates: [FUTURE_DATE, laterDate],
+      title: "Weekly Dinner",
+      meetingType: 1,
+    });
+
+    // Alpha customizes only the LATER occurrence; the anchor's children are
+    // all untouched.
+    const laterAlpha = await childMeeting(t, s.groupId1, laterDate);
+    await t.mutation(api.functions.meetings.index.update, {
+      token: s.leaderToken,
+      meetingId: laterAlpha._id,
+      note: "Alpha does its own thing",
+    });
+
+    const anchorParent = await parentFor(t, FUTURE_DATE);
+    const result = await t.mutation(api.functions.communityWideEvents.update, {
+      token: s.adminToken,
+      communityWideEventId: anchorParent._id,
+      title: "Renamed Dinner",
+      scope: "all_in_series",
+    });
+
+    expect(result.meetingsSkipped).toBe(1);
+    expect(result.skippedGroupNames).toEqual(["Group Alpha"]);
+    // And the skip is real — Alpha's later copy keeps its old title.
+    expect((await getMeeting(t, laterAlpha._id))?.title).toBe("Weekly Dinner");
+  });
+
+  test("does not report the anchor's overrides when the anchor is out of scope", async () => {
+    // A past anchor under all_in_series contributes no meetings to the
+    // cascade, so its overridden children were never in scope to skip.
+    const t = convexTest(schema, modules);
+    const s = await setupTestData(t);
+    await createSeries(t, s);
+
+    const pastAlpha = await childMeeting(t, s.groupId1, PAST_DATE);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(pastAlpha._id, { isOverridden: true });
+    });
+
+    const pastParent = await parentFor(t, PAST_DATE);
+    const result = await t.mutation(api.functions.communityWideEvents.update, {
+      token: s.adminToken,
+      communityWideEventId: pastParent._id,
+      title: "Renamed Dinner",
+      scope: "all_in_series",
+    });
+
+    expect(result.meetingsSkipped).toBe(0);
+  });
+
   test("reports nothing skipped when no child is overridden", async () => {
     const t = convexTest(schema, modules);
     const s = await setupTestData(t);

--- a/apps/convex/functions/communityWideEvents.ts
+++ b/apps/convex/functions/communityWideEvents.ts
@@ -13,6 +13,7 @@
 
 import { v } from "convex/values";
 import { query, mutation, internalMutation } from "../_generated/server";
+import type { MutationCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { Doc, Id } from "../_generated/dataModel";
 import { now, generateShortId } from "../lib/utils";
@@ -202,7 +203,10 @@ export const create = mutation({
  * Updates the parent event and propagates changes to all child meetings
  * that have NOT been overridden by group leaders.
  *
- * @returns Count of meetings updated
+ * @returns Count of meetings updated, plus the count and group names of the
+ *   overridden children deliberately skipped — an admin needs to see those to
+ *   know why a group's copy still looks wrong. Use
+ *   `resetChildToCommunityDefault` to pull a skipped child back in.
  */
 export const update = mutation({
   args: {
@@ -314,6 +318,20 @@ export const update = mutation({
     const directChildren = allDirectChildren.filter(
       (m) => m.isOverridden !== true && m.status !== "cancelled"
     );
+
+    // Children this edit deliberately leaves alone because a leader customized
+    // them. Reported back so the admin UI can say so — a silent skip reads as
+    // "the save didn't work", which is exactly how an admin discovers too late
+    // that a corrupt child is unreachable.
+    const skippedChildren = allDirectChildren.filter(
+      (m) => m.isOverridden === true && m.status !== "cancelled"
+    );
+    const skippedGroupNames: string[] = [];
+    for (const m of skippedChildren) {
+      const group = await ctx.db.get(m.groupId);
+      if (group) skippedGroupNames.push(group.name);
+    }
+    skippedGroupNames.sort();
 
     // Meetings that receive non-date field edits.
     let cascadeMeetings: typeof directChildren = directChildren;
@@ -516,8 +534,160 @@ export const update = mutation({
       }
     }
 
-    return { meetingsUpdated };
+    return {
+      meetingsUpdated,
+      meetingsSkipped: skippedChildren.length,
+      skippedGroupNames,
+    };
   },
+});
+
+/**
+ * Restore one group's copy of a community-wide event to the parent's values.
+ *
+ * `meetings.update` latches `isOverridden` the first time a leader customizes
+ * their group's copy, and every cascade — including `repairCollapsedChildDates`
+ * — skips latched rows. Without a way to clear that flag an admin has no route
+ * back: `update` reports success while leaving the diverged child untouched.
+ * This is that route.
+ *
+ * Restores only what the parent owns (title, date and its derived reminder /
+ * confirmation timing, meeting type, link, note) and drops the child's own
+ * cover so it inherits the shared one again. `locationOverride` is deliberately
+ * left alone — each group meets at its own address and the parent holds no
+ * location to restore it to.
+ *
+ * Shared by the admin-facing mutation and the internal CLI variant below, so
+ * an on-call fix and an in-app tap can never drift apart.
+ *
+ * @returns The restored date and the group whose copy was reset
+ */
+async function resetChildToParent(
+  ctx: MutationCtx,
+  meetingId: Id<"meetings">
+): Promise<{ scheduledAt: number; groupName: string | undefined }> {
+  const meeting = await ctx.db.get(meetingId);
+  if (!meeting) {
+    throw new Error("Meeting not found");
+  }
+  if (!meeting.communityWideEventId) {
+    throw new Error("This event is not part of a community-wide event");
+  }
+
+  const parent = await ctx.db.get(meeting.communityWideEventId);
+  if (!parent) {
+    throw new Error("Community-wide event not found");
+  }
+
+  if (meeting.status === "cancelled") {
+    throw new Error("Cannot reset a cancelled event");
+  }
+
+  const timestamp = now();
+
+  // Drop jobs pinned to the child's diverged date before re-syncing.
+  if (meeting.reminderJobId) {
+    try { await ctx.scheduler.cancel(meeting.reminderJobId); } catch { /* already run */ }
+  }
+  if (meeting.attendanceConfirmationJobId) {
+    try { await ctx.scheduler.cancel(meeting.attendanceConfirmationJobId); } catch { /* already run */ }
+  }
+
+  const reminderAt = parent.scheduledAt - DEFAULT_REMINDER_OFFSET_MS;
+  const attendanceConfirmationAt =
+    parent.scheduledAt + DEFAULT_MEETING_DURATION_MS + DEFAULT_ATTENDANCE_CONFIRMATION_OFFSET_MS;
+
+  const group = await ctx.db.get(meeting.groupId);
+
+  await ctx.db.patch(meetingId, {
+    isOverridden: false,
+    title: parent.title,
+    scheduledAt: parent.scheduledAt,
+    meetingType: parent.meetingType,
+    meetingLink: parent.meetingLink,
+    note: parent.note,
+    // Children render the parent's cover when they have none of their own,
+    // so clearing this restores the shared image.
+    coverImage: undefined,
+    reminderAt,
+    attendanceConfirmationAt,
+    // A window already in the past counts as handled so no sweep re-fires
+    // it; a future window stays pending for the fresh job scheduled below.
+    reminderSent: reminderAt <= timestamp,
+    attendanceConfirmationSent: attendanceConfirmationAt <= timestamp,
+    searchText: buildMeetingSearchText({
+      title: parent.title,
+      locationOverride: meeting.locationOverride,
+      groupName: group?.name,
+    }),
+  });
+
+  let reminderJobId = undefined;
+  let attendanceConfirmationJobId = undefined;
+  if (reminderAt > timestamp) {
+    reminderJobId = await ctx.scheduler.runAt(
+      reminderAt,
+      internal.functions.scheduledJobs.sendMeetingReminder,
+      { meetingId }
+    );
+  }
+  if (attendanceConfirmationAt > timestamp) {
+    attendanceConfirmationJobId = await ctx.scheduler.runAt(
+      attendanceConfirmationAt,
+      internal.functions.scheduledJobs.sendAttendanceConfirmation,
+      { meetingId }
+    );
+  }
+
+  await ctx.db.patch(meetingId, {
+    reminderJobId,
+    attendanceConfirmationJobId,
+  });
+
+  return {
+    scheduledAt: parent.scheduledAt,
+    groupName: group?.name,
+  };
+}
+
+/** Admin-facing reset. See `resetChildToParent` for what it restores. */
+export const resetChildToCommunityDefault = mutation({
+  args: {
+    token: v.string(),
+    meetingId: v.id("meetings"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+
+    const meeting = await ctx.db.get(args.meetingId);
+    if (!meeting) {
+      throw new Error("Meeting not found");
+    }
+    if (!meeting.communityWideEventId) {
+      throw new Error("This event is not part of a community-wide event");
+    }
+    const parent = await ctx.db.get(meeting.communityWideEventId);
+    if (!parent) {
+      throw new Error("Community-wide event not found");
+    }
+
+    await requireCommunityAdmin(ctx, parent.communityId, userId);
+
+    return await resetChildToParent(ctx, args.meetingId);
+  },
+});
+
+/**
+ * CLI variant of the reset, for repairing a stuck event before the client
+ * carrying the in-app button has shipped. Backend deploys land immediately;
+ * the mobile button needs an OTA.
+ *
+ * Run with:
+ *   npx convex run functions/communityWideEvents:resetChildToCommunityDefaultInternal '{"meetingId":"<id>"}'
+ */
+export const resetChildToCommunityDefaultInternal = internalMutation({
+  args: { meetingId: v.id("meetings") },
+  handler: async (ctx, args) => await resetChildToParent(ctx, args.meetingId),
 });
 
 /**

--- a/apps/convex/functions/communityWideEvents.ts
+++ b/apps/convex/functions/communityWideEvents.ts
@@ -319,19 +319,24 @@ export const update = mutation({
       (m) => m.isOverridden !== true && m.status !== "cancelled"
     );
 
-    // Children this edit deliberately leaves alone because a leader customized
+    // Meetings this edit deliberately leaves alone because a leader customized
     // them. Reported back so the admin UI can say so — a silent skip reads as
     // "the save didn't work", which is exactly how an admin discovers too late
     // that a corrupt child is unreachable.
-    const skippedChildren = allDirectChildren.filter(
-      (m) => m.isOverridden === true && m.status !== "cancelled"
-    );
-    const skippedGroupNames: string[] = [];
-    for (const m of skippedChildren) {
-      const group = await ctx.db.get(m.groupId);
-      if (group) skippedGroupNames.push(group.name);
+    //
+    // Keyed by _id and scoped to the meetings this edit would otherwise have
+    // touched: a past all_in_series anchor contributes nothing (its children
+    // aren't in scope at all), and an all_in_series edit must also account for
+    // overrides on the *future* occurrences it cascades to — counting only the
+    // anchor's children would report 0 while silently skipping a later one.
+    const skippedById = new Map<Id<"meetings">, Doc<"meetings">>();
+    if (includeAnchor) {
+      for (const m of allDirectChildren) {
+        if (m.isOverridden === true && m.status !== "cancelled") {
+          skippedById.set(m._id, m);
+        }
+      }
     }
-    skippedGroupNames.sort();
 
     // Meetings that receive non-date field edits.
     let cascadeMeetings: typeof directChildren = directChildren;
@@ -380,11 +385,17 @@ export const update = mutation({
           for (const m of directChildren) byId.set(m._id, m);
         }
         for (const m of seriesMeetings) {
-          if (m.isOverridden === true || m.status === "cancelled") continue;
+          if (m.status === "cancelled") continue;
           if (!m.communityWideEventId) continue;
           const parent = parentById.get(m.communityWideEventId);
           if (!parent || parent.status === "cancelled") continue;
           if (parent.scheduledAt < timestamp) continue;
+          // Overridden check comes *after* the in-scope checks so the skip
+          // report only names meetings this edit would really have changed.
+          if (m.isOverridden === true) {
+            skippedById.set(m._id, m);
+            continue;
+          }
           byId.set(m._id, m);
         }
         cascadeMeetings = [...byId.values()];
@@ -397,6 +408,17 @@ export const update = mutation({
         );
       }
     }
+
+    // Resolve the skipped groups now that the full cascade scope is known.
+    // Deduplicated by name: one group with two customized occurrences is still
+    // one group for the admin to go and reset.
+    const skippedChildren = [...skippedById.values()];
+    const skippedNameSet = new Set<string>();
+    for (const m of skippedChildren) {
+      const group = await ctx.db.get(m.groupId);
+      if (group) skippedNameSet.add(group.name);
+    }
+    const skippedGroupNames = [...skippedNameSet].sort();
 
     // Non-date field updates — cascade to the scoped set.
     const cascadeUpdates: Record<string, unknown> = {};

--- a/apps/convex/functions/meetings/index.ts
+++ b/apps/convex/functions/meetings/index.ts
@@ -13,6 +13,7 @@ import { now, generateShortId, getDisplayName, getMediaUrl } from "../../lib/uti
 import { resolveChannelCommunityId } from "../../lib/messaging/communityScope";
 import { requireAuth } from "../../lib/auth";
 import { isActiveLeader, isActiveMembership } from "../../lib/helpers";
+import { isCommunityAdmin } from "../../lib/permissions";
 import {
   canCreateInGroup,
   canEditMeeting,
@@ -445,6 +446,36 @@ export const update = mutation({
       hostsChanged =
         prev.length !== validated.length ||
         prev.some((id, i) => id !== validated[i]);
+    }
+
+    // The date of a community-wide event's per-group copy belongs to the
+    // community admin who scheduled the fan-out — a leader moving their copy
+    // desynchronises it from the parent occurrence AND latches `isOverridden`
+    // below, which permanently excludes the row from every admin cascade and
+    // from `communityWideEvents.repairCollapsedChildDates`. That combination
+    // is what let one leader drag a past occurrence (RSVPs and all) onto a
+    // future date that already had a real occurrence, with no way for an admin
+    // to put it back. Leaders keep every other field, and keep full date
+    // control over ordinary group events.
+    //
+    // Compared against the stored value, not merely `!== undefined`: the edit
+    // form always posts `scheduledAt`, so a leader saving a note change
+    // resubmits the existing date and must not trip this.
+    if (
+      meeting.communityWideEventId &&
+      updates.scheduledAt !== undefined &&
+      updates.scheduledAt !== meeting.scheduledAt
+    ) {
+      const parent = await ctx.db.get(meeting.communityWideEventId);
+      const communityId = parent?.communityId ?? meeting.communityId;
+      const canMoveDate = communityId
+        ? await isCommunityAdmin(ctx, communityId, userId)
+        : false;
+      if (!canMoveDate) {
+        throw new Error(
+          "Only a community admin can change the date of a community-wide event. Ask an admin to reschedule it, or create a separate event for your group."
+        );
+      }
     }
 
     // Series-wide scope can cascade writes to siblings the caller may not own

--- a/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
@@ -312,6 +312,13 @@ export function CreateEventScreen() {
   const isCommunityWideContext =
     isCommunityWideEnabled || (isEditMode && !!meeting?.communityWideEventId);
 
+  // The date of a community-wide event's per-group copy is owned by the
+  // community admin who scheduled the fan-out — `meetings.update` rejects a
+  // non-admin date change outright. Lock the field rather than letting a leader
+  // pick a date and meet an error on save.
+  const isDateLockedToCommunityWide =
+    isEditMode && !!meeting?.communityWideEventId && !isAdmin;
+
   // Guard against a stale narrow-audience selection once we're in a
   // community-wide context (e.g. host enables the toggle, or a CWE child
   // loads). Falls back to "community" so we never persist a "groups" event
@@ -622,7 +629,10 @@ export function CreateEventScreen() {
     if (!meetingId) return;
 
     const hasSeries = !!meeting?.seriesId;
-    const isCommunityWide = !!meeting?.communityWideEventId;
+    // Cross-group scopes route to `communityWideEvents.*`, which are admin-only.
+    // Offering "All groups on this date" to a group leader just throws a raw
+    // permission error after they've already picked it.
+    const isCommunityWide = !!meeting?.communityWideEventId && isAdmin;
 
     if (!hasSeries && !isCommunityWide) {
       // Simple case: no series, no community-wide
@@ -848,7 +858,9 @@ export function CreateEventScreen() {
 
       if (isEditMode && meetingId) {
         const hasSeries = !!meeting?.seriesId;
-        const isCommunityWide = !!meeting?.communityWideEventId;
+        // Admin-only, for the same reason as the cancel flow above: the
+        // cross-group scopes are served by `communityWideEvents.update`.
+        const isCommunityWide = !!meeting?.communityWideEventId && isAdmin;
 
         // Event chat lives on chatChannels, not on the meeting. Flip it once
         // up front for the meeting being edited so the state persists no
@@ -894,7 +906,7 @@ export function CreateEventScreen() {
           ) {
             setIsUpdating(true);
             try {
-              await updateCommunityWideEventMutation({
+              const result = await updateCommunityWideEventMutation({
                 communityWideEventId: meeting.communityWideEventId as Id<"communityWideEvents">,
                 title: data.title,
                 scheduledAt: data.scheduledAt
@@ -917,6 +929,18 @@ export function CreateEventScreen() {
                 visibility: data.visibility,
                 scope,
               });
+              // Groups whose leader customized their copy are deliberately
+              // skipped. Say which ones — silently reporting success is how an
+              // admin ends up believing a date fix landed when it didn't.
+              if (result?.meetingsSkipped) {
+                const names = result.skippedGroupNames?.length
+                  ? result.skippedGroupNames.join(", ")
+                  : `${result.meetingsSkipped} group(s)`;
+                showAlert(
+                  "Updated, with exceptions",
+                  `${names} customized this event, so their version was left unchanged. Open that group's event and choose "Reset to community version" to bring it back in line.`
+                );
+              }
               router.back();
             } catch (error: any) {
               showAlert("Error", formatError(error, "Failed to update event"));
@@ -1533,15 +1557,24 @@ export function CreateEventScreen() {
               )}
             </>
           ) : (
-            <DatePicker
-              label="Date & Time"
-              value={scheduledAt}
-              onChange={setScheduledAt}
-              mode="datetime"
-              placeholder="Select date and time"
-              error={errors.scheduledAt}
-              required
-            />
+            <>
+              <DatePicker
+                label="Date & Time"
+                value={scheduledAt}
+                onChange={setScheduledAt}
+                mode="datetime"
+                placeholder="Select date and time"
+                error={errors.scheduledAt}
+                required
+                disabled={isDateLockedToCommunityWide}
+              />
+              {isDateLockedToCommunityWide && (
+                <Text style={[styles.helperText, { color: colors.textTertiary }]}>
+                  A community admin sets the date for this event. You can still
+                  edit everything else for your group.
+                </Text>
+              )}
+            </>
           )}
 
           {/* Title */}

--- a/apps/mobile/features/leader-tools/components/EventDetails.tsx
+++ b/apps/mobile/features/leader-tools/components/EventDetails.tsx
@@ -30,6 +30,7 @@ import { FloatingRsvpButtons } from "./FloatingRsvpButtons";
 import { FloatingRsvpCard } from "./FloatingRsvpCard";
 import { GuestListSection } from "./GuestListSection";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
+import { showAlert, showConfirm, formatError } from "@utils/error-handling";
 import { DOMAIN_CONFIG } from "@togather/shared";
 import * as Clipboard from "expo-clipboard";
 import { DragHandle } from "@components/ui/DragHandle";
@@ -258,33 +259,33 @@ export function EventDetails({
   // `isOverridden` latch excludes it from every admin cascade — so an admin
   // fixing the parent sees "saved" while this copy keeps its old date. This is
   // the only way back in sync.
-  const handleResetToCommunityDefault = () => {
-    Alert.alert(
-      "Reset to community version?",
-      "This group's customizations to this event — including its date — will be replaced with the community-wide version. Their own location is kept.",
-      [
-        { text: "Keep customizations", style: "cancel" },
-        {
-          text: "Reset",
-          style: "destructive",
-          onPress: async () => {
-            setIsResettingToCommunityDefault(true);
-            try {
-              await resetToCommunityDefaultMutation({
-                meetingId: meetingId as Id<"meetings">,
-              });
-            } catch {
-              Alert.alert(
-                "Error",
-                "Failed to reset this event to the community version."
-              );
-            } finally {
-              setIsResettingToCommunityDefault(false);
-            }
-          },
-        },
-      ]
-    );
+  const handleResetToCommunityDefault = async () => {
+    const confirmed = await showConfirm({
+      title: "Reset to community version?",
+      message:
+        "This group's customizations to this event — including its date — will be replaced with the community-wide version. Their own location is kept.",
+      confirmLabel: "Reset",
+      cancelLabel: "Keep customizations",
+      destructive: true,
+    });
+    if (!confirmed) return;
+
+    setIsResettingToCommunityDefault(true);
+    try {
+      await resetToCommunityDefaultMutation({
+        meetingId: meetingId as Id<"meetings">,
+      });
+    } catch (error) {
+      showAlert(
+        "Error",
+        formatError(
+          error,
+          "Failed to reset this event to the community version."
+        )
+      );
+    } finally {
+      setIsResettingToCommunityDefault(false);
+    }
   };
 
   const handleEdit = () => {

--- a/apps/mobile/features/leader-tools/components/EventDetails.tsx
+++ b/apps/mobile/features/leader-tools/components/EventDetails.tsx
@@ -146,6 +146,13 @@ export function EventDetails({
   // Toggle RSVP leader notifications mutation
   const toggleRsvpNotifyMutation = useAuthenticatedMutation(api.functions.meetings.index.toggleRsvpLeaderNotifications);
 
+  // Admin escape hatch for a customized community-wide copy — see handler below
+  const resetToCommunityDefaultMutation = useAuthenticatedMutation(
+    api.functions.communityWideEvents.resetChildToCommunityDefault
+  );
+  const [isResettingToCommunityDefault, setIsResettingToCommunityDefault] =
+    useState(false);
+
   // Wrapper for submitRsvp mutation
   const submitRsvp = {
     mutate: async (data: { meetingId: string; optionId: number }) => {
@@ -245,6 +252,39 @@ export function EventDetails({
   // Toggle expanded option to show users
   const toggleExpandOption = (optionId: number) => {
     setExpandedOption(expandedOption === optionId ? null : optionId);
+  };
+
+  // Once a leader customizes their group's copy of a community-wide event, the
+  // `isOverridden` latch excludes it from every admin cascade — so an admin
+  // fixing the parent sees "saved" while this copy keeps its old date. This is
+  // the only way back in sync.
+  const handleResetToCommunityDefault = () => {
+    Alert.alert(
+      "Reset to community version?",
+      "This group's customizations to this event — including its date — will be replaced with the community-wide version. Their own location is kept.",
+      [
+        { text: "Keep customizations", style: "cancel" },
+        {
+          text: "Reset",
+          style: "destructive",
+          onPress: async () => {
+            setIsResettingToCommunityDefault(true);
+            try {
+              await resetToCommunityDefaultMutation({
+                meetingId: meetingId as Id<"meetings">,
+              });
+            } catch {
+              Alert.alert(
+                "Error",
+                "Failed to reset this event to the community version."
+              );
+            } finally {
+              setIsResettingToCommunityDefault(false);
+            }
+          },
+        },
+      ]
+    );
   };
 
   const handleEdit = () => {
@@ -514,6 +554,38 @@ export function EventDetails({
                   isOverridden={meeting.isOverridden}
                   showOverrideNote={isLeader}
                 />
+                {/* Admin-only: a customized copy is invisible to every
+                    community-wide cascade until it's reset. */}
+                {isCommunityAdmin && meeting.isOverridden && (
+                  <TouchableOpacity
+                    style={[
+                      styles.resetToCommunityButton,
+                      { borderColor: colors.border },
+                    ]}
+                    onPress={handleResetToCommunityDefault}
+                    disabled={isResettingToCommunityDefault}
+                  >
+                    {isResettingToCommunityDefault ? (
+                      <ActivityIndicator size="small" color={colors.textSecondary} />
+                    ) : (
+                      <>
+                        <Ionicons
+                          name="refresh"
+                          size={16}
+                          color={colors.textSecondary}
+                        />
+                        <Text
+                          style={[
+                            styles.resetToCommunityText,
+                            { color: colors.textSecondary },
+                          ]}
+                        >
+                          Reset to community version
+                        </Text>
+                      </>
+                    )}
+                  </TouchableOpacity>
+                )}
               </View>
             )}
 
@@ -1040,6 +1112,21 @@ const styles = StyleSheet.create({
   },
   communityWideBadgeContainer: {
     marginBottom: 16,
+  },
+  resetToCommunityButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    marginTop: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+    borderRadius: 8,
+  },
+  resetToCommunityText: {
+    fontSize: 13,
+    fontWeight: "500",
   },
   detailCard: {
     borderRadius: 12,

--- a/apps/mobile/features/leader-tools/components/__tests__/EventDetails.test.tsx
+++ b/apps/mobile/features/leader-tools/components/__tests__/EventDetails.test.tsx
@@ -75,6 +75,10 @@ jest.mock("@services/api/convex", () => ({
         list: "api.functions.eventBlasts.list",
         initiate: "api.functions.eventBlasts.initiate",
       },
+      communityWideEvents: {
+        resetChildToCommunityDefault:
+          "api.functions.communityWideEvents.resetChildToCommunityDefault",
+      },
     },
   },
   useQuery: (...args: any[]) => mockUseQuery(...args),

--- a/apps/mobile/utils/__tests__/showConfirm.test.ts
+++ b/apps/mobile/utils/__tests__/showConfirm.test.ts
@@ -1,0 +1,119 @@
+/**
+ * showConfirm tests
+ *
+ * A confirmation built directly on `Alert.alert` is a no-op on React Native
+ * Web — the user presses the button and nothing happens. These lock in that
+ * the helper actually prompts on web, and that every way of dismissing the
+ * prompt resolves `false` so a destructive action never runs by default.
+ */
+
+import { Alert, Platform } from "react-native";
+import { showConfirm } from "../error-handling";
+
+const OPTIONS = {
+  title: "Reset to community version?",
+  message: "This group's customizations will be replaced.",
+  confirmLabel: "Reset",
+  cancelLabel: "Keep customizations",
+  destructive: true,
+};
+
+describe("showConfirm", () => {
+  const originalOS = Platform.OS;
+
+  afterEach(() => {
+    Object.defineProperty(Platform, "OS", { value: originalOS, writable: true });
+    jest.restoreAllMocks();
+  });
+
+  function setPlatform(os: string) {
+    Object.defineProperty(Platform, "OS", { value: os, writable: true });
+  }
+
+  describe("on web", () => {
+    // jest-expo's environment has no `window.confirm` to spy on, so assign
+    // the double directly and restore whatever was there afterwards.
+    const globalWindow = window as unknown as Record<string, unknown>;
+    let originalConfirm: unknown;
+
+    beforeEach(() => {
+      setPlatform("web");
+      originalConfirm = globalWindow.confirm;
+    });
+
+    afterEach(() => {
+      globalWindow.confirm = originalConfirm;
+    });
+
+    it("prompts via window.confirm and resolves true when accepted", async () => {
+      const confirmMock = jest.fn().mockReturnValue(true);
+      globalWindow.confirm = confirmMock;
+
+      await expect(showConfirm(OPTIONS)).resolves.toBe(true);
+      expect(confirmMock).toHaveBeenCalledWith(
+        `${OPTIONS.title}\n\n${OPTIONS.message}`
+      );
+    });
+
+    it("resolves false when dismissed", async () => {
+      globalWindow.confirm = jest.fn().mockReturnValue(false);
+      await expect(showConfirm(OPTIONS)).resolves.toBe(false);
+    });
+
+    it("does not fall through to the native Alert", async () => {
+      globalWindow.confirm = jest.fn().mockReturnValue(true);
+      const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+      await showConfirm(OPTIONS);
+      expect(alertSpy).not.toHaveBeenCalled();
+    });
+
+    it("resolves false rather than throwing when no confirm is available", async () => {
+      globalWindow.confirm = undefined;
+      await expect(showConfirm(OPTIONS)).resolves.toBe(false);
+    });
+  });
+
+  describe("on native", () => {
+    beforeEach(() => setPlatform("ios"));
+
+    it("resolves true when the confirm button is pressed", async () => {
+      jest.spyOn(Alert, "alert").mockImplementation((_t, _m, buttons) => {
+        buttons?.find((b) => b.text === OPTIONS.confirmLabel)?.onPress?.();
+      });
+
+      await expect(showConfirm(OPTIONS)).resolves.toBe(true);
+    });
+
+    it("resolves false when the cancel button is pressed", async () => {
+      jest.spyOn(Alert, "alert").mockImplementation((_t, _m, buttons) => {
+        buttons?.find((b) => b.text === OPTIONS.cancelLabel)?.onPress?.();
+      });
+
+      await expect(showConfirm(OPTIONS)).resolves.toBe(false);
+    });
+
+    it("resolves false when dismissed with the Android back button", async () => {
+      jest.spyOn(Alert, "alert").mockImplementation((_t, _m, _b, opts) => {
+        (opts as { onDismiss?: () => void })?.onDismiss?.();
+      });
+
+      await expect(showConfirm(OPTIONS)).resolves.toBe(false);
+    });
+
+    it("marks the confirm button destructive when asked", async () => {
+      const alertSpy = jest
+        .spyOn(Alert, "alert")
+        .mockImplementation((_t, _m, buttons) => {
+          buttons?.find((b) => b.text === OPTIONS.confirmLabel)?.onPress?.();
+        });
+
+      await showConfirm(OPTIONS);
+
+      const buttons = alertSpy.mock.calls[0][2];
+      expect(
+        buttons?.find((b) => b.text === OPTIONS.confirmLabel)?.style
+      ).toBe("destructive");
+    });
+  });
+});

--- a/apps/mobile/utils/error-handling.ts
+++ b/apps/mobile/utils/error-handling.ts
@@ -24,6 +24,53 @@ export function showAlert(title: string, message: string): void {
 }
 
 /**
+ * Ask the user to confirm an action, on any platform. Same reason as
+ * `showAlert`: a confirmation built directly on `Alert.alert` silently does
+ * nothing on React Native Web, so the button appears to be broken.
+ *
+ * Resolves `false` for cancel and for an Android back-button dismissal, so a
+ * destructive action never runs just because the prompt went away.
+ */
+export function showConfirm(options: {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+}): Promise<boolean> {
+  const {
+    title,
+    message,
+    confirmLabel,
+    cancelLabel = 'Cancel',
+    destructive = false,
+  } = options;
+
+  if (Platform.OS === 'web') {
+    if (typeof window !== 'undefined' && typeof window.confirm === 'function') {
+      return Promise.resolve(window.confirm(`${title}\n\n${message}`));
+    }
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    Alert.alert(
+      title,
+      message,
+      [
+        { text: cancelLabel, style: 'cancel', onPress: () => resolve(false) },
+        {
+          text: confirmLabel,
+          style: destructive ? 'destructive' : 'default',
+          onPress: () => resolve(true),
+        },
+      ],
+      { cancelable: true, onDismiss: () => resolve(false) }
+    );
+  });
+}
+
+/**
  * Extract a readable message from a ConvexError (or plain Error).
  *
  * ConvexError carries its payload on `.data`; production `.message` is a

--- a/apps/web/src/pages/guides/Events.tsx
+++ b/apps/web/src/pages/guides/Events.tsx
@@ -38,7 +38,10 @@ const toc: TocItem[] = [
  *     meeting is created per selected date and they share a seriesId.
  *   - community-wide behavior: apps/convex/functions/communityWideEvents.ts
  *     (scope = community + group type, spawns a linked meeting for every active
- *      group; isOverridden breaks the cascade so leaders can customize a copy)
+ *      group; isOverridden breaks the cascade so leaders can customize a copy.
+ *      scheduledAt on a copy is admin-only — see the guard in
+ *      functions/meetings/index.ts — and resetChildToCommunityDefault clears
+ *      the override and re-syncs a copy to its parent)
  *
  * NOTE: Event *plans* (rostering, run sheets) are a separate feature with its
  * own guide at /guides/event-plans. This guide is strictly about the public,
@@ -301,6 +304,22 @@ export function Events() {
           You manage all of them from the{" "}
           <Term>Community-Wide Events</Term> admin screen, which flags any copy a
           leader has customized.
+        </P>
+        <P>
+          One field stays yours alone: <strong>the date</strong>. A leader can
+          change their copy's title, note, location, poster and RSVP options, but
+          only a community admin can move it in time — otherwise one group's copy
+          drifts away from the occurrence everyone else is attending. A leader
+          who needs a different date creates a separate event for their group.
+        </P>
+        <P>
+          When you edit a community-wide event, copies a leader has already
+          customized are left as they are, and Togather now <em>tells you which
+          ones</em> rather than reporting a clean success. To pull one back in
+          line, open that group's event and choose{" "}
+          <Term>Reset to community version</Term> — it restores the shared title,
+          date, note and poster, and reconnects the copy to future updates. The
+          group's own location is kept.
         </P>
 
         <Figure caption="The Community-Wide Events admin screen, showing reach and any leader overrides.">


### PR DESCRIPTION
## What happened

A group leader opened an **old** occurrence of a community-wide series (a past event, with RSVPs) and changed its date to match a future occurrence. The result: that group ended up with two events on the same day, and the community admin could not fix it — every attempt appeared to save and changed nothing.

## Root cause

The cross-group date cascade is already fixed on `main` — I verified that with a reproduction: a leader's `all_in_series` date edit does **not** move sibling groups. That's not what left this stuck.

`meetings.update` latches `isOverridden` on a community-wide child the first time a leader edits it, including a date edit:

```ts
if (meeting.communityWideEventId && !meeting.isOverridden) {
  cleanedUpdates.isOverridden = true;
}
```

Every admin path skips latched rows — the `communityWideEvents.update` cascade (`communityWideEvents.ts:315`) and the `repairCollapsedChildDates` migration (`:892`) both filter them out — and **nothing anywhere ever sets the flag back to `false`**. So the admin's repair ran, skipped the one meeting that was actually wrong, and returned `{ meetingsUpdated: 2 }`: a success. Reproduced:

```
AFTER ADMIN FIX:
  Alpha  2026-09-01  overridden: true   (parent says 2026-06-01)  ← still wrong
  Beta   2026-06-01  overridden: false
  Gamma  2026-06-01  overridden: false
```

## Changes

- **`meetings.update` rejects a date change on a community-wide child from anyone who isn't a community admin.** Compared against the *stored* value rather than `!== undefined` — the edit form always posts `scheduledAt`, so a leader saving a note resubmits the existing date and must not trip the guard. Leaders keep every other field, and keep full date control over ordinary group events.
- **`communityWideEvents.update` returns `meetingsSkipped` and `skippedGroupNames`**, and the admin UI names the groups it left alone. A silent skip reads as "the save didn't work" — which is exactly how this went unnoticed.
- **New `resetChildToCommunityDefault`** clears the latch and re-syncs a copy to its parent (title, date and derived reminder / confirmation timing, meeting type, link, note; the group's own `locationOverride` is kept, since the parent holds no location to restore). Surfaced as **"Reset to community version"** for admins on an overridden event, plus an internal CLI variant sharing the same helper so a stuck event can be repaired before the mobile OTA carrying the button ships.
- **The scope picker no longer offers "All groups on this date" to non-admins** — it routes to admin-only mutations and previously just threw a raw permission error after the leader had already picked it.
- The date field is disabled with an explanatory note for leaders on a community-wide copy, rather than letting them pick a date and meet an error on save.

## Tests

New `apps/convex/__tests__/communityWideEvents-override-lockout.test.ts` (14 tests) covers the leader date block across both scopes, the unchanged-date resubmit, admin date control, ordinary group events staying unrestricted, the skipped-children reporting, and the reset (including job re-scheduling, admin-only access, and that a reset child is reachable by the cascade again).

- `apps/convex`: 183 files / 3437 tests pass
- `apps/mobile`: 247 suites / 2638 tests pass
- eslint clean on touched files (0 errors)

## Docs

`apps/web/src/pages/guides/Events.tsx` documents the admin-only date rule and the reset action.

## Note for deploy

Worth confirming the Convex deployment is actually up to date with `main` — the earlier cascade fix landed ~Jul 31 and the incident is Aug 10. If prod is behind, that cascade is still live independently of this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXNaad6Cv5D3m7fNdvpdpQ)_