### PR TITLE
fix(events): stop "Save Changes" silently doing nothing on a series event

### DIFF
--- a/apps/mobile/components/ui/EditScopeModal.tsx
+++ b/apps/mobile/components/ui/EditScopeModal.tsx
@@ -1,72 +1,75 @@
-import { Alert, Platform, ActionSheetIOS } from "react-native";
+/**
+ * EditScopeModal
+ *
+ * Asks which events an edit or cancel should apply to (this one, all groups on
+ * this date, or the whole series).
+ *
+ * This used to be an imperative `ActionSheetIOS` / `Alert.alert` prompt. Both
+ * are unreliable here: `Alert.alert` is a no-op on React Native Web, and the
+ * native action sheet is presented from the root view controller while every
+ * `(user)` screen — including Edit Event — is itself inside a `presentation:
+ * "modal"` stack. When the sheet fails to appear the caller is left waiting on
+ * a callback that never fires, so "Save Changes" silently does nothing forever.
+ *
+ * Rendering the picker in the React tree removes that whole failure class, and
+ * matches `ActionMenuSheet`'s existing role as the in-app replacement for
+ * iOS-only action sheets. Callers own the `visible` state.
+ */
+import React from "react";
+import { ActionMenuSheet, type MenuAction } from "./ActionMenuSheet";
 
 export type EditScope = "this_only" | "this_date_all_groups" | "all_in_series";
 
