### PR TITLE
fix(web): stop the native force-update modal from locking out togather.nyc

### DIFF
--- a/apps/mobile/components/ui/NativeUpdateModal.web.tsx
+++ b/apps/mobile/components/ui/NativeUpdateModal.web.tsx
@@ -1,0 +1,19 @@
+/**
+ * NativeUpdateModal (Web) - No-op
+ *
+ * The native modal force-blocks the app when the R2 release manifest reports a
+ * newer *native* build than the one the user installed. That question is
+ * meaningless on web: togather.nyc always serves the latest deployed export, so
+ * there is nothing for a visitor to update, and the modal's only action ("Open
+ * App Store") sends them to an iOS binary that has no bearing on the page they
+ * are looking at.
+ *
+ * Without this stub the native component shipped in the web export and compared
+ * the version baked into the deployed bundle against the iOS manifest. Bumping
+ * that manifest to 1.0.22 put every web visitor behind an undismissable
+ * "Update Required" dialog on /signin — the sign-in page is served by this
+ * Expo web export, not by apps/web (see apps/link-preview/cloudflare-worker.js).
+ */
+export function NativeUpdateModal() {
+  return null;
+}

--- a/apps/mobile/components/ui/__tests__/NativeUpdateModal.web.test.tsx
+++ b/apps/mobile/components/ui/__tests__/NativeUpdateModal.web.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * Tests for the web variant of NativeUpdateModal.
+ *
+ * The native modal force-blocks the whole app when the R2 release manifest
+ * reports a newer build than the one the user is running. On web there is no
+ * installable build to update to — togather.nyc always serves the latest
+ * deployed export — so the gate must be completely inert there. It previously
+ * was not, and a manifest bump to 1.0.22 locked every web visitor out of
+ * /signin behind an undismissable "Open App Store" dialog.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { NativeUpdateModal } from '../NativeUpdateModal.web';
+
+describe('NativeUpdateModal (web)', () => {
+  it('renders nothing', () => {
+    const { toJSON } = render(<NativeUpdateModal />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('never fetches the release manifest', () => {
+    const fetchSpy = jest.spyOn(global, 'fetch');
+    render(<NativeUpdateModal />);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## The bug

Every visitor to `togather.nyc/signin` is currently hard-blocked behind an undismissable **"Update Required — Open App Store"** dialog. There is no app to update: it's a web page.

## Why a native gate is running on the web

`togather.nyc/signin` is not the marketing site. The Cloudflare worker (`apps/link-preview/cloudflare-worker.js`) routes only `/`, `/guides/*`, `/legal/*`, `/android*`, `/assets/*`, `/images/*` to `apps/web` — **everything else, `signin` included, is the Expo web export of `apps/mobile`**. And `apps/mobile/app/_layout.tsx:250` mounts `<NativeUpdateModal />` above every route, with no web guard, so it shipped in the web bundle and ran its native version check in the browser:

- `__DEV__` is `false` in the production export, so the dev bail-out at `NativeUpdateModal.tsx:114` never fires.
- `Application.nativeApplicationVersion` is `null` on web, so `currentVersion` falls back to the version baked into the deployed bundle — **1.0.21**.
- `Platform.OS` is `'web'`, not `'android'`, so it takes the **iOS** branch: fetches `releases/ios/production/manifest.json` and labels the button "Open App Store".
- The modal is non-dismissable — `onRequestClose` is a no-op.

Moving the iOS manifest to `1.0.22` therefore locked out the web app. Nothing in this repo changed to cause it: the blocking value lives in R2, not in git, and was set by a manual `workflow_dispatch` of `update-release-manifest.yml` ([run 23324570970](https://github.com/togathernyc/togather/actions/runs/23324570970)). That's why `git log -S "1.0.22"` finds nothing.

The marketing site was never affected — `togather.nyc/` returns 200 and its bundle contains none of this code.

## The fix

Add `apps/mobile/components/ui/NativeUpdateModal.web.tsx` as a no-op, matching the existing `ConnectionProvider.web.tsx` and `ServingTaskQueueSync.web.tsx` pattern. Babel's `module-resolver` rewrites the `@components/...` alias to a relative path, so Metro's platform-extension resolution picks the `.web.tsx` variant — the same mechanism those two siblings already rely on.

The gate is meaningless on web by construction: the bundle being served *is* the latest deployed one, and its only remedy points at an iOS binary.

## Verification

Exported the web bundle (`npx expo export --platform web`) and grepped it against the bundle live at togather.nyc today:

| String | Live bundle | This branch |
| --- | --- | --- |
| `releases/ios/production/manifest.json` | present | **absent** |
| `Open App Store` | present | **absent** |
| `Please update to continue using the app` | present | **absent** |

(An unrelated dismissible `Alert` in `MessageInput` also uses the words "Update Required" and is untouched.)

- `components/ui` suite: **82/82 pass**, including two new tests asserting the web variant renders `null` and never fetches the manifest.
- ESLint clean on both new files.
- `pnpm-lock.yaml` untouched; no dependency change, so no native-instance risk.
- `tsc` reports one error on `NativeUpdateModal.tsx` (`Cannot find module '@togather/shared'`) — pre-existing, unrelated, and one of ~100 identical unbuilt-shared-package errors across the repo.

## Note for reviewers, not addressed here

The gate compares against `manifest.version` and never reads `minSupportedVersion` (currently `"1.0.0"`). Per #157's commit message that appears deliberate — every release is meant to force an update — so this PR leaves the semantics alone. Two consequences worth being aware of regardless: `minSupportedVersion` is dead weight in the manifest, and **iOS users on 1.0.21 are being force-blocked right now** while `app.json` is already at 1.0.23 and the manifest says 1.0.22.

## Deploying

Merging is not sufficient. `deploy-web.yml` auto-deploys **staging** only; production needs a manual `workflow_dispatch` with `environment: production`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqDCfBXXiGBte7bVKHVApx)_