### PR TITLE
test(web): make the NativeUpdateModal web test actually guard the bug

### DIFF
--- a/apps/mobile/components/ui/__tests__/NativeUpdateModal.web.test.tsx
+++ b/apps/mobile/components/ui/__tests__/NativeUpdateModal.web.test.tsx
@@ -7,21 +7,80 @@
  * deployed export — so the gate must be completely inert there. It previously
  * was not, and a manifest bump to 1.0.22 locked every web visitor out of
  * /signin behind an undismissable "Open App Store" dialog.
+ *
+ * These tests deliberately run the NATIVE component first, as a control. Under
+ * jest-expo `__DEV__` is true, so the native component short-circuits at
+ * NativeUpdateModal.tsx:114 and renders null too — meaning a naive "web variant
+ * renders null" assertion passes against BOTH components and guards nothing.
+ * Forcing `__DEV__ = false` and serving a newer manifest makes the native
+ * component actually block, so the web assertions below can only pass because
+ * the web variant is inert — not because the harness never armed the gate.
  */
 import React from 'react';
-import { render } from '@testing-library/react-native';
-import { NativeUpdateModal } from '../NativeUpdateModal.web';
+import { act, render } from '@testing-library/react-native';
+import { NativeUpdateModal as NativeVariant } from '../NativeUpdateModal';
+import { NativeUpdateModal as WebVariant } from '../NativeUpdateModal.web';
 
-describe('NativeUpdateModal (web)', () => {
-  it('renders nothing', () => {
-    const { toJSON } = render(<NativeUpdateModal />);
-    expect(toJSON()).toBeNull();
+const NEWER_MANIFEST = {
+  version: '1.0.22',
+  platform: 'ios',
+  environment: 'production',
+  releaseDate: '2026-03-20T01:05:46Z',
+  downloadUrl: 'https://apps.apple.com/us/app/togather-life-in-community/id6756286011',
+  minSupportedVersion: '1.0.0',
+};
+
+/** Reproduces production: not dev, and a manifest newer than the running build. */
+function armTheGate() {
+  (global as any).__DEV__ = false;
+  return jest.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => NEWER_MANIFEST,
+  } as Response);
+}
+
+describe('NativeUpdateModal', () => {
+  const realDev = (global as any).__DEV__;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = armTheGate();
   });
 
-  it('never fetches the release manifest', () => {
-    const fetchSpy = jest.spyOn(global, 'fetch');
-    render(<NativeUpdateModal />);
-    expect(fetchSpy).not.toHaveBeenCalled();
+  afterEach(() => {
     fetchSpy.mockRestore();
+    (global as any).__DEV__ = realDev;
+  });
+
+  // Control: proves the harness can actually trigger the block. If this test
+  // stops failing-open, the web assertions below become meaningless again.
+  describe('native variant (control)', () => {
+    it('fetches the manifest and blocks when a newer version exists', async () => {
+      const { findByText } = render(<NativeVariant />);
+
+      expect(await findByText('Update Required')).toBeTruthy();
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining('releases/ios/production/manifest.json')
+      );
+    });
+  });
+
+  describe('web variant', () => {
+    it('stays inert under the exact conditions that block on native', async () => {
+      const { queryByText, toJSON } = render(<WebVariant />);
+
+      // Flush the effects and the resolved fetch. Asserting null immediately
+      // would pass even against the native gate, which also renders null on its
+      // first pass while `isChecking` is true — the block only appears once the
+      // manifest promise settles.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(queryByText('Update Required')).toBeNull();
+      expect(toJSON()).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
Follow-up to #800. The fix in that PR was correct; **the test shipped with it was not.**

## The test guarded nothing

`NativeUpdateModal.web.test.tsx` asserted that the web variant renders `null` and never fetches the manifest. Both assertions pass **identically against the native component** — verified by running them against `../NativeUpdateModal`:

```
VACUITY CHECK: native component under the web test assertions
  ✓ renders nothing
  ✓ never fetches the release manifest
```

The cause is `NativeUpdateModal.tsx:113-116` — `if (__DEV__) { setIsChecking(false); return; }` — and jest-expo sets `__DEV__ = true`. The native gate therefore also renders `null` and never fetches under test, so the assertions were satisfied by the harness rather than by the fix.

Consequence: delete `NativeUpdateModal.web.tsx`, or revert it to the native implementation, and **CI stays green while togather.nyc/signin re-locks** behind the undismissable "Update Required / Open App Store" dialog. That is exactly the regression the file exists to catch.

Credit where due: this was caught by the adversarial review pass on #800, after that PR had already merged.

## The fix

Arm the gate before asserting:

- `__DEV__ = false` (restored in `afterEach`) so the check actually runs.
- `fetch` stubbed with a manifest at `1.0.22`, newer than the running build.
- **Run the native component first, as a control.** It asserts the modal *does* appear and the manifest *is* fetched. If that control ever stops firing, the harness has lost the ability to detect the block and the web assertions are meaningless again — so the control failing is the signal that the test has rotted.

Also merged the two web cases into one. The old "renders null" case passed even under mutation, because the native gate *also* renders `null` on its first pass while `isChecking` is true — the block only appears once the manifest promise settles. The merged assertion flushes the promise first, then checks no fetch, no "Update Required" text, and a null tree.

## Mutation-tested both directions

Replacing `NativeUpdateModal.web.tsx` with `export { NativeUpdateModal } from './NativeUpdateModal';` — i.e. reintroducing the exact production bug:

| | control (native blocks) | web variant inert |
| --- | --- | --- |
| stub intact | ✓ | ✓ |
| **stub reverted to native** | ✓ | **✕ fails** |
| stub restored | ✓ | ✓ |

The suite now fails when the bug comes back, which the merged version did not.

## Verification

- `components/ui`: **82/82 pass**.
- ESLint: 0 errors (3 `no-explicit-any` warnings for the `__DEV__` global cast and the `fetch` mock).
- No production code touched — test file only.

## Still open from the #800 review, not addressed here

- **Production web is still not deployed.** `deploy-web.yml` auto-deployed *staging* on the #800 merge ([run 31491310473](https://github.com/togathernyc/togather/actions/runs/31491310473), success). Production web lives in `deploy-to-production.yml` and is `workflow_dispatch`-only, so **togather.nyc/signin remains blocked until someone runs it manually.**
- `features/chat/components/MessageInput.tsx:500-508` carries the same App-Store-on-web mistake (`isFileUploadAvailable` is always false on web per `fileTypes.ts:246-253`). Harmless today only because `pickFile` is dead code — referenced nowhere. Worth deleting.
- Nothing in CI enforces that a component touching `expo-updates` / `expo-application` / `NativeModules` has a `.web` counterpart. Four hand-written web no-ops now exist and this one was missed for the modal's whole lifetime.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqDCfBXXiGBte7bVKHVApx)_