-interface EditScopeOptions {
+interface EditScopeModalProps {
+  visible: boolean;
   isCommunityWide: boolean;
   isInSeries: boolean;
-  actionLabel?: string; // "Edit" or "Cancel"
+  /** "Edit" or "Cancel" — used for the title and destructive styling. */
+  actionLabel?: string;
   onSelect: (scope: EditScope) => void;
-  onCancel?: () => void;
+  onCancel: () => void;
 }
 
-/**
- * Show a scope selection prompt for editing/cancelling series or community-wide events.
- * Uses ActionSheetIOS on iOS, Alert on Android.
- */
-export function showEditScopePrompt({
+export function EditScopeModal({
+  visible,
   isCommunityWide,
   isInSeries,
   actionLabel = "Edit",
   onSelect,
   onCancel,
-}: EditScopeOptions) {
-  const options: { label: string; scope: EditScope }[] = [
-    { label: "This event only", scope: "this_only" },
+}: EditScopeModalProps) {
+  const isCancelAction = actionLabel === "Cancel";
+
+  const actions: MenuAction[] = [
+    {
+      label: "This event only",
+      onPress: () => onSelect("this_only"),
+      destructive: isCancelAction,
+    },
   ];
 
   if (isCommunityWide) {
-    options.push({
+    actions.push({
       label: "All groups on this date",
-      scope: "this_date_all_groups",
+      onPress: () => onSelect("this_date_all_groups"),
+      destructive: isCancelAction,
     });
   }
 
   if (isInSeries) {
-    options.push({
+    actions.push({
       label: "All events in this series",
-      scope: "all_in_series",
+      onPress: () => onSelect("all_in_series"),
+      destructive: isCancelAction,
     });
   }
 
-  if (Platform.OS === "ios") {
-    const labels = [...options.map((o) => o.label), "Cancel"];
-    ActionSheetIOS.showActionSheetWithOptions(
-      {
-        title: `${actionLabel} which events?`,
-        options: labels,
-        cancelButtonIndex: labels.length - 1,
-        destructiveButtonIndex: actionLabel === "Cancel" ? options.length - 1 : undefined,
-      },
-      (buttonIndex) => {
-        if (buttonIndex < options.length) {
-          onSelect(options[buttonIndex].scope);
-        } else {
-          onCancel?.();
-        }
-      }
-    );
-  } else {
-    Alert.alert(
-      `${actionLabel} which events?`,
-      undefined,
-      [
-        ...options.map((o) => ({
-          text: o.label,
-          onPress: () => onSelect(o.scope),
-        })),
-        { text: "Cancel", style: "cancel" as const, onPress: onCancel },
-      ]
-    );
-  }
+  return (
+    <ActionMenuSheet
+      visible={visible}
+      title={`${actionLabel} which events?`}
+      actions={actions}
+      onClose={onCancel}
+    />
+  );
 }

--- a/apps/mobile/components/ui/__tests__/EditScopeModal.test.tsx
+++ b/apps/mobile/components/ui/__tests__/EditScopeModal.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * EditScopeModal tests
+ *
+ * The scope picker used to be an imperative ActionSheetIOS / Alert prompt.
+ * Both can fail to appear — Alert.alert is a no-op on React Native Web, and
+ * the native sheet is presented from the root view controller while Edit Event
+ * lives inside the `(user)` modal stack — leaving "Save Changes" waiting on a
+ * callback that never fires. These lock in that the options render in the
+ * React tree and that choosing one reports the right scope.
+ */
+
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react-native";
+import { EditScopeModal } from "../EditScopeModal";
+
+describe("EditScopeModal", () => {
+  const baseProps = {
+    visible: true,
+    isCommunityWide: false,
+    isInSeries: false,
+    onSelect: jest.fn(),
+    onCancel: jest.fn(),
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders the options in the React tree, not a native action sheet", () => {
+    render(<EditScopeModal {...baseProps} isInSeries />);
+
+    // Visible to the test renderer at all == rendered in-tree.
+    expect(screen.getByText("This event only")).toBeTruthy();
+    expect(screen.getByText("All events in this series")).toBeTruthy();
+  });
+
+  it("offers the cross-group scope only for community-wide events", () => {
+    const { rerender } = render(<EditScopeModal {...baseProps} isInSeries />);
+    expect(screen.queryByText("All groups on this date")).toBeNull();
+
+    rerender(<EditScopeModal {...baseProps} isInSeries isCommunityWide />);
+    expect(screen.getByText("All groups on this date")).toBeTruthy();
+  });
+
+  it("offers the series scope only when the event is in a series", () => {
+    const { rerender } = render(<EditScopeModal {...baseProps} />);
+    expect(screen.queryByText("All events in this series")).toBeNull();
+
+    rerender(<EditScopeModal {...baseProps} isInSeries />);
+    expect(screen.getByText("All events in this series")).toBeTruthy();
+  });
+
+  it("reports the chosen scope", () => {
+    const onSelect = jest.fn();
+    render(
+      <EditScopeModal
+        {...baseProps}
+        isInSeries
+        isCommunityWide
+        onSelect={onSelect}
+      />
+    );
+
+    fireEvent.press(screen.getByText("All events in this series"));
+    expect(onSelect).toHaveBeenCalledWith("all_in_series");
+
+    fireEvent.press(screen.getByText("All groups on this date"));
+    expect(onSelect).toHaveBeenCalledWith("this_date_all_groups");
+
+    fireEvent.press(screen.getByText("This event only"));
+    expect(onSelect).toHaveBeenCalledWith("this_only");
+  });
+
+  it("titles itself for the action being scoped", () => {
+    const { rerender } = render(<EditScopeModal {...baseProps} isInSeries />);
+    expect(screen.getByText("Edit which events?")).toBeTruthy();
+
+    rerender(
+      <EditScopeModal {...baseProps} isInSeries actionLabel="Cancel" />
+    );
+    expect(screen.getByText("Cancel which events?")).toBeTruthy();
+  });
+
+  it("renders nothing to press when hidden", () => {
+    render(<EditScopeModal {...baseProps} isInSeries visible={false} />);
+    expect(screen.queryByText("This event only")).toBeNull();
+  });
+});

--- a/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
+++ b/apps/mobile/features/leader-tools/components/CreateEventScreen.tsx
@@ -40,11 +40,11 @@ import { ConfirmModal } from "@components/ui/ConfirmModal";
 import { getGroupCoordinates, geocodeAddressAsync } from "../../groups/utils/geocodeLocation";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useAuth } from "@providers/AuthProvider";
-import { formatError, showAlert } from "@/utils/error-handling";
+import { formatError, showAlert, showConfirm } from "@/utils/error-handling";
 import { useGroupTypes } from "../../admin/hooks/useGroupTypes";
 import { DragHandle } from "@components/ui/DragHandle";
 import { useTheme } from "@hooks/useTheme";
-import { showEditScopePrompt, type EditScope } from "@components/ui/EditScopeModal";
+import { EditScopeModal, type EditScope } from "@components/ui/EditScopeModal";
 import { SeriesBadge } from "@components/ui/SeriesBadge";
 import { HostsPicker } from "./HostsPicker";
 
@@ -210,6 +210,16 @@ export function CreateEventScreen() {
 
   // Past date confirmation modal state (for admins only)
   const [showPastDateModal, setShowPastDateModal] = useState(false);
+  // Which-events picker for series / community-wide edits and cancels. Held in
+  // state (rather than fired imperatively) so it renders in the React tree —
+  // see EditScopeModal for why the native action sheet could never be trusted
+  // from inside the `(user)` modal stack.
+  const [scopePrompt, setScopePrompt] = useState<{
+    actionLabel: string;
+    isCommunityWide: boolean;
+    isInSeries: boolean;
+    onSelect: (scope: EditScope) => void;
+  } | null>(null);
 
   // Location geocoding validation state
   const [locationCanBeGeocoded, setLocationCanBeGeocoded] = useState<boolean | null>(null);
@@ -652,7 +662,7 @@ export function CreateEventScreen() {
     }
 
     // Show scope selection for series/community-wide events
-    showEditScopePrompt({
+    setScopePrompt({
       isCommunityWide,
       isInSeries: hasSeries,
       actionLabel: "Cancel",
@@ -703,7 +713,8 @@ export function CreateEventScreen() {
     });
   };
 
-  const validateForm = (): boolean => {
+  /** Returns the blocking error messages — empty means the form is valid. */
+  const validateForm = (): string[] => {
     const newErrors: { scheduledAt?: string; hostingGroup?: string; groupType?: string; seriesName?: string } = {};
 
     if (isSeriesMode) {
@@ -738,7 +749,10 @@ export function CreateEventScreen() {
     }
 
     setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
+    // Return the messages, not just a boolean: every field this can reject
+    // lives near the top of a long form, so a caller that silently bails
+    // shows nothing at all to someone scrolled down at the Save button.
+    return Object.values(newErrors).filter(Boolean) as string[];
   };
 
   // Check if the scheduled date is in the past
@@ -976,7 +990,7 @@ export function CreateEventScreen() {
         if (isCweAdminEdit && isCommunityWide) {
           performUpdate("this_date_all_groups");
         } else if (hasSeries || isCommunityWide) {
-          showEditScopePrompt({
+          setScopePrompt({
             isCommunityWide,
             isInSeries: hasSeries,
             actionLabel: "Edit",
@@ -1093,7 +1107,13 @@ export function CreateEventScreen() {
 
   // Main submit handler - validates and shows confirmation modal for past dates
   const handleSubmit = async () => {
-    if (!validateForm()) return;
+    const validationErrors = validateForm();
+    if (validationErrors.length > 0) {
+      // The inline error renders next to its field, which is off-screen when
+      // you're at the Save button — without this the button just looks dead.
+      showAlert("Can't save yet", validationErrors.join("\n"));
+      return;
+    }
 
     // For admins creating NEW events in the past, show confirmation modal
     // Skip if editing an existing event that already had a past date
@@ -1135,49 +1155,34 @@ export function CreateEventScreen() {
       if (locationChanged) changeDescriptions.push("location");
       const changeText = changeDescriptions.join(" and ");
 
-      Alert.alert(
-        "Notify Guests?",
-        `You changed the ${changeText}. Would you like to notify ${goingCount} guest${goingCount > 1 ? 's' : ''} who RSVP'd 'Going'?`,
-        [
-          {
-            text: "No",
-            style: "cancel",
-            onPress: () => {
-              // Update without notification
-              updateMeeting.mutate({ meetingId: eventMeetingId, ...data });
-            },
-          },
-          {
-            text: "Yes, Notify",
-            onPress: () => {
-              // Update WITH notification
-              updateMeeting.mutate({ meetingId: eventMeetingId, ...data, notifyGuests: true });
-            },
-          },
-        ]
-      );
+      // `showConfirm`, not `Alert.alert`: the alert is a no-op on React Native
+      // Web, and this sits between the user pressing Save and the write ever
+      // happening — a prompt that never appears loses the edit silently.
+      const notify = await showConfirm({
+        title: "Notify Guests?",
+        message: `You changed the ${changeText}. Would you like to notify ${goingCount} guest${goingCount > 1 ? 's' : ''} who RSVP'd 'Going'?`,
+        confirmLabel: "Yes, Notify",
+        cancelLabel: "No",
+      });
+      updateMeeting.mutate({
+        meetingId: eventMeetingId,
+        ...data,
+        ...(notify ? { notifyGuests: true } : {}),
+      });
     } catch (error) {
       console.error("Failed to check RSVPs:", error);
-      // Fall back to showing prompt anyway
-      Alert.alert(
-        "Notify Guests?",
-        "Would you like to notify guests who RSVP'd 'Going' about this change?",
-        [
-          {
-            text: "No",
-            style: "cancel",
-            onPress: () => {
-              updateMeeting.mutate({ meetingId: eventMeetingId, ...data });
-            },
-          },
-          {
-            text: "Yes, Notify",
-            onPress: () => {
-              updateMeeting.mutate({ meetingId: eventMeetingId, ...data, notifyGuests: true });
-            },
-          },
-        ]
-      );
+      // Fall back to prompting anyway — the edit still has to land either way.
+      const notify = await showConfirm({
+        title: "Notify Guests?",
+        message: "Would you like to notify guests who RSVP'd 'Going' about this change?",
+        confirmLabel: "Yes, Notify",
+        cancelLabel: "No",
+      });
+      updateMeeting.mutate({
+        meetingId: eventMeetingId,
+        ...data,
+        ...(notify ? { notifyGuests: true } : {}),
+      });
     }
   };
 
@@ -2224,6 +2229,20 @@ export function CreateEventScreen() {
             // (undefined would be interpreted as "no change").
             setPosterId(sel.posterId ?? null);
           }}
+        />
+
+        {/* Which-events picker for series / community-wide edits and cancels */}
+        <EditScopeModal
+          visible={!!scopePrompt}
+          isCommunityWide={scopePrompt?.isCommunityWide ?? false}
+          isInSeries={scopePrompt?.isInSeries ?? false}
+          actionLabel={scopePrompt?.actionLabel}
+          onSelect={(scope) => {
+            const pending = scopePrompt;
+            setScopePrompt(null);
+            pending?.onSelect(scope);
+          }}
+          onCancel={() => setScopePrompt(null)}
         />
 
         {/* Past Date Confirmation Modal (for admins only) */}


### PR DESCRIPTION
Follow-up to #796. That PR fixed the data problem (the `isOverridden` lockout); this one fixes the reason the screen appeared frozen.

## Symptom

On Edit Event for an event in a series ("Dinner Party · 13 of 15"), pressing **Save Changes** does nothing. No error, no spinner, no navigation — forever.

## Why

The Convex logs for this report show **no `meetings:update` call at all**, so the save never reaches the backend. Every dead-end is client-side, before any write. There are three of them on that one path:

1. **The which-events scope picker was an imperative `ActionSheetIOS` / `Alert.alert` prompt.** `Alert.alert` is a no-op on React Native Web (documented at `utils/error-handling.ts:12`), and the native action sheet is presented from the root view controller while *every* `(user)` screen — Edit Event included — is itself inside a `presentation: "modal"` stack (`app/_layout.tsx:99`). If the sheet doesn't appear, `onSelect` never fires, `performUpdate` is never called, and the edit is simply lost with the UI left intact. This fires for exactly the events the report involves: anything with `hasSeries || isCommunityWide`. The **cancel** flow had the identical dead-end.

2. **`handleSubmit` bailed on a failed `validateForm()` with a bare `return`.** Every field it can reject (date, hosting group, group type, series name) sits near the top of a long form, so someone scrolled to the Save button sees no inline error and no action — the button just looks dead.

3. **The notify-guests prompt** sits between the press and the write on any time/location change, and was another raw `Alert.alert`. On web it swallowed the edit outright.

## Changes

- `EditScopeModal` is now a real component rendered in the React tree, built on the existing `ActionMenuSheet` — which exists for precisely this reason per its own docstring: *"on web the native action sheet never shows, so an imperative ⋯ menu silently does nothing."* The imperative `showEditScopePrompt` is removed rather than kept alongside. Both call sites (edit and cancel) now drive it from state.
- `validateForm()` returns its messages instead of a bare boolean, and `handleSubmit` surfaces them.
- The notify-guests prompt routes through `showConfirm` (added in #796), which works on web and resolves `false` on dismissal.

## Tests

New `apps/mobile/components/ui/__tests__/EditScopeModal.test.tsx` (6 tests): options render in-tree, the cross-group scope appears only for community-wide events, the series scope only for series events, each choice reports the right scope, the title tracks the action, and nothing is pressable when hidden.

- `apps/mobile`: 249 suites / 2652 tests pass
- typecheck clean on the touched files; eslint 0 errors

## Note

This is mobile-only, so it needs an OTA to reach devices — and a push to `main` only publishes to the **staging** channel (`deploy-mobile-update.yml:44`). Reaching production takes a manual `workflow_dispatch` with `channel: production`, same as the #796 changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXNaad6Cv5D3m7fNdvpdpQ)_