### PR TITLE
feat(admin): edit a member's profile, with an audit trail

### DIFF
--- a/apps/convex/__tests__/admin-member-profile-edit.test.ts
+++ b/apps/convex/__tests__/admin-member-profile-edit.test.ts
@@ -1153,6 +1153,105 @@ describe("actor authorization", () => {
     ).rejects.toThrow();
   });
 
+  test("the detail query hides the edit button from a regular admin viewing a fellow admin", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    // A second, non-primary admin — the actor.
+    const regularAdminId = await t.run(async (ctx) => {
+      const id = await ctx.db.insert("users", {
+        firstName: "Second",
+        lastName: "Admin",
+        email: "second@test.com",
+        isActive: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("userCommunities", {
+        userId: id,
+        communityId: s.communityId,
+        roles: COMMUNITY_ROLES.ADMIN,
+        status: 1,
+        createdAt: Date.now(),
+      });
+      // Promote the target to admin too.
+      const membership = await ctx.db
+        .query("userCommunities")
+        .withIndex("by_user", (q) => q.eq("userId", s.memberId))
+        .first();
+      await ctx.db.patch(membership!._id, { roles: COMMUNITY_ROLES.ADMIN });
+      return id;
+    });
+    const tokens = await generateTokens(regularAdminId, s.communityId);
+
+    // `canEditProfile` is actor-specific. If the query ignored the caller's
+    // rank, it would advertise an edit form here whose every save is rejected
+    // by the mutation.
+    const detail = await t.query(
+      api.functions.admin.members.getCommunityMemberById,
+      {
+        token: tokens.accessToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+      },
+    );
+    expect(detail?.canEditProfile).toBe(false);
+
+    // The primary admin still sees the button on the same record.
+    const asPrimary = await t.query(
+      api.functions.admin.members.getCommunityMemberById,
+      {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+      },
+    );
+    expect(asPrimary?.canEditProfile).toBe(true);
+  });
+
+  test("an admin can always edit their OWN record, even without Primary Admin", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const selfAdminId = await t.run(async (ctx) => {
+      const id = await ctx.db.insert("users", {
+        firstName: "Self",
+        lastName: "Admin",
+        email: "self@test.com",
+        isActive: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("userCommunities", {
+        userId: id,
+        communityId: s.communityId,
+        roles: COMMUNITY_ROLES.ADMIN,
+        status: 1,
+        createdAt: Date.now(),
+      });
+      return id;
+    });
+    const tokens = await generateTokens(selfAdminId, s.communityId);
+
+    const detail = await t.query(
+      api.functions.admin.members.getCommunityMemberById,
+      {
+        token: tokens.accessToken,
+        communityId: s.communityId,
+        targetUserId: selfAdminId,
+      },
+    );
+    expect(detail?.canEditProfile).toBe(true);
+
+    await editProfile(t, {
+      token: tokens.accessToken,
+      communityId: s.communityId,
+      targetUserId: selfAdminId,
+      firstName: "Selwyn",
+    });
+    expect((await readMember(t, selfAdminId))?.firstName).toBe("Selwyn");
+  });
+
   test("a regular admin cannot edit a fellow admin's record", async () => {
     const t = convexTest(schema, modules);
     const s = await seed(t);

--- a/apps/convex/__tests__/admin-member-profile-edit.test.ts
+++ b/apps/convex/__tests__/admin-member-profile-edit.test.ts
@@ -1,0 +1,1316 @@
+/**
+ * Admin Member Profile Edit Tests (ADR-034)
+ *
+ * Covers `admin.members.updateMemberProfile` and `listMemberProfileAudits`:
+ * - who may edit, and which fields
+ * - the claimed-account rule (every ownership signal)
+ * - the no-authority-anywhere rule (every authority surface)
+ * - membership status, legacy-format values, validation, uniqueness
+ * - audit row contents and ordering
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/admin-member-profile-edit.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../schema";
+import { api } from "../_generated/api";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+import { generateTokens } from "../lib/auth";
+import { drainScheduledFunctions } from "./helpers/drainScheduledFunctions";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+const COMMUNITY_ROLES = {
+  MEMBER: 1,
+  ADMIN: 3,
+  PRIMARY_ADMIN: 4,
+} as const;
+
+interface TestSetup {
+  adminId: Id<"users">;
+  memberId: Id<"users">;
+  communityId: Id<"communities">;
+  groupTypeId: Id<"groupTypes">;
+  groupId: Id<"groups">;
+  adminToken: string;
+}
+
+/**
+ * A primary admin, and an UNCLAIMED plain member — no verified phone, no
+ * password, no login anywhere. That is the population this feature exists for,
+ * so it is the default fixture; individual tests add whatever signal they are
+ * exercising.
+ */
+async function seed(t: ReturnType<typeof convexTest>): Promise<TestSetup> {
+  const ids = await t.run(async (ctx) => {
+    const ts = Date.now();
+
+    const adminId = await ctx.db.insert("users", {
+      firstName: "Reg",
+      lastName: "Admin",
+      email: "admin@test.com",
+      phone: "+12025551001",
+      isActive: true,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    const memberId = await ctx.db.insert("users", {
+      firstName: "Rafel",
+      lastName: "Ortiz",
+      email: "rafael@test.com",
+      phone: "+12025550123",
+      isActive: true,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    const communityId = await ctx.db.insert("communities", {
+      name: "Test Community",
+      slug: "test-community",
+      isPublic: true,
+      timezone: "America/New_York",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    const groupTypeId = await ctx.db.insert("groupTypes", {
+      communityId,
+      name: "Small Group",
+      slug: "small-group",
+      isActive: true,
+      createdAt: ts,
+      displayOrder: 1,
+    });
+
+    const groupId = await ctx.db.insert("groups", {
+      communityId,
+      groupTypeId,
+      name: "Group 1",
+      isArchived: false,
+      isPublic: true,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+
+    await ctx.db.insert("userCommunities", {
+      userId: adminId,
+      communityId,
+      roles: COMMUNITY_ROLES.PRIMARY_ADMIN,
+      status: 1,
+      createdAt: ts,
+    });
+
+    await ctx.db.insert("userCommunities", {
+      userId: memberId,
+      communityId,
+      roles: COMMUNITY_ROLES.MEMBER,
+      status: 1,
+      createdAt: ts,
+    });
+
+    return { adminId, memberId, communityId, groupTypeId, groupId };
+  });
+
+  const tokens = await generateTokens(ids.adminId, ids.communityId);
+  return { ...ids, adminToken: tokens.accessToken };
+}
+
+/**
+ * Call the mutation and drain what it schedules.
+ *
+ * A name change schedules `syncUserProfileToChannels`; left running, that job
+ * keeps convex-test's global transaction state open and trips "test began
+ * while previous transaction was still open" in a LATER test — possibly in an
+ * unrelated file sharing the vitest worker. See the helper's own comment.
+ */
+async function editProfile(
+  t: ReturnType<typeof convexTest>,
+  args: Parameters<typeof t.mutation>[1],
+) {
+  const result = await t.mutation(
+    api.functions.admin.members.updateMemberProfile,
+    args as any,
+  );
+  await drainScheduledFunctions(t);
+  return result;
+}
+
+/** Read the target user row straight from the DB. */
+async function readMember(t: ReturnType<typeof convexTest>, id: Id<"users">) {
+  return await t.run(async (ctx) => await ctx.db.get(id));
+}
+
+async function listAudits(t: ReturnType<typeof convexTest>, s: TestSetup) {
+  return await t.query(api.functions.admin.members.listMemberProfileAudits, {
+    token: s.adminToken,
+    communityId: s.communityId,
+    targetUserId: s.memberId,
+    paginationOpts: { numItems: 50, cursor: null },
+  });
+}
+
+// ============================================================================
+// Editing
+// ============================================================================
+
+describe("updateMemberProfile — editing", () => {
+  test("corrects a misspelled first name and records one audit row", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const result = await editProfile(
+      t,
+      {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        firstName: "Rafael",
+        reason: "Corrected from Gold Card",
+      },
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.changedFields).toEqual(["firstName"]);
+
+    const user = await readMember(t, s.memberId);
+    expect(user?.firstName).toBe("Rafael");
+
+    const audits = await listAudits(t, s);
+    expect(audits.page).toHaveLength(1);
+    expect(audits.page[0].changes).toEqual([
+      { field: "firstName", previousValue: "Rafel", newValue: "Rafael" },
+    ]);
+    expect(audits.page[0].reason).toBe("Corrected from Gold Card");
+    expect(audits.page[0].actor?.id).toBe(s.adminId);
+  });
+
+  test("an edit touching two fields is ONE audit row, not two", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      firstName: "Rafael",
+      phone: "+12025559999",
+    });
+
+    const audits = await listAudits(t, s);
+    expect(audits.page).toHaveLength(1);
+    expect(audits.page[0].changes.map((c: any) => c.field).sort()).toEqual([
+      "firstName",
+      "phone",
+    ]);
+  });
+
+  test("rebuilds searchText so the member stays findable by corrected details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      firstName: "Rafael",
+    });
+
+    const user = await readMember(t, s.memberId);
+    expect(user?.searchText).toContain("rafael");
+  });
+
+  test("a no-op edit writes nothing at all — not even an audit row", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const result = await editProfile(
+      t,
+      {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        firstName: "Rafel",
+        reason: "a reason alone is not an edit",
+      },
+    );
+
+    expect(result.changed).toBe(false);
+    const audits = await listAudits(t, s);
+    expect(audits.page).toHaveLength(0);
+  });
+
+  test("leaves another admin's concurrent name fix alone when only the phone changed", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    // First admin corrects the name.
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      firstName: "Rafael",
+    });
+
+    // Second admin, working from a form opened BEFORE that fix, changes only
+    // the phone. Because the client submits dirty fields only, the stale name
+    // is never sent and cannot revert the first correction.
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      phone: "+12025559999",
+    });
+
+    const user = await readMember(t, s.memberId);
+    expect(user?.firstName).toBe("Rafael");
+    expect(user?.phone).toBe("+12025559999");
+  });
+
+  test("allows profile edits for a member who has no phone on record", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.memberId, { phone: undefined });
+    });
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      firstName: "Rafael",
+      phone: "",
+    });
+
+    const user = await readMember(t, s.memberId);
+    expect(user?.firstName).toBe("Rafael");
+  });
+
+  test("refuses to remove an existing phone, which is how the member signs in", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await expect(
+      t.mutation(api.functions.admin.members.updateMemberProfile, {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        phone: "",
+      }),
+    ).rejects.toThrow(/cannot be removed/i);
+  });
+
+  test("first name cannot be cleared", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await expect(
+      t.mutation(api.functions.admin.members.updateMemberProfile, {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        firstName: "   ",
+      }),
+    ).rejects.toThrow(/first name is required/i);
+  });
+
+  test("email can be cleared", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      email: null,
+    });
+
+    const user = await readMember(t, s.memberId);
+    expect(user?.email).toBeUndefined();
+  });
+
+  test("changing a phone number leaves phoneVerified false", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      phone: "2025559999",
+    });
+
+    const user = await readMember(t, s.memberId);
+    // Normalized to E.164 on the way in, and NOT trusted as verified: an admin
+    // typing a number is not proof the member owns it.
+    expect(user?.phone).toBe("+12025559999");
+    expect(user?.phoneVerified).toBe(false);
+  });
+});
+
+// ============================================================================
+// Date of birth
+// ============================================================================
+
+describe("updateMemberProfile — date of birth", () => {
+  test("stores a picked date as UTC midnight of that calendar day", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      dateOfBirth: "1990-04-12",
+    });
+
+    const user = await readMember(t, s.memberId);
+    expect(user?.dateOfBirth).toBe(Date.UTC(1990, 3, 12));
+    // Read back in UTC, the day must be the day that was picked — this is the
+    // assertion that fails if the converters ever drift to local getters.
+    expect(new Date(user!.dateOfBirth!).getUTCDate()).toBe(12);
+  });
+
+  test("treats the Unix epoch as a real birthday, not an empty value", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.memberId, { dateOfBirth: 0 });
+    });
+
+    // The detail query must report timestamp 0 rather than null, or the edit
+    // form treats the birthday as empty and clears it on the next save.
+    const detail = await t.query(
+      api.functions.admin.members.getCommunityMemberById,
+      {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+      },
+    );
+    expect(detail?.dateOfBirth).toBe(0);
+
+    // And resubmitting the same day is a no-op, not a clear.
+    const result = await editProfile(
+      t,
+      {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        dateOfBirth: "1970-01-01",
+      },
+    );
+    expect(result.changed).toBe(false);
+    expect((await readMember(t, s.memberId))?.dateOfBirth).toBe(0);
+  });
+
+  test("clears the date of birth when null is submitted", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.memberId, { dateOfBirth: Date.UTC(1990, 3, 12) });
+    });
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      dateOfBirth: null,
+    });
+
+    const user = await readMember(t, s.memberId);
+    expect(user?.dateOfBirth).toBeUndefined();
+    const audits = await listAudits(t, s);
+    expect(audits.page[0].changes).toEqual([
+      { field: "dateOfBirth", previousValue: "1990-04-12", newValue: null },
+    ]);
+  });
+
+  test("rejects an impossible calendar date instead of rolling it forward", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await expect(
+      t.mutation(api.functions.admin.members.updateMemberProfile, {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        dateOfBirth: "2026-02-30",
+      }),
+    ).rejects.toThrow(/valid calendar date/i);
+  });
+});
+
+// ============================================================================
+// The claimed-account rule
+// ============================================================================
+
+describe("contact edits — the claimed-account rule", () => {
+  test("an unclaimed account allows contact edits", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      email: "rafael.ortiz@test.com",
+    });
+
+    expect((await readMember(t, s.memberId))?.email).toBe(
+      "rafael.ortiz@test.com",
+    );
+  });
+
+  // Each of these four is an independent signal that a human has signed in.
+  // `phoneVerified` alone is NOT sufficient: `legacyLogin` issues real JWTs
+  // without ever setting it.
+  const claimSignals: Array<[string, Record<string, unknown>]> = [
+    ["a verified phone", { phoneVerified: true }],
+    ["a stored legacy password", { password: "$2b$10$abcdefghijklmnop" }],
+    ["a recorded login on the user row", { lastLogin: 1_700_000_000_000 }],
+  ];
+
+  for (const [label, patch] of claimSignals) {
+    test(`${label} means the account is claimed and locks contact edits`, async () => {
+      const t = convexTest(schema, modules);
+      const s = await seed(t);
+      await t.run(async (ctx) => {
+        await ctx.db.patch(s.memberId, patch);
+      });
+
+      await expect(
+        t.mutation(api.functions.admin.members.updateMemberProfile, {
+          token: s.adminToken,
+          communityId: s.communityId,
+          targetUserId: s.memberId,
+          email: "attacker@evil.com",
+        }),
+      ).rejects.toThrow(/cannot be changed here/i);
+
+      expect((await readMember(t, s.memberId))?.email).toBe("rafael@test.com");
+    });
+  }
+
+  test("a login recorded on a MEMBERSHIP row also means the account is claimed", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    // Current sign-in paths stamp lastLogin here, not on the user row, so
+    // checking only `users.lastLogin` would miss almost everyone.
+    await t.run(async (ctx) => {
+      const membership = await ctx.db
+        .query("userCommunities")
+        .withIndex("by_user", (q) => q.eq("userId", s.memberId))
+        .first();
+      await ctx.db.patch(membership!._id, { lastLogin: 1_700_000_000_000 });
+    });
+
+    await expect(
+      t.mutation(api.functions.admin.members.updateMemberProfile, {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        phone: "+12025559999",
+      }),
+    ).rejects.toThrow(/cannot be changed here/i);
+  });
+
+  test("names and birthdays stay correctable on a CLAIMED account", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.memberId, { phoneVerified: true });
+    });
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      firstName: "Rafael",
+      dateOfBirth: "1990-04-12",
+    });
+
+    const user = await readMember(t, s.memberId);
+    expect(user?.firstName).toBe("Rafael");
+    expect(user?.dateOfBirth).toBe(Date.UTC(1990, 3, 12));
+  });
+});
+
+// ============================================================================
+// The no-authority-anywhere rule — one case per surface
+// ============================================================================
+
+describe("contact edits — the authority rule", () => {
+  /** Apply an authority-granting row/field, then assert contact edits fail. */
+  async function expectLocked(
+    t: ReturnType<typeof convexTest>,
+    s: TestSetup,
+  ): Promise<void> {
+    await expect(
+      t.mutation(api.functions.admin.members.updateMemberProfile, {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        email: "attacker@evil.com",
+      }),
+    ).rejects.toThrow(/cannot be changed here/i);
+
+    // …while a name edit still goes through, since names are not credentials.
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      firstName: "Rafael",
+    });
+    expect((await readMember(t, s.memberId))?.firstName).toBe("Rafael");
+  }
+
+  test("a platform superuser flag locks contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.memberId, { isSuperuser: true });
+    });
+    await expectLocked(t, s);
+  });
+
+  test("a platform staff flag locks contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.memberId, { isStaff: true });
+    });
+    await expectLocked(t, s);
+  });
+
+  test("a platform role such as poster_admin locks contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.memberId, { platformRoles: ["poster_admin"] });
+    });
+    await expectLocked(t, s);
+  });
+
+  test("a GLOBAL users.roles admin flag locks contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    // messaging/flagging.ts isUserAdmin reads this field directly, with no
+    // membership behind it, and grants cross-community moderation.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.memberId, { roles: 3 });
+    });
+    await expectLocked(t, s);
+  });
+
+  test("an admin role in ANOTHER community locks contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      const otherId = await ctx.db.insert("communities", {
+        name: "Other",
+        slug: "other",
+        isPublic: true,
+        timezone: "America/New_York",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("userCommunities", {
+        userId: s.memberId,
+        communityId: otherId,
+        roles: COMMUNITY_ROLES.ADMIN,
+        status: 1,
+        createdAt: Date.now(),
+      });
+    });
+    await expectLocked(t, s);
+  });
+
+  test("an admin role in a community the member has LEFT does not lock contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      const otherId = await ctx.db.insert("communities", {
+        name: "Other",
+        slug: "other",
+        isPublic: true,
+        timezone: "America/New_York",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("userCommunities", {
+        userId: s.memberId,
+        communityId: otherId,
+        roles: COMMUNITY_ROLES.ADMIN,
+        status: 2, // left — confers no authority
+        createdAt: Date.now(),
+      });
+    });
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      email: "rafael.ortiz@test.com",
+    });
+    expect((await readMember(t, s.memberId))?.email).toBe(
+      "rafael.ortiz@test.com",
+    );
+  });
+
+  test("leading a group locks contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("groupMembers", {
+        groupId: s.groupId,
+        userId: s.memberId,
+        role: "leader",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    });
+    await expectLocked(t, s);
+  });
+
+  test("an ordinary group membership does NOT lock contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("groupMembers", {
+        groupId: s.groupId,
+        userId: s.memberId,
+        role: "member",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    });
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      email: "rafael.ortiz@test.com",
+    });
+    expect((await readMember(t, s.memberId))?.email).toBe(
+      "rafael.ortiz@test.com",
+    );
+  });
+
+  test("leading an ARCHIVED group does not lock contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.groupId, { isArchived: true });
+      await ctx.db.insert("groupMembers", {
+        groupId: s.groupId,
+        userId: s.memberId,
+        role: "leader",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    });
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      email: "rafael.ortiz@test.com",
+    });
+    expect((await readMember(t, s.memberId))?.email).toBe(
+      "rafael.ortiz@test.com",
+    );
+  });
+
+  test("a channel moderator role locks contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      const channelId = await ctx.db.insert("chatChannels", {
+        communityId: s.communityId,
+        name: "general",
+        channelType: "custom",
+        createdById: s.adminId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        memberCount: 1,
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId,
+        userId: s.memberId,
+        role: "moderator",
+        joinedAt: Date.now(),
+        isMuted: false,
+      });
+    });
+    await expectLocked(t, s);
+  });
+
+  test("a channel OWNER role locks contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    // "owner" is a real fourth role value the schema comment omits; it can
+    // delete the channel and remove other admins.
+    await t.run(async (ctx) => {
+      const channelId = await ctx.db.insert("chatChannels", {
+        communityId: s.communityId,
+        name: "general",
+        channelType: "custom",
+        createdById: s.adminId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        memberCount: 1,
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId,
+        userId: s.memberId,
+        role: "owner",
+        joinedAt: Date.now(),
+        isMuted: false,
+      });
+    });
+    await expectLocked(t, s);
+  });
+
+  test("ordinary channel membership does NOT lock contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      const channelId = await ctx.db.insert("chatChannels", {
+        communityId: s.communityId,
+        name: "general",
+        channelType: "custom",
+        createdById: s.adminId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        memberCount: 1,
+      });
+      await ctx.db.insert("chatChannelMembers", {
+        channelId,
+        userId: s.memberId,
+        role: "member",
+        joinedAt: Date.now(),
+        isMuted: false,
+      });
+    });
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      email: "rafael.ortiz@test.com",
+    });
+    expect((await readMember(t, s.memberId))?.email).toBe(
+      "rafael.ortiz@test.com",
+    );
+  });
+
+  test("an active fund role locks contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      const fundId = await ctx.db.insert("funds", {
+        communityId: s.communityId,
+        name: "General Fund",
+        type: "general",
+        status: "active",
+        balanceCents: 0,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("fundRoles", {
+        fundId,
+        userId: s.memberId,
+        role: "manager",
+        grantedBy: s.adminId,
+        grantedAt: Date.now(),
+      });
+    });
+    await expectLocked(t, s);
+  });
+
+  test("a REVOKED fund role does not lock contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      const fundId = await ctx.db.insert("funds", {
+        communityId: s.communityId,
+        name: "General Fund",
+        type: "general",
+        status: "active",
+        balanceCents: 0,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("fundRoles", {
+        fundId,
+        userId: s.memberId,
+        role: "manager",
+        grantedBy: s.adminId,
+        grantedAt: Date.now(),
+        revokedAt: Date.now(),
+      });
+    });
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      email: "rafael.ortiz@test.com",
+    });
+    expect((await readMember(t, s.memberId))?.email).toBe(
+      "rafael.ortiz@test.com",
+    );
+  });
+
+  test("managing a serving team locks contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      const teamId = await ctx.db.insert("teams", {
+        groupId: s.groupId,
+        communityId: s.communityId,
+        name: "Worship",
+        createdAt: Date.now(),
+        createdById: s.adminId,
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("teamManagers", {
+        teamId,
+        userId: s.memberId,
+        communityId: s.communityId,
+        addedById: s.adminId,
+        addedAt: Date.now(),
+      });
+      // teamManagers rows are never cleaned up on exit, so the row alone must
+      // not count — active group membership is what makes it real.
+      await ctx.db.insert("groupMembers", {
+        groupId: s.groupId,
+        userId: s.memberId,
+        role: "member",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    });
+    await expectLocked(t, s);
+  });
+
+  test("a stale team-manager row for a group the member left does not lock contact details", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      const teamId = await ctx.db.insert("teams", {
+        groupId: s.groupId,
+        communityId: s.communityId,
+        name: "Worship",
+        createdAt: Date.now(),
+        createdById: s.adminId,
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("teamManagers", {
+        teamId,
+        userId: s.memberId,
+        communityId: s.communityId,
+        addedById: s.adminId,
+        addedAt: Date.now(),
+      });
+      // No groupMembers row at all — they left the group.
+    });
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      email: "rafael.ortiz@test.com",
+    });
+    expect((await readMember(t, s.memberId))?.email).toBe(
+      "rafael.ortiz@test.com",
+    );
+  });
+
+  test("an UNCLAIMED placeholder that already carries a role is still locked", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    // A placeholder's _id is stable, so roleAssignments / groupMembers /
+    // userCommunities rows can already point at it. Unclaimed-ness must never
+    // short-circuit the authority check.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.memberId, { isPlaceholder: true });
+      await ctx.db.insert("groupMembers", {
+        groupId: s.groupId,
+        userId: s.memberId,
+        role: "leader",
+        joinedAt: Date.now(),
+        notificationsEnabled: true,
+      });
+    });
+    await expectLocked(t, s);
+  });
+});
+
+// ============================================================================
+// Membership status
+// ============================================================================
+
+describe("membership status", () => {
+  for (const [label, status] of [
+    ["left", 2],
+    ["blocked", 3],
+  ] as const) {
+    test(`rejects a member who has ${label}, and the detail query agrees`, async () => {
+      const t = convexTest(schema, modules);
+      const s = await seed(t);
+      await t.run(async (ctx) => {
+        const membership = await ctx.db
+          .query("userCommunities")
+          .withIndex("by_user", (q) => q.eq("userId", s.memberId))
+          .first();
+        await ctx.db.patch(membership!._id, { status });
+      });
+
+      await expect(
+        t.mutation(api.functions.admin.members.updateMemberProfile, {
+          token: s.adminToken,
+          communityId: s.communityId,
+          targetUserId: s.memberId,
+          firstName: "Rafael",
+        }),
+      ).rejects.toThrow(/not an active member/i);
+
+      // The query must report editability the same way the mutation enforces
+      // it, or the UI offers a button that always fails.
+      const detail = await t.query(
+        api.functions.admin.members.getCommunityMemberById,
+        {
+          token: s.adminToken,
+          communityId: s.communityId,
+          targetUserId: s.memberId,
+        },
+      );
+      expect(detail?.canEditProfile).toBe(false);
+    });
+  }
+});
+
+// ============================================================================
+// Legacy values, validation and uniqueness
+// ============================================================================
+
+describe("legacy values, validation and uniqueness", () => {
+  test("resubmitting a legacy-formatted phone or email is not a contact change", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.memberId, {
+        phone: "(202) 555-9999",
+        email: "Rafael@Test.com",
+        phoneVerified: true, // claimed, so contact edits are locked
+      });
+    });
+
+    // Canonically identical values, differently formatted. These must not
+    // register as a change, so the name edit alongside them succeeds…
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      firstName: "Rafael",
+      phone: "+12025559999",
+      email: "rafael@test.com",
+    });
+
+    const user = await readMember(t, s.memberId);
+    expect(user?.firstName).toBe("Rafael");
+    // …and the stored values are left exactly as they were.
+    expect(user?.phone).toBe("(202) 555-9999");
+    expect(user?.email).toBe("Rafael@Test.com");
+
+    const audits = await listAudits(t, s);
+    expect(audits.page[0].changes.map((c: any) => c.field)).toEqual([
+      "firstName",
+    ]);
+  });
+
+  test("legacy contact values that fail today's validation still allow other edits", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      // A seven-digit phone and an address with no public TLD: both rejected
+      // by today's rules. Comparing before validating is what keeps an
+      // unrelated name edit from going down with them.
+      await ctx.db.patch(s.memberId, {
+        phone: "5550123",
+        email: "rafael@localhost",
+      });
+    });
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      firstName: "Rafael",
+      phone: "5550123",
+      email: "rafael@localhost",
+    });
+
+    expect((await readMember(t, s.memberId))?.firstName).toBe("Rafael");
+  });
+
+  test("rejects an invalid new phone number", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await expect(
+      t.mutation(api.functions.admin.members.updateMemberProfile, {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        phone: "12345",
+      }),
+    ).rejects.toThrow(/valid phone number/i);
+  });
+
+  test("rejects an invalid new email address", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await expect(
+      t.mutation(api.functions.admin.members.updateMemberProfile, {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        email: "not-an-email",
+      }),
+    ).rejects.toThrow(/valid email address/i);
+  });
+
+  test("refuses a phone already used by another account", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await expect(
+      t.mutation(api.functions.admin.members.updateMemberProfile, {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        phone: "+12025551001", // the admin's number
+      }),
+    ).rejects.toThrow(/already uses this phone/i);
+  });
+
+  test("refuses an email already used by another account, ignoring case", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await expect(
+      t.mutation(api.functions.admin.members.updateMemberProfile, {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        email: "ADMIN@test.com",
+      }),
+    ).rejects.toThrow(/already uses this email/i);
+  });
+
+  test("rejects a reason longer than 500 characters", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await expect(
+      t.mutation(api.functions.admin.members.updateMemberProfile, {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        firstName: "Rafael",
+        reason: "x".repeat(501),
+      }),
+    ).rejects.toThrow(/500 characters/i);
+  });
+});
+
+// ============================================================================
+// Authorization of the ACTOR
+// ============================================================================
+
+describe("actor authorization", () => {
+  test("a non-admin member cannot edit anyone's profile", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    const memberTokens = await generateTokens(s.memberId, s.communityId);
+
+    await expect(
+      t.mutation(api.functions.admin.members.updateMemberProfile, {
+        token: memberTokens.accessToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        firstName: "Rafael",
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("a regular admin cannot edit a fellow admin's record", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const regularAdminToken = await t.run(async (ctx) => {
+      const id = await ctx.db.insert("users", {
+        firstName: "Second",
+        lastName: "Admin",
+        email: "second@test.com",
+        isActive: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("userCommunities", {
+        userId: id,
+        communityId: s.communityId,
+        roles: COMMUNITY_ROLES.ADMIN,
+        status: 1,
+        createdAt: Date.now(),
+      });
+      return id;
+    });
+    const tokens = await generateTokens(regularAdminToken, s.communityId);
+
+    // Promote the target to admin.
+    await t.run(async (ctx) => {
+      const membership = await ctx.db
+        .query("userCommunities")
+        .withIndex("by_user", (q) => q.eq("userId", s.memberId))
+        .first();
+      await ctx.db.patch(membership!._id, { roles: COMMUNITY_ROLES.ADMIN });
+    });
+
+    await expect(
+      t.mutation(api.functions.admin.members.updateMemberProfile, {
+        token: tokens.accessToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        firstName: "Rafael",
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ============================================================================
+// Audit trail
+// ============================================================================
+
+describe("listMemberProfileAudits", () => {
+  test("returns entries newest first and paginates the whole trail", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const names = ["Rafael", "Raphael", "Rafaél", "Rafa"];
+    for (const name of names) {
+      await editProfile(t, {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        firstName: name,
+      });
+    }
+
+    const firstPage = await t.query(
+      api.functions.admin.members.listMemberProfileAudits,
+      {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        paginationOpts: { numItems: 2, cursor: null },
+      },
+    );
+
+    expect(firstPage.page).toHaveLength(2);
+    expect(firstPage.isDone).toBe(false);
+    // Newest first.
+    expect(firstPage.page[0].changes[0].newValue).toBe("Rafa");
+
+    const secondPage = await t.query(
+      api.functions.admin.members.listMemberProfileAudits,
+      {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        paginationOpts: { numItems: 2, cursor: firstPage.continueCursor },
+      },
+    );
+
+    // Every entry stays reachable — no cap makes older rows disappear.
+    expect(secondPage.page).toHaveLength(2);
+    expect(secondPage.page[1].changes[0].newValue).toBe("Rafael");
+  });
+
+  test("a non-admin cannot read the audit trail", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    const memberTokens = await generateTokens(s.memberId, s.communityId);
+
+    await expect(
+      t.query(api.functions.admin.members.listMemberProfileAudits, {
+        token: memberTokens.accessToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+        paginationOpts: { numItems: 10, cursor: null },
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("audit rows follow the person through a duplicate-account merge", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      firstName: "Rafael",
+    });
+
+    // Simulate the merge re-keying: rows must end up on the surviving primary,
+    // otherwise the history query (which filters on the primary's exact
+    // targetUserId) can never reach them again.
+    const primaryId = await t.run(async (ctx) => {
+      const primaryId = await ctx.db.insert("users", {
+        firstName: "Rafael",
+        lastName: "Ortiz",
+        phone: "+12025550123",
+        isActive: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("userCommunities", {
+        userId: primaryId,
+        communityId: s.communityId,
+        roles: COMMUNITY_ROLES.MEMBER,
+        status: 1,
+        createdAt: Date.now(),
+      });
+      const audits = await ctx.db
+        .query("memberProfileAudits")
+        .withIndex("by_target", (q) => q.eq("targetUserId", s.memberId))
+        .collect();
+      expect(audits).toHaveLength(1);
+      for (const audit of audits) {
+        await ctx.db.patch(audit._id, { targetUserId: primaryId });
+      }
+      return primaryId;
+    });
+
+    const merged = await t.query(
+      api.functions.admin.members.listMemberProfileAudits,
+      {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: primaryId,
+        paginationOpts: { numItems: 10, cursor: null },
+      },
+    );
+    expect(merged.page).toHaveLength(1);
+  });
+});

--- a/apps/convex/__tests__/admin-member-profile-edit.test.ts
+++ b/apps/convex/__tests__/admin-member-profile-edit.test.ts
@@ -58,9 +58,9 @@ async function seed(t: ReturnType<typeof convexTest>): Promise<TestSetup> {
     });
 
     const memberId = await ctx.db.insert("users", {
-      firstName: "Rafel",
-      lastName: "Ortiz",
-      email: "rafael@test.com",
+      firstName: "Jorden",
+      lastName: "Reyes",
+      email: "jordan@test.com",
       phone: "+12025550123",
       isActive: true,
       createdAt: ts,
@@ -167,7 +167,7 @@ describe("updateMemberProfile — editing", () => {
         token: s.adminToken,
         communityId: s.communityId,
         targetUserId: s.memberId,
-        firstName: "Rafael",
+        firstName: "Jordan",
         reason: "Corrected from Gold Card",
       },
     );
@@ -176,12 +176,12 @@ describe("updateMemberProfile — editing", () => {
     expect(result.changedFields).toEqual(["firstName"]);
 
     const user = await readMember(t, s.memberId);
-    expect(user?.firstName).toBe("Rafael");
+    expect(user?.firstName).toBe("Jordan");
 
     const audits = await listAudits(t, s);
     expect(audits.page).toHaveLength(1);
     expect(audits.page[0].changes).toEqual([
-      { field: "firstName", previousValue: "Rafel", newValue: "Rafael" },
+      { field: "firstName", previousValue: "Jorden", newValue: "Jordan" },
     ]);
     expect(audits.page[0].reason).toBe("Corrected from Gold Card");
     expect(audits.page[0].actor?.id).toBe(s.adminId);
@@ -195,7 +195,7 @@ describe("updateMemberProfile — editing", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      firstName: "Rafael",
+      firstName: "Jordan",
       phone: "+12025559999",
     });
 
@@ -215,11 +215,11 @@ describe("updateMemberProfile — editing", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      firstName: "Rafael",
+      firstName: "Jordan",
     });
 
     const user = await readMember(t, s.memberId);
-    expect(user?.searchText).toContain("rafael");
+    expect(user?.searchText).toContain("jordan");
   });
 
   test("a no-op edit writes nothing at all — not even an audit row", async () => {
@@ -232,7 +232,7 @@ describe("updateMemberProfile — editing", () => {
         token: s.adminToken,
         communityId: s.communityId,
         targetUserId: s.memberId,
-        firstName: "Rafel",
+        firstName: "Jorden",
         reason: "a reason alone is not an edit",
       },
     );
@@ -251,7 +251,7 @@ describe("updateMemberProfile — editing", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      firstName: "Rafael",
+      firstName: "Jordan",
     });
 
     // Second admin, working from a form opened BEFORE that fix, changes only
@@ -265,7 +265,7 @@ describe("updateMemberProfile — editing", () => {
     });
 
     const user = await readMember(t, s.memberId);
-    expect(user?.firstName).toBe("Rafael");
+    expect(user?.firstName).toBe("Jordan");
     expect(user?.phone).toBe("+12025559999");
   });
 
@@ -280,12 +280,12 @@ describe("updateMemberProfile — editing", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      firstName: "Rafael",
+      firstName: "Jordan",
       phone: "",
     });
 
     const user = await readMember(t, s.memberId);
-    expect(user?.firstName).toBe("Rafael");
+    expect(user?.firstName).toBe("Jordan");
   });
 
   test("refuses to remove an existing phone, which is how the member signs in", async () => {
@@ -456,11 +456,11 @@ describe("contact edits — the claimed-account rule", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      email: "rafael.ortiz@test.com",
+      email: "jordan.reyes@test.com",
     });
 
     expect((await readMember(t, s.memberId))?.email).toBe(
-      "rafael.ortiz@test.com",
+      "jordan.reyes@test.com",
     );
   });
 
@@ -490,7 +490,7 @@ describe("contact edits — the claimed-account rule", () => {
         }),
       ).rejects.toThrow(/cannot be changed here/i);
 
-      expect((await readMember(t, s.memberId))?.email).toBe("rafael@test.com");
+      expect((await readMember(t, s.memberId))?.email).toBe("jordan@test.com");
     });
   }
 
@@ -528,12 +528,12 @@ describe("contact edits — the claimed-account rule", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      firstName: "Rafael",
+      firstName: "Jordan",
       dateOfBirth: "1990-04-12",
     });
 
     const user = await readMember(t, s.memberId);
-    expect(user?.firstName).toBe("Rafael");
+    expect(user?.firstName).toBe("Jordan");
     expect(user?.dateOfBirth).toBe(Date.UTC(1990, 3, 12));
   });
 });
@@ -562,9 +562,9 @@ describe("contact edits — the authority rule", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      firstName: "Rafael",
+      firstName: "Jordan",
     });
-    expect((await readMember(t, s.memberId))?.firstName).toBe("Rafael");
+    expect((await readMember(t, s.memberId))?.firstName).toBe("Jordan");
   }
 
   test("a platform superuser flag locks contact details", async () => {
@@ -653,10 +653,10 @@ describe("contact edits — the authority rule", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      email: "rafael.ortiz@test.com",
+      email: "jordan.reyes@test.com",
     });
     expect((await readMember(t, s.memberId))?.email).toBe(
-      "rafael.ortiz@test.com",
+      "jordan.reyes@test.com",
     );
   });
 
@@ -692,10 +692,10 @@ describe("contact edits — the authority rule", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      email: "rafael.ortiz@test.com",
+      email: "jordan.reyes@test.com",
     });
     expect((await readMember(t, s.memberId))?.email).toBe(
-      "rafael.ortiz@test.com",
+      "jordan.reyes@test.com",
     );
   });
 
@@ -717,10 +717,10 @@ describe("contact edits — the authority rule", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      email: "rafael.ortiz@test.com",
+      email: "jordan.reyes@test.com",
     });
     expect((await readMember(t, s.memberId))?.email).toBe(
-      "rafael.ortiz@test.com",
+      "jordan.reyes@test.com",
     );
   });
 
@@ -803,10 +803,10 @@ describe("contact edits — the authority rule", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      email: "rafael.ortiz@test.com",
+      email: "jordan.reyes@test.com",
     });
     expect((await readMember(t, s.memberId))?.email).toBe(
-      "rafael.ortiz@test.com",
+      "jordan.reyes@test.com",
     );
   });
 
@@ -861,10 +861,10 @@ describe("contact edits — the authority rule", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      email: "rafael.ortiz@test.com",
+      email: "jordan.reyes@test.com",
     });
     expect((await readMember(t, s.memberId))?.email).toBe(
-      "rafael.ortiz@test.com",
+      "jordan.reyes@test.com",
     );
   });
 
@@ -926,10 +926,10 @@ describe("contact edits — the authority rule", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      email: "rafael.ortiz@test.com",
+      email: "jordan.reyes@test.com",
     });
     expect((await readMember(t, s.memberId))?.email).toBe(
-      "rafael.ortiz@test.com",
+      "jordan.reyes@test.com",
     );
   });
 
@@ -978,7 +978,7 @@ describe("membership status", () => {
           token: s.adminToken,
           communityId: s.communityId,
           targetUserId: s.memberId,
-          firstName: "Rafael",
+          firstName: "Jordan",
         }),
       ).rejects.toThrow(/not an active member/i);
 
@@ -1008,7 +1008,7 @@ describe("legacy values, validation and uniqueness", () => {
     await t.run(async (ctx) => {
       await ctx.db.patch(s.memberId, {
         phone: "(202) 555-9999",
-        email: "Rafael@Test.com",
+        email: "Jordan@Test.com",
         phoneVerified: true, // claimed, so contact edits are locked
       });
     });
@@ -1019,16 +1019,16 @@ describe("legacy values, validation and uniqueness", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      firstName: "Rafael",
+      firstName: "Jordan",
       phone: "+12025559999",
-      email: "rafael@test.com",
+      email: "jordan@test.com",
     });
 
     const user = await readMember(t, s.memberId);
-    expect(user?.firstName).toBe("Rafael");
+    expect(user?.firstName).toBe("Jordan");
     // …and the stored values are left exactly as they were.
     expect(user?.phone).toBe("(202) 555-9999");
-    expect(user?.email).toBe("Rafael@Test.com");
+    expect(user?.email).toBe("Jordan@Test.com");
 
     const audits = await listAudits(t, s);
     expect(audits.page[0].changes.map((c: any) => c.field)).toEqual([
@@ -1045,7 +1045,7 @@ describe("legacy values, validation and uniqueness", () => {
       // unrelated name edit from going down with them.
       await ctx.db.patch(s.memberId, {
         phone: "5550123",
-        email: "rafael@localhost",
+        email: "jordan@localhost",
       });
     });
 
@@ -1053,12 +1053,12 @@ describe("legacy values, validation and uniqueness", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      firstName: "Rafael",
+      firstName: "Jordan",
       phone: "5550123",
-      email: "rafael@localhost",
+      email: "jordan@localhost",
     });
 
-    expect((await readMember(t, s.memberId))?.firstName).toBe("Rafael");
+    expect((await readMember(t, s.memberId))?.firstName).toBe("Jordan");
   });
 
   test("rejects an invalid new phone number", async () => {
@@ -1126,7 +1126,7 @@ describe("legacy values, validation and uniqueness", () => {
         token: s.adminToken,
         communityId: s.communityId,
         targetUserId: s.memberId,
-        firstName: "Rafael",
+        firstName: "Jordan",
         reason: "x".repeat(501),
       }),
     ).rejects.toThrow(/500 characters/i);
@@ -1148,7 +1148,7 @@ describe("actor authorization", () => {
         token: memberTokens.accessToken,
         communityId: s.communityId,
         targetUserId: s.memberId,
-        firstName: "Rafael",
+        firstName: "Jordan",
       }),
     ).rejects.toThrow();
   });
@@ -1290,7 +1290,7 @@ describe("actor authorization", () => {
         token: tokens.accessToken,
         communityId: s.communityId,
         targetUserId: s.memberId,
-        firstName: "Rafael",
+        firstName: "Jordan",
       }),
     ).rejects.toThrow();
   });
@@ -1305,7 +1305,7 @@ describe("listMemberProfileAudits", () => {
     const t = convexTest(schema, modules);
     const s = await seed(t);
 
-    const names = ["Rafael", "Raphael", "Rafaél", "Rafa"];
+    const names = ["Jordan", "Jordyn", "Jordán", "Jord"];
     for (const name of names) {
       await editProfile(t, {
         token: s.adminToken,
@@ -1328,7 +1328,7 @@ describe("listMemberProfileAudits", () => {
     expect(firstPage.page).toHaveLength(2);
     expect(firstPage.isDone).toBe(false);
     // Newest first.
-    expect(firstPage.page[0].changes[0].newValue).toBe("Rafa");
+    expect(firstPage.page[0].changes[0].newValue).toBe("Jord");
 
     const secondPage = await t.query(
       api.functions.admin.members.listMemberProfileAudits,
@@ -1342,7 +1342,7 @@ describe("listMemberProfileAudits", () => {
 
     // Every entry stays reachable — no cap makes older rows disappear.
     expect(secondPage.page).toHaveLength(2);
-    expect(secondPage.page[1].changes[0].newValue).toBe("Rafael");
+    expect(secondPage.page[1].changes[0].newValue).toBe("Jordan");
   });
 
   test("a non-admin cannot read the audit trail", async () => {
@@ -1368,7 +1368,7 @@ describe("listMemberProfileAudits", () => {
       token: s.adminToken,
       communityId: s.communityId,
       targetUserId: s.memberId,
-      firstName: "Rafael",
+      firstName: "Jordan",
     });
 
     // Simulate the merge re-keying: rows must end up on the surviving primary,
@@ -1376,8 +1376,8 @@ describe("listMemberProfileAudits", () => {
     // targetUserId) can never reach them again.
     const primaryId = await t.run(async (ctx) => {
       const primaryId = await ctx.db.insert("users", {
-        firstName: "Rafael",
-        lastName: "Ortiz",
+        firstName: "Jordan",
+        lastName: "Reyes",
         phone: "+12025550123",
         isActive: true,
         createdAt: Date.now(),

--- a/apps/convex/functions/admin/duplicates.ts
+++ b/apps/convex/functions/admin/duplicates.ts
@@ -298,6 +298,23 @@ export const mergeDuplicateAccounts = mutation({
         }
       }
 
+      // Carry the profile-edit audit trail across to the primary (ADR-034).
+      // These rows are otherwise append-only, but leaving them keyed to the
+      // account we are about to deactivate would strand them: the history
+      // query filters on the primary's exact `targetUserId`, so a merged
+      // member's edit history would silently vanish. Re-key so the trail
+      // follows the person rather than the row.
+      const profileAudits = await ctx.db
+        .query("memberProfileAudits")
+        .withIndex("by_target", (q) => q.eq("targetUserId", secondary._id))
+        .collect();
+
+      for (const audit of profileAudits) {
+        await ctx.db.patch(audit._id, {
+          targetUserId: args.primaryAccountId,
+        });
+      }
+
       // Deactivate secondary account (soft delete)
       const newEmail = secondary.email?.startsWith("merged_")
         ? secondary.email

--- a/apps/convex/functions/admin/index.ts
+++ b/apps/convex/functions/admin/index.ts
@@ -31,6 +31,8 @@ export {
   searchCommunityMembers,
   getCommunityMemberById,
   updateMemberRole,
+  updateMemberProfile,
+  listMemberProfileAudits,
   transferPrimaryAdmin,
   getUserGroupHistory,
 } from "./members";

--- a/apps/convex/functions/admin/members.ts
+++ b/apps/convex/functions/admin/members.ts
@@ -257,19 +257,35 @@ async function describeAccountAuthority(
 }
 
 /**
- * The single source of truth for "may this admin edit this member's profile,
+ * The single source of truth for "may THIS admin edit THIS member's profile,
  * and may they touch the contact fields?"
  *
  * Called by BOTH `updateMemberProfile` and `getCommunityMemberById`, so the
- * detail screen hides exactly the actions the mutation would reject. Keeping
+ * detail screen offers exactly the actions the mutation would accept. Keeping
  * these in one place is deliberate: when the query and the mutation disagree,
- * the UI offers buttons that always fail.
+ * the UI shows buttons whose every save fails.
+ *
+ * Note this takes the ACTOR as well as the target. An earlier version did not,
+ * which meant the rank rule below lived only in the mutation — so a regular
+ * admin viewing a fellow admin saw an edit form that always rejected them.
+ * Any rule the mutation enforces has to be decided here, or the two drift.
  */
 async function getProfileEditPermissions(
   ctx: QueryCtx | MutationCtx,
   communityId: Id<"communities">,
   targetUserId: Id<"users">,
-): Promise<{ canEditProfile: boolean; contactEditBlockedReason: string | null }> {
+  actorUserId: Id<"users">,
+): Promise<{
+  canEditProfile: boolean;
+  profileEditBlockedReason: string | null;
+  contactEditBlockedReason: string | null;
+}> {
+  const blocked = (reason: string) => ({
+    canEditProfile: false,
+    profileEditBlockedReason: reason,
+    contactEditBlockedReason: reason,
+  });
+
   const membership = await ctx.db
     .query("userCommunities")
     .withIndex("by_user_community", (q) =>
@@ -281,23 +297,59 @@ async function getProfileEditPermissions(
   // both are retained in People search, and a community that someone has left
   // has no business editing their global user record.
   if (!membership || membership.status !== 1) {
-    return {
-      canEditProfile: false,
-      contactEditBlockedReason: "this member is not active in this community",
-    };
+    return blocked(
+      "This member is not an active member of this community, so their profile cannot be edited here.",
+    );
+  }
+
+  // Editing a fellow admin's record requires Primary Admin, mirroring
+  // `updateMemberRole`. Editing your OWN is always allowed — self-service
+  // profile settings already permit it.
+  if (
+    actorUserId !== targetUserId &&
+    (membership.roles ?? 0) >= ADMIN_ROLE_THRESHOLD
+  ) {
+    const actorMembership = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_user_community", (q) =>
+        q.eq("userId", actorUserId).eq("communityId", communityId),
+      )
+      .first();
+
+    const actorIsPrimaryAdmin =
+      actorMembership?.status === 1 &&
+      actorMembership.roles === COMMUNITY_ROLES.PRIMARY_ADMIN;
+
+    if (!actorIsPrimaryAdmin) {
+      return blocked(
+        "Only a Primary Admin can edit another admin's profile.",
+      );
+    }
   }
 
   const claimReason = await describeAccountClaim(ctx, targetUserId);
   if (claimReason) {
-    return { canEditProfile: true, contactEditBlockedReason: claimReason };
+    return {
+      canEditProfile: true,
+      profileEditBlockedReason: null,
+      contactEditBlockedReason: claimReason,
+    };
   }
 
   const authorityReason = await describeAccountAuthority(ctx, targetUserId);
   if (authorityReason) {
-    return { canEditProfile: true, contactEditBlockedReason: authorityReason };
+    return {
+      canEditProfile: true,
+      profileEditBlockedReason: null,
+      contactEditBlockedReason: authorityReason,
+    };
   }
 
-  return { canEditProfile: true, contactEditBlockedReason: null };
+  return {
+    canEditProfile: true,
+    profileEditBlockedReason: null,
+    contactEditBlockedReason: null,
+  };
 }
 
 // ============================================================================
@@ -583,8 +635,15 @@ export const getCommunityMemberById = query({
 
     // Reported here so the detail screen offers exactly the actions
     // `updateMemberProfile` would accept — see `getProfileEditPermissions`.
+    // `userId` is the CALLER, so this answer is actor-specific: a regular admin
+    // looking at a fellow admin correctly gets `canEditProfile: false`.
     const { canEditProfile, contactEditBlockedReason } =
-      await getProfileEditPermissions(ctx, args.communityId, args.targetUserId);
+      await getProfileEditPermissions(
+        ctx,
+        args.communityId,
+        args.targetUserId,
+        userId,
+      );
 
     return {
       id: user._id,
@@ -899,29 +958,16 @@ export const updateMemberProfile = mutation({
       throw new Error("User not found");
     }
 
-    const { canEditProfile, contactEditBlockedReason } =
-      await getProfileEditPermissions(ctx, args.communityId, args.targetUserId);
+    const { canEditProfile, profileEditBlockedReason, contactEditBlockedReason } =
+      await getProfileEditPermissions(
+        ctx,
+        args.communityId,
+        args.targetUserId,
+        actorUserId,
+      );
 
     if (!canEditProfile) {
-      throw new Error(
-        "This member is not an active member of this community, so their profile cannot be edited here.",
-      );
-    }
-
-    // Editing a fellow admin's record requires Primary Admin, mirroring
-    // `updateMemberRole`. Editing your OWN record is always allowed — you can
-    // already change all of it through self-service profile settings.
-    const isSelfEdit = actorUserId === args.targetUserId;
-    if (!isSelfEdit) {
-      const targetMembership = await ctx.db
-        .query("userCommunities")
-        .withIndex("by_user_community", (q) =>
-          q.eq("userId", args.targetUserId).eq("communityId", args.communityId),
-        )
-        .first();
-      if ((targetMembership?.roles ?? 0) >= ADMIN_ROLE_THRESHOLD) {
-        await requirePrimaryAdmin(ctx, args.communityId, actorUserId);
-      }
+      throw new Error(profileEditBlockedReason ?? "Profile cannot be edited");
     }
 
     if (args.reason !== undefined && args.reason.length > MAX_REASON_LENGTH) {

--- a/apps/convex/functions/admin/members.ts
+++ b/apps/convex/functions/admin/members.ts
@@ -9,8 +9,18 @@
  */
 
 import { v } from "convex/values";
+import { paginationOptsValidator } from "convex/server";
 import { query, mutation } from "../../_generated/server";
-import { now, normalizePhone, getMediaUrl } from "../../lib/utils";
+import type { QueryCtx, MutationCtx } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+import { internal } from "../../_generated/api";
+import {
+  now,
+  normalizePhone,
+  getMediaUrl,
+  isValidPhone,
+  buildSearchText,
+} from "../../lib/utils";
 import { requireAuth } from "../../lib/auth";
 import { searchCommunityMembersPaginated } from "../../lib/memberSearch";
 import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
@@ -21,6 +31,274 @@ import {
   COMMUNITY_ROLES,
   ADMIN_ROLE_THRESHOLD,
 } from "./auth";
+
+// ============================================================================
+// Member Profile Edits — claim and authority guards (ADR-034)
+// ============================================================================
+
+/**
+ * Why any of this exists: `users.phone` and `users.email` are not data, they
+ * are credentials. The phone receives sign-in OTPs, and the email is
+ * sufficient on its own — `auth/accountClaim.ts` exposes an *unauthenticated*
+ * `verify_and_link` action that mails a code to whatever address is on the
+ * record and hands back access and refresh tokens for that account. Both
+ * fields live on the global `users` row while admin roles are per-community,
+ * so an unrestricted admin edit reaches into communities the acting admin has
+ * no authority over.
+ *
+ * Hence the rule: contact details are editable ONLY while nobody has claimed
+ * the account AND the account holds no authority anywhere. Names and dates of
+ * birth are not credentials and follow ordinary role rules.
+ */
+
+/**
+ * Ownership signals that mean a human has actually signed in as this account.
+ *
+ * Deliberately broader than `phoneVerified`, because that flag does not mean
+ * what its name suggests: `auth/login.ts` `legacyLogin` authenticates a
+ * migrated password holder and issues real JWTs without ever setting it. Any
+ * ONE of these signals means the account is someone's identity, not data an
+ * admin typed off a paper card.
+ *
+ * Returns a human-readable reason, or null when the account is unclaimed.
+ */
+async function describeAccountClaim(
+  ctx: QueryCtx | MutationCtx,
+  userId: Id<"users">,
+): Promise<string | null> {
+  const user = await ctx.db.get(userId);
+  if (!user) return null;
+
+  // 1. Verified phone — the OTP path completed.
+  if (user.phoneVerified === true) {
+    return "this member has verified their phone number";
+  }
+
+  // 2. Stored password — legacy migrated accounts sign in via `legacyLogin`,
+  //    which issues real tokens and never touches `phoneVerified`.
+  if (user.password) {
+    return "this member has a password on their account";
+  }
+
+  // 3. Recorded login on the user row (backfilled from legacy login data by
+  //    admin/cleanup.ts, so it is an independent record of the same fact).
+  if (user.lastLogin) {
+    return "this member has signed in before";
+  }
+
+  // 4. Recorded login on ANY membership row. Current sign-in paths stamp
+  //    `lastLogin` here (`ensureUserCommunityInternal`), NOT on the user, so
+  //    checking only `users.lastLogin` misses almost everyone who has
+  //    actually signed in.
+  const memberships = await ctx.db
+    .query("userCommunities")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .collect();
+
+  if (memberships.some((m) => m.lastLogin)) {
+    return "this member has signed in before";
+  }
+
+  return null;
+}
+
+/**
+ * Every table and field in this codebase that grants a user a capability
+ * beyond their own rows. Returns a human-readable description of the first
+ * authority found, or null when the account holds none.
+ *
+ * ⚠️ A FEATURE THAT ADDS A NEW KIND OF ROLE MUST ADD IT HERE. ⚠️
+ *
+ * This enumeration is the whole safety of admin-written contact details: if a
+ * role-bearing table is missing below, a local admin can redirect the contact
+ * details of an account holding that role, claim it via the OTP or
+ * account-claim flow, and inherit the capability. Nothing in the type system
+ * will flag the omission — see the known limitation in ADR-034.
+ *
+ * Note that "unclaimed" does NOT imply "powerless", which is why this runs
+ * alongside `describeAccountClaim` rather than instead of it: legacy accounts
+ * were migrated with roles intact, leaders are routinely entered before they
+ * first sign in, and a placeholder row's `_id` is stable so it can already
+ * carry `roleAssignments` / `groupMembers` / `userCommunities` rows (see
+ * `auth/registration.ts`).
+ */
+async function describeAccountAuthority(
+  ctx: QueryCtx | MutationCtx,
+  userId: Id<"users">,
+): Promise<string | null> {
+  // --- Platform-global authority, all on the users doc itself ---------------
+  const user = await ctx.db.get(userId);
+  if (!user) return null;
+
+  // `isSuperuser` / `isStaff` bypass every other platform check
+  // (posters.ts `hasPlatformRole`, devAssistant/access.ts).
+  if (user.isSuperuser === true) return "this member is a platform superuser";
+  if (user.isStaff === true) return "this member is platform staff";
+
+  // Delegated platform roles: "poster_admin" (posters.ts) and
+  // "dev_maintainer" (devAssistant/access.ts) today.
+  if (user.platformRoles && user.platformRoles.length > 0) {
+    return `this member holds the platform role ${user.platformRoles.join(", ")}`;
+  }
+
+  // GLOBAL users.roles — not the per-community one. `messaging/flagging.ts`
+  // `isUserAdmin` reads this field directly, with no membership behind it,
+  // and grants cross-community flag review and message moderation.
+  if ((user.roles ?? 0) >= ADMIN_ROLE_THRESHOLD) {
+    return "this member has a global admin role";
+  }
+
+  // --- Community-scoped authority ------------------------------------------
+  const memberships = await ctx.db
+    .query("userCommunities")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .collect();
+
+  // Only status 1 counts: `isCommunityAdmin` / `isPrimaryAdmin` require it, so
+  // a stale role in a community the member has left confers nothing and must
+  // not permanently lock their contact details.
+  const activeAdminMemberships = memberships.filter(
+    (m) => m.status === 1 && (m.roles ?? 0) >= ADMIN_ROLE_THRESHOLD,
+  );
+  if (activeAdminMemberships.length > 0) {
+    return "this member is an admin of a community";
+  }
+
+  // Community finance roles (ADR-033). The grant alone is not authority —
+  // `canManageCommunityFinance` also requires the holder to still be a
+  // community admin, which the check above has already ruled out. Included so
+  // the enumeration stays complete if that conjunction is ever relaxed.
+  const financeRoles = await ctx.db
+    .query("communityFinanceRoles")
+    .withIndex("by_user_community", (q) => q.eq("userId", userId))
+    .collect();
+  const activeCommunityIds = new Set(
+    memberships.filter((m) => m.status === 1).map((m) => m.communityId),
+  );
+  if (
+    financeRoles.some(
+      (r) => r.revokedAt === undefined && activeCommunityIds.has(r.communityId),
+    )
+  ) {
+    return "this member holds a community finance role";
+  }
+
+  // --- Group-scoped authority ----------------------------------------------
+  const groupMemberships = await ctx.db
+    .query("groupMembers")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .collect();
+
+  for (const membership of groupMemberships) {
+    // `isGroupLeader` semantics (lib/membership.ts): active, accepted, leader.
+    const isActive =
+      membership.leftAt === undefined &&
+      (!membership.requestStatus || membership.requestStatus === "accepted");
+    if (!isActive || membership.role !== "leader") continue;
+
+    // Leading an archived group confers nothing — `isCommunityGroupLeader`
+    // (scheduling/permissions.ts) excludes archived groups too.
+    const group = await ctx.db.get(membership.groupId);
+    if (!group || group.isArchived === true) continue;
+
+    return "this member leads a group";
+  }
+
+  // Fund roles (ADR-032). `revokedAt === undefined` means active; re-grants
+  // leave the revoked row in place, so filter rather than taking the first.
+  const fundRoles = await ctx.db
+    .query("fundRoles")
+    .withIndex("by_user_fund", (q) => q.eq("userId", userId))
+    .collect();
+  if (fundRoles.some((r) => r.revokedAt === undefined)) {
+    return "this member holds a fund role";
+  }
+
+  // Serving-team managers (ADR-025). The row itself is never cleaned up when
+  // someone leaves the group, so `isTeamManager` re-verifies active group
+  // membership on every check — mirror that here rather than trusting the row.
+  const teamManagerRows = await ctx.db
+    .query("teamManagers")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .collect();
+  for (const row of teamManagerRows) {
+    const team = await ctx.db.get(row.teamId);
+    if (!team || team.isArchived === true) continue;
+    // Still an active member of the team's group?
+    const stillInGroup = groupMemberships.some(
+      (m) =>
+        m.groupId === team.groupId &&
+        m.leftAt === undefined &&
+        (!m.requestStatus || m.requestStatus === "accepted"),
+    );
+    if (stillInGroup) return "this member manages a serving team";
+  }
+
+  // --- Channel-scoped authority --------------------------------------------
+  // `chatChannelMembers` roles are granted directly, with no group leadership
+  // behind them. "owner" is a real fourth value the schema comment omits.
+  // Moderators can delete other people's messages (messaging/messages.ts);
+  // owners can remove members and delete the channel (messaging/channels.ts).
+  const channelMemberships = await ctx.db
+    .query("chatChannelMembers")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .collect();
+
+  const CHANNEL_AUTHORITY_ROLES = new Set(["owner", "admin", "moderator"]);
+  if (
+    channelMemberships.some(
+      (m) => m.leftAt === undefined && CHANNEL_AUTHORITY_ROLES.has(m.role),
+    )
+  ) {
+    return "this member holds a channel admin or moderator role";
+  }
+
+  return null;
+}
+
+/**
+ * The single source of truth for "may this admin edit this member's profile,
+ * and may they touch the contact fields?"
+ *
+ * Called by BOTH `updateMemberProfile` and `getCommunityMemberById`, so the
+ * detail screen hides exactly the actions the mutation would reject. Keeping
+ * these in one place is deliberate: when the query and the mutation disagree,
+ * the UI offers buttons that always fail.
+ */
+async function getProfileEditPermissions(
+  ctx: QueryCtx | MutationCtx,
+  communityId: Id<"communities">,
+  targetUserId: Id<"users">,
+): Promise<{ canEditProfile: boolean; contactEditBlockedReason: string | null }> {
+  const membership = await ctx.db
+    .query("userCommunities")
+    .withIndex("by_user_community", (q) =>
+      q.eq("userId", targetUserId).eq("communityId", communityId),
+    )
+    .first();
+
+  // Status 1 (active) only. Status 2 is "left" and status 3 is "blocked";
+  // both are retained in People search, and a community that someone has left
+  // has no business editing their global user record.
+  if (!membership || membership.status !== 1) {
+    return {
+      canEditProfile: false,
+      contactEditBlockedReason: "this member is not active in this community",
+    };
+  }
+
+  const claimReason = await describeAccountClaim(ctx, targetUserId);
+  if (claimReason) {
+    return { canEditProfile: true, contactEditBlockedReason: claimReason };
+  }
+
+  const authorityReason = await describeAccountAuthority(ctx, targetUserId);
+  if (authorityReason) {
+    return { canEditProfile: true, contactEditBlockedReason: authorityReason };
+  }
+
+  return { canEditProfile: true, contactEditBlockedReason: null };
+}
 
 // ============================================================================
 // Community Members
@@ -303,6 +581,11 @@ export const getCommunityMemberById = query({
       user._id,
     ]);
 
+    // Reported here so the detail screen offers exactly the actions
+    // `updateMemberProfile` would accept — see `getProfileEditPermissions`.
+    const { canEditProfile, contactEditBlockedReason } =
+      await getProfileEditPermissions(ctx, args.communityId, args.targetUserId);
+
     return {
       id: user._id,
       firstName: user.firstName || "",
@@ -312,7 +595,12 @@ export const getCommunityMemberById = query({
       phoneVerified: user.phoneVerified || false,
       profilePhoto: getMediaUrl(user.profilePhoto),
       notificationsDisabled: notifsDisabled.has(user._id),
-      dateOfBirth: user.dateOfBirth || null,
+      canEditProfile,
+      contactEditBlockedReason,
+      // `?? null`, never `|| null`: timestamp 0 is 1970-01-01, a real
+      // birthday, and turning it into null would make the edit form think the
+      // date was empty.
+      dateOfBirth: user.dateOfBirth ?? null,
       lastLogin: communityMembership.lastLogin || null,
       communityMembership: {
         roles: communityMembership.roles || 0,
@@ -526,6 +814,404 @@ export const transferPrimaryAdmin = mutation({
     }
 
     return { success: true };
+  },
+});
+
+// ============================================================================
+// Member Profile Edits (ADR-034)
+// ============================================================================
+
+const MAX_REASON_LENGTH = 500;
+
+/**
+ * `dateOfBirth` is stored as UTC midnight of the calendar day, which is what
+ * `new Date("YYYY-MM-DD")` produces in the signup path
+ * (`auth/helpers.parseAndValidateDate`). The API therefore speaks in
+ * `YYYY-MM-DD` strings rather than timestamps: a calendar date has no
+ * timezone, so there is nothing for the client and server to disagree about.
+ */
+function isoDateToUtcTimestamp(isoDate: string): number {
+  const match = isoDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    throw new Error("Date of birth must be in YYYY-MM-DD format");
+  }
+  const year = parseInt(match[1], 10);
+  const month = parseInt(match[2], 10);
+  const day = parseInt(match[3], 10);
+
+  const timestamp = Date.UTC(year, month - 1, day);
+  const reconstructed = new Date(timestamp);
+  // Rejects impossible calendar dates like 2026-02-30, which Date.UTC would
+  // otherwise silently roll forward into March.
+  if (
+    reconstructed.getUTCFullYear() !== year ||
+    reconstructed.getUTCMonth() !== month - 1 ||
+    reconstructed.getUTCDate() !== day
+  ) {
+    throw new Error("Date of birth is not a valid calendar date");
+  }
+  if (timestamp > Date.now()) {
+    throw new Error("Date of birth cannot be in the future");
+  }
+  return timestamp;
+}
+
+/** Format a stored dateOfBirth timestamp back to YYYY-MM-DD, read in UTC. */
+function utcTimestampToIsoDate(timestamp: number): string {
+  const date = new Date(timestamp);
+  const year = String(date.getUTCFullYear()).padStart(4, "0");
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Update a community member's profile, recording an append-only audit row.
+ *
+ * Callers submit ONLY the fields the admin actually changed. Every argument is
+ * optional and `undefined` means "untouched": sending the whole form would let
+ * a stale copy revert a concurrent edit by another admin, and the audit trail
+ * would then record that reversal as a deliberate change by someone who never
+ * touched the field. `null` is an explicit clear, which `email` and
+ * `dateOfBirth` accept.
+ *
+ * See ADR-034 for why contact fields are gated the way they are.
+ */
+export const updateMemberProfile = mutation({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+    targetUserId: v.id("users"),
+    firstName: v.optional(v.string()),
+    lastName: v.optional(v.string()),
+    email: v.optional(v.union(v.string(), v.null())),
+    phone: v.optional(v.union(v.string(), v.null())),
+    // YYYY-MM-DD, or null to clear.
+    dateOfBirth: v.optional(v.union(v.string(), v.null())),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const actorUserId = await requireAuth(ctx, args.token);
+    await requireCommunityAdmin(ctx, args.communityId, actorUserId);
+
+    const target = await ctx.db.get(args.targetUserId);
+    if (!target) {
+      throw new Error("User not found");
+    }
+
+    const { canEditProfile, contactEditBlockedReason } =
+      await getProfileEditPermissions(ctx, args.communityId, args.targetUserId);
+
+    if (!canEditProfile) {
+      throw new Error(
+        "This member is not an active member of this community, so their profile cannot be edited here.",
+      );
+    }
+
+    // Editing a fellow admin's record requires Primary Admin, mirroring
+    // `updateMemberRole`. Editing your OWN record is always allowed — you can
+    // already change all of it through self-service profile settings.
+    const isSelfEdit = actorUserId === args.targetUserId;
+    if (!isSelfEdit) {
+      const targetMembership = await ctx.db
+        .query("userCommunities")
+        .withIndex("by_user_community", (q) =>
+          q.eq("userId", args.targetUserId).eq("communityId", args.communityId),
+        )
+        .first();
+      if ((targetMembership?.roles ?? 0) >= ADMIN_ROLE_THRESHOLD) {
+        await requirePrimaryAdmin(ctx, args.communityId, actorUserId);
+      }
+    }
+
+    if (args.reason !== undefined && args.reason.length > MAX_REASON_LENGTH) {
+      throw new Error(
+        `Reason must be ${MAX_REASON_LENGTH} characters or fewer`,
+      );
+    }
+
+    const changes: Array<{
+      field: string;
+      previousValue: string | null;
+      newValue: string | null;
+    }> = [];
+    const updates: Record<string, unknown> = {};
+
+    // --- Names ---------------------------------------------------------------
+    if (args.firstName !== undefined) {
+      const trimmed = args.firstName.trim();
+      if (trimmed.length === 0) {
+        throw new Error("First name is required");
+      }
+      if (trimmed !== (target.firstName ?? "")) {
+        changes.push({
+          field: "firstName",
+          previousValue: target.firstName || null,
+          newValue: trimmed,
+        });
+        updates.firstName = trimmed;
+      }
+    }
+
+    if (args.lastName !== undefined) {
+      const trimmed = args.lastName.trim();
+      if (trimmed !== (target.lastName ?? "")) {
+        changes.push({
+          field: "lastName",
+          previousValue: target.lastName || null,
+          newValue: trimmed || null,
+        });
+        updates.lastName = trimmed || undefined;
+      }
+    }
+
+    // --- Contact details -----------------------------------------------------
+    // Order matters throughout this block: compare against the STORED value
+    // before validating anything. Legacy rows hold values today's rules reject
+    // (seven-digit phones, addresses with no public TLD), and validating a
+    // value that has not actually changed would take an unrelated name edit
+    // down with it. Comparison is on canonical forms, so `(202) 555-0123` and
+    // `+12025550123` — or `Rafael@Test.com` and `rafael@test.com` — are the
+    // same value and produce no change, no audit row and no blocker.
+
+    let phoneChanged = false;
+    let normalizedNewPhone: string | null = null;
+    if (args.phone !== undefined) {
+      const submitted = args.phone?.trim() ?? "";
+      const stored = target.phone ?? "";
+
+      if (submitted.length === 0) {
+        // An empty phone means "none on file", not "remove it". Members
+        // without a phone are common in migrated data, so a profile edit must
+        // never require inventing one — but removing an existing number would
+        // lock the member out of sign-in.
+        if (stored.length > 0) {
+          throw new Error(
+            "A member's phone number cannot be removed, because it is how they sign in.",
+          );
+        }
+      } else {
+        const canonicalSubmitted = normalizePhone(submitted);
+        const canonicalStored = stored ? normalizePhone(stored) : "";
+        if (canonicalSubmitted !== canonicalStored) {
+          phoneChanged = true;
+          normalizedNewPhone = canonicalSubmitted;
+        }
+      }
+    }
+
+    let emailChanged = false;
+    let normalizedNewEmail: string | null = null;
+    if (args.email !== undefined) {
+      const submitted = args.email?.trim() ?? "";
+      const stored = target.email ?? "";
+
+      if (submitted.length === 0) {
+        if (stored.length > 0) {
+          emailChanged = true;
+          normalizedNewEmail = null;
+        }
+      } else {
+        const canonicalSubmitted = submitted.toLowerCase();
+        const canonicalStored = stored.toLowerCase();
+        if (canonicalSubmitted !== canonicalStored) {
+          emailChanged = true;
+          normalizedNewEmail = canonicalSubmitted;
+        }
+      }
+    }
+
+    // Only a REAL contact change trips the guard.
+    if ((phoneChanged || emailChanged) && contactEditBlockedReason) {
+      throw new Error(
+        `Phone and email cannot be changed here because ${contactEditBlockedReason}. ` +
+          `They are sign-in credentials, so only the member can change them, through a flow that proves they own the new details.`,
+      );
+    }
+
+    if (phoneChanged && normalizedNewPhone) {
+      if (!isValidPhone(normalizedNewPhone)) {
+        throw new Error("Please enter a valid phone number");
+      }
+      const existing = await ctx.db
+        .query("users")
+        .withIndex("by_phone", (q) => q.eq("phone", normalizedNewPhone))
+        .first();
+      if (existing && existing._id !== args.targetUserId) {
+        throw new Error("Another account already uses this phone number");
+      }
+
+      changes.push({
+        field: "phone",
+        previousValue: target.phone || null,
+        newValue: normalizedNewPhone,
+      });
+      updates.phone = normalizedNewPhone;
+      // An admin typing a number is not proof the member owns it, so the
+      // account must not inherit the previous number's verified status.
+      updates.phoneVerified = false;
+    }
+
+    if (emailChanged) {
+      if (normalizedNewEmail) {
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedNewEmail)) {
+          throw new Error("Please enter a valid email address");
+        }
+        const existing = await ctx.db
+          .query("users")
+          .withIndex("by_email", (q) => q.eq("email", normalizedNewEmail))
+          .first();
+        if (existing && existing._id !== args.targetUserId) {
+          throw new Error("Another account already uses this email address");
+        }
+      }
+
+      changes.push({
+        field: "email",
+        previousValue: target.email || null,
+        newValue: normalizedNewEmail,
+      });
+      updates.email = normalizedNewEmail ?? undefined;
+    }
+
+    // --- Date of birth -------------------------------------------------------
+    if (args.dateOfBirth !== undefined) {
+      // `?? null`, never `|| null`: timestamp 0 is 1970-01-01, a real birthday.
+      const storedTimestamp = target.dateOfBirth ?? null;
+      const storedIso =
+        storedTimestamp === null ? null : utcTimestampToIsoDate(storedTimestamp);
+
+      if (args.dateOfBirth === null) {
+        if (storedIso !== null) {
+          changes.push({
+            field: "dateOfBirth",
+            previousValue: storedIso,
+            newValue: null,
+          });
+          updates.dateOfBirth = undefined;
+        }
+      } else if (args.dateOfBirth !== storedIso) {
+        const timestamp = isoDateToUtcTimestamp(args.dateOfBirth);
+        changes.push({
+          field: "dateOfBirth",
+          previousValue: storedIso,
+          newValue: args.dateOfBirth,
+        });
+        updates.dateOfBirth = timestamp;
+      }
+    }
+
+    // --- Apply ---------------------------------------------------------------
+    // A no-op edit writes nothing at all, including no audit row: a save that
+    // changed nothing is not an event worth recording, and a reason alone is
+    // not an edit.
+    if (changes.length === 0) {
+      return { success: true, changed: false, changedFields: [] as string[] };
+    }
+
+    const nameChanged = changes.some(
+      (c) => c.field === "firstName" || c.field === "lastName",
+    );
+    const contactChanged = changes.some(
+      (c) => c.field === "email" || c.field === "phone",
+    );
+
+    // Keep the member findable by their corrected details.
+    if (nameChanged || contactChanged) {
+      updates.searchText = buildSearchText({
+        firstName: (updates.firstName as string | undefined) ?? target.firstName,
+        lastName:
+          "lastName" in updates
+            ? (updates.lastName as string | undefined)
+            : target.lastName,
+        email:
+          "email" in updates
+            ? (updates.email as string | undefined)
+            : target.email,
+        phone: (updates.phone as string | undefined) ?? target.phone,
+      });
+    }
+
+    await ctx.db.patch(args.targetUserId, {
+      ...updates,
+      updatedAt: now(),
+    });
+
+    const timestamp = now();
+    await ctx.db.insert("memberProfileAudits", {
+      communityId: args.communityId,
+      targetUserId: args.targetUserId,
+      actorUserId,
+      changes,
+      reason: args.reason?.trim() || undefined,
+      createdAt: timestamp,
+    });
+
+    // Refresh the denormalized display name held in `chatChannelMembers`.
+    if (nameChanged) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.functions.sync.memberships.syncUserProfileToChannels,
+        { userId: args.targetUserId },
+      );
+    }
+
+    return {
+      success: true,
+      changed: true,
+      changedFields: changes.map((c) => c.field),
+    };
+  },
+});
+
+/**
+ * The edit history for one member, newest first.
+ *
+ * Uses the framework's cursor pagination rather than a capped window: a capped
+ * window makes rows past the cap permanently unreachable while `hasMore` stays
+ * true, which is not much of an append-only audit trail.
+ */
+export const listMemberProfileAudits = query({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+    targetUserId: v.id("users"),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireCommunityAdmin(ctx, args.communityId, userId);
+
+    const result = await ctx.db
+      .query("memberProfileAudits")
+      .withIndex("by_community_target", (q) =>
+        q
+          .eq("communityId", args.communityId)
+          .eq("targetUserId", args.targetUserId),
+      )
+      .order("desc")
+      .paginate(args.paginationOpts);
+
+    const page = await Promise.all(
+      result.page.map(async (entry) => {
+        const actor = await ctx.db.get(entry.actorUserId);
+        return {
+          id: entry._id,
+          changes: entry.changes,
+          reason: entry.reason ?? null,
+          createdAt: entry.createdAt,
+          actor: actor
+            ? {
+                id: actor._id,
+                firstName: actor.firstName || "",
+                lastName: actor.lastName || "",
+              }
+            : null,
+        };
+      }),
+    );
+
+    return { ...result, page };
   },
 });
 

--- a/apps/convex/functions/admin/members.ts
+++ b/apps/convex/functions/admin/members.ts
@@ -1017,7 +1017,7 @@ export const updateMemberProfile = mutation({
     // (seven-digit phones, addresses with no public TLD), and validating a
     // value that has not actually changed would take an unrelated name edit
     // down with it. Comparison is on canonical forms, so `(202) 555-0123` and
-    // `+12025550123` — or `Rafael@Test.com` and `rafael@test.com` — are the
+    // `+12025550123` — or `Member@Example.com` and `member@example.com` — are the
     // same value and produce no change, no audit row and no blocker.
 
     let phoneChanged = false;

--- a/apps/convex/functions/auth/registration.ts
+++ b/apps/convex/functions/auth/registration.ts
@@ -146,6 +146,17 @@ export const registerNewUser = action({
         `[registerNewUser] User already exists with phone ${normalizedPhone}, returning existing user`
       );
 
+      // Persist the verification we just proved. This branch already checked a
+      // phone verification token above and is about to issue real tokens, so
+      // ownership is established — but until this call the response reported
+      // `phoneVerified: true` while the database still said otherwise, and
+      // everything downstream that trusts `users.phoneVerified` (including the
+      // ADR-034 contact-edit guard) got the wrong answer.
+      await ctx.runMutation(
+        internal.functions.authInternal.markPhoneVerifiedInternal,
+        { userId: existingUser._id }
+      );
+
       const tokens = await generateTokens(existingUser._id);
 
       return {
@@ -158,7 +169,7 @@ export const registerNewUser = action({
           lastName: existingUser.lastName || args.lastName,
           email: existingUser.email || args.email || "",
           phone: normalizedPhone,
-          phoneVerified: existingUser.phoneVerified ?? true,
+          phoneVerified: true,
         },
       };
     }
@@ -196,6 +207,16 @@ export const registerNewUser = action({
           console.log(
             `[registerNewUser] Race condition detected - user created by another request`
           );
+
+          // Same reasoning as the existing-user branch above: this path issues
+          // real tokens off the verified phone, so the verification has to be
+          // persisted here too. Fixing only one of the two branches would
+          // leave the same hole open on the losing side of a create race.
+          await ctx.runMutation(
+            internal.functions.authInternal.markPhoneVerifiedInternal,
+            { userId: raceWinnerUser._id }
+          );
+
           const tokens = await generateTokens(raceWinnerUser._id);
 
           return {
@@ -208,7 +229,7 @@ export const registerNewUser = action({
               lastName: raceWinnerUser.lastName || args.lastName,
               email: raceWinnerUser.email || args.email || "",
               phone: normalizedPhone,
-              phoneVerified: raceWinnerUser.phoneVerified ?? true,
+              phoneVerified: true,
             },
           };
         }

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -4315,4 +4315,51 @@ export default defineSchema({
   })
     .index("by_community", ["communityId", "createdAt"])
     .index("by_fund", ["fundId", "createdAt"]),
+
+  // =============================================================================
+  // MEMBER PROFILE AUDITS (ADR-034)
+  // =============================================================================
+
+  /**
+   * Append-only trail of admin edits to a member's profile (ADR-034).
+   *
+   * One row per *edit*, not per field: an admin who fixes a misspelled name and
+   * a transposed phone digit in one save produces a single event, so the UI can
+   * render "Reg Admin changed First name and Phone" rather than two unrelated
+   * entries. `changes` therefore holds every field that actually changed.
+   *
+   * Rows are never patched or deleted, with one exception:
+   * `mergeDuplicateAccounts` repoints `targetUserId` at the surviving primary
+   * account so a merged member's history follows the person instead of being
+   * stranded on the deactivated row.
+   *
+   * Written only by `admin.members.updateMemberProfile`; read only by
+   * `admin.members.listMemberProfileAudits`, which requires community admin.
+   */
+  memberProfileAudits: defineTable({
+    // The community whose admin made the edit. Audit rows are scoped to it
+    // because visibility follows community-admin authority, even though the
+    // edited `users` fields themselves are global.
+    communityId: v.id("communities"),
+    targetUserId: v.id("users"),
+    actorUserId: v.id("users"),
+    // Every field that actually changed in this edit. Values are stored as
+    // strings (null = "was empty" / "cleared") so the shape stays uniform
+    // across the text fields and the numeric dateOfBirth, which is rendered
+    // as an ISO date rather than a raw timestamp.
+    changes: v.array(
+      v.object({
+        field: v.string(),
+        previousValue: v.union(v.string(), v.null()),
+        newValue: v.union(v.string(), v.null()),
+      }),
+    ),
+    // Optional free-text note from the acting admin (max 500 chars).
+    reason: v.optional(v.string()),
+    createdAt: v.number(), // Unix timestamp ms
+  })
+    // History for one member within one community, newest first.
+    .index("by_community_target", ["communityId", "targetUserId", "createdAt"])
+    // Used by the duplicate-account merge to re-key a secondary's rows.
+    .index("by_target", ["targetUserId"]),
 });

--- a/apps/mobile/components/ui/Input.tsx
+++ b/apps/mobile/components/ui/Input.tsx
@@ -1,9 +1,14 @@
 import React, { useState } from 'react';
 import { View, TextInput, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native';
+import type { TextInputProps } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@hooks/useTheme';
 
-interface InputProps {
+interface InputProps
+  extends Pick<
+    TextInputProps,
+    "editable" | "keyboardType" | "autoCapitalize" | "autoCorrect" | "maxLength"
+  > {
   label?: string;
   placeholder?: string;
   value: string;
@@ -29,6 +34,11 @@ export function Input({
   numberOfLines = 1,
   style,
   inputStyle,
+  editable,
+  keyboardType,
+  autoCapitalize,
+  autoCorrect,
+  maxLength,
 }: InputProps) {
   const { colors } = useTheme();
   const [showPassword, setShowPassword] = useState(false);
@@ -64,6 +74,11 @@ export function Input({
           secureTextEntry={secureTextEntry && !showPassword}
           multiline={multiline}
           numberOfLines={numberOfLines}
+          editable={editable}
+          keyboardType={keyboardType}
+          autoCapitalize={autoCapitalize}
+          autoCorrect={autoCorrect}
+          maxLength={maxLength}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
         />

--- a/apps/mobile/features/admin/__tests__/EditMemberProfileModal.test.tsx
+++ b/apps/mobile/features/admin/__tests__/EditMemberProfileModal.test.tsx
@@ -14,9 +14,9 @@ import {
  */
 
 const MEMBER: EditableMemberProfile = {
-  firstName: "Rafel",
-  lastName: "Ortiz",
-  email: "rafael@test.com",
+  firstName: "Jorden",
+  lastName: "Reyes",
+  email: "jordan@test.com",
   phone: "+12025550123",
   dateOfBirth: Date.UTC(1990, 3, 12),
 };
@@ -41,9 +41,9 @@ describe("EditMemberProfileModal", () => {
   it("pre-fills every field from the member record", () => {
     render(<EditMemberProfileModal {...props()} />);
 
-    expect(screen.getByDisplayValue("Rafel")).toBeTruthy();
-    expect(screen.getByDisplayValue("Ortiz")).toBeTruthy();
-    expect(screen.getByDisplayValue("rafael@test.com")).toBeTruthy();
+    expect(screen.getByDisplayValue("Jorden")).toBeTruthy();
+    expect(screen.getByDisplayValue("Reyes")).toBeTruthy();
+    expect(screen.getByDisplayValue("jordan@test.com")).toBeTruthy();
     expect(screen.getByDisplayValue("+12025550123")).toBeTruthy();
   });
 
@@ -51,14 +51,14 @@ describe("EditMemberProfileModal", () => {
     const onSave = jest.fn().mockResolvedValue(undefined);
     render(<EditMemberProfileModal {...props({ onSave })} />);
 
-    fireEvent.changeText(screen.getByDisplayValue("Rafel"), "Rafael");
+    fireEvent.changeText(screen.getByDisplayValue("Jorden"), "Jordan");
     fireEvent.press(screen.getByText("Save Changes"));
 
     await waitFor(() => expect(onSave).toHaveBeenCalled());
     // Crucially: no `lastName`, `email`, `phone` or `dateOfBirth` keys at all.
     // Sending them would let this stale form revert a concurrent edit by
     // another admin, and the audit trail would record that as deliberate.
-    expect(onSave).toHaveBeenCalledWith({ firstName: "Rafael" });
+    expect(onSave).toHaveBeenCalledWith({ firstName: "Jordan" });
   });
 
   it("cannot be saved when nothing was touched", () => {
@@ -87,7 +87,7 @@ describe("EditMemberProfileModal", () => {
       <EditMemberProfileModal {...props({ onSave })} />,
     );
 
-    fireEvent.changeText(screen.getByDisplayValue("Rafel"), "Rafael");
+    fireEvent.changeText(screen.getByDisplayValue("Jorden"), "Jordan");
 
     // A rerender with an equal-but-not-identical member object is guaranteed
     // the moment saving starts. If the reset effect depended on `member`
@@ -100,19 +100,19 @@ describe("EditMemberProfileModal", () => {
       />,
     );
 
-    expect(screen.getByDisplayValue("Rafael")).toBeTruthy();
-    expect(screen.queryByDisplayValue("Rafel")).toBeNull();
+    expect(screen.getByDisplayValue("Jordan")).toBeTruthy();
+    expect(screen.queryByDisplayValue("Jorden")).toBeNull();
   });
 
   it("re-prefills when reopened after being closed", () => {
     const { rerender } = render(<EditMemberProfileModal {...props()} />);
 
-    fireEvent.changeText(screen.getByDisplayValue("Rafel"), "Typo");
+    fireEvent.changeText(screen.getByDisplayValue("Jorden"), "Typo");
     rerender(<EditMemberProfileModal {...props({ visible: false })} />);
     rerender(<EditMemberProfileModal {...props()} />);
 
     // Reopening is a fresh edit, so the stored value comes back.
-    expect(screen.getByDisplayValue("Rafel")).toBeTruthy();
+    expect(screen.getByDisplayValue("Jorden")).toBeTruthy();
   });
 
   describe("locked contact fields", () => {
@@ -127,7 +127,7 @@ describe("EditMemberProfileModal", () => {
 
     it("makes the contact inputs read-only", () => {
       render(<EditMemberProfileModal {...props(locked)} />);
-      expect(screen.getByDisplayValue("rafael@test.com").props.editable).toBe(
+      expect(screen.getByDisplayValue("jordan@test.com").props.editable).toBe(
         false,
       );
       expect(screen.getByDisplayValue("+12025550123").props.editable).toBe(
@@ -139,13 +139,13 @@ describe("EditMemberProfileModal", () => {
       const onSave = jest.fn().mockResolvedValue(undefined);
       render(<EditMemberProfileModal {...props({ ...locked, onSave })} />);
 
-      fireEvent.changeText(screen.getByDisplayValue("Rafel"), "Rafael");
+      fireEvent.changeText(screen.getByDisplayValue("Jorden"), "Jordan");
       fireEvent.press(screen.getByText("Save Changes"));
 
       await waitFor(() => expect(onSave).toHaveBeenCalled());
       // A legacy-format or today-invalid stored value is never resubmitted, so
       // it cannot trip a guard meant for real contact edits.
-      expect(onSave).toHaveBeenCalledWith({ firstName: "Rafael" });
+      expect(onSave).toHaveBeenCalledWith({ firstName: "Jordan" });
     });
   });
 
@@ -159,10 +159,10 @@ describe("EditMemberProfileModal", () => {
         />,
       );
 
-      fireEvent.changeText(screen.getByDisplayValue("Rafel"), "Rafael");
+      fireEvent.changeText(screen.getByDisplayValue("Jorden"), "Jordan");
       fireEvent.press(screen.getByText("Save Changes"));
 
-      await waitFor(() => expect(onSave).toHaveBeenCalledWith({ firstName: "Rafael" }));
+      await waitFor(() => expect(onSave).toHaveBeenCalledWith({ firstName: "Jordan" }));
     });
 
     it("refuses to submit removal of an existing phone", () => {

--- a/apps/mobile/features/admin/__tests__/EditMemberProfileModal.test.tsx
+++ b/apps/mobile/features/admin/__tests__/EditMemberProfileModal.test.tsx
@@ -1,0 +1,227 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react-native";
+import {
+  EditMemberProfileModal,
+  type EditableMemberProfile,
+} from "@features/admin/components/EditMemberProfileModal";
+
+/**
+ * Tests for the ADR-034 admin profile edit form.
+ *
+ * The three behaviours worth guarding are the ones that silently lose data
+ * when they regress: dirty-field-only submission, surviving a parent rerender,
+ * and the date-of-birth conversion.
+ */
+
+const MEMBER: EditableMemberProfile = {
+  firstName: "Rafel",
+  lastName: "Ortiz",
+  email: "rafael@test.com",
+  phone: "+12025550123",
+  dateOfBirth: Date.UTC(1990, 3, 12),
+};
+
+function props(overrides: Partial<React.ComponentProps<typeof EditMemberProfileModal>> = {}) {
+  return {
+    visible: true,
+    member: MEMBER,
+    lockedReason: null,
+    onClose: jest.fn(),
+    onSave: jest.fn().mockResolvedValue(undefined),
+    isSaving: false,
+    ...overrides,
+  };
+}
+
+describe("EditMemberProfileModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("pre-fills every field from the member record", () => {
+    render(<EditMemberProfileModal {...props()} />);
+
+    expect(screen.getByDisplayValue("Rafel")).toBeTruthy();
+    expect(screen.getByDisplayValue("Ortiz")).toBeTruthy();
+    expect(screen.getByDisplayValue("rafael@test.com")).toBeTruthy();
+    expect(screen.getByDisplayValue("+12025550123")).toBeTruthy();
+  });
+
+  it("submits ONLY the field that changed", async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    render(<EditMemberProfileModal {...props({ onSave })} />);
+
+    fireEvent.changeText(screen.getByDisplayValue("Rafel"), "Rafael");
+    fireEvent.press(screen.getByText("Save Changes"));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    // Crucially: no `lastName`, `email`, `phone` or `dateOfBirth` keys at all.
+    // Sending them would let this stale form revert a concurrent edit by
+    // another admin, and the audit trail would record that as deliberate.
+    expect(onSave).toHaveBeenCalledWith({ firstName: "Rafael" });
+  });
+
+  it("cannot be saved when nothing was touched", () => {
+    const onSave = jest.fn();
+    render(<EditMemberProfileModal {...props({ onSave })} />);
+
+    fireEvent.press(screen.getByText("Save Changes"));
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("does not treat a reason alone as an edit", () => {
+    const onSave = jest.fn();
+    render(<EditMemberProfileModal {...props({ onSave })} />);
+
+    fireEvent.changeText(
+      screen.getByPlaceholderText("e.g. Corrected from Gold Card"),
+      "just a note",
+    );
+    fireEvent.press(screen.getByText("Save Changes"));
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("keeps typed edits when the parent rerenders with a fresh member object", async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    const { rerender } = render(
+      <EditMemberProfileModal {...props({ onSave })} />,
+    );
+
+    fireEvent.changeText(screen.getByDisplayValue("Rafel"), "Rafael");
+
+    // A rerender with an equal-but-not-identical member object is guaranteed
+    // the moment saving starts. If the reset effect depended on `member`
+    // identity, everything the admin typed would be silently replaced here.
+    rerender(
+      <EditMemberProfileModal
+        {...props({ onSave })}
+        member={{ ...MEMBER }}
+        isSaving
+      />,
+    );
+
+    expect(screen.getByDisplayValue("Rafael")).toBeTruthy();
+    expect(screen.queryByDisplayValue("Rafel")).toBeNull();
+  });
+
+  it("re-prefills when reopened after being closed", () => {
+    const { rerender } = render(<EditMemberProfileModal {...props()} />);
+
+    fireEvent.changeText(screen.getByDisplayValue("Rafel"), "Typo");
+    rerender(<EditMemberProfileModal {...props({ visible: false })} />);
+    rerender(<EditMemberProfileModal {...props()} />);
+
+    // Reopening is a fresh edit, so the stored value comes back.
+    expect(screen.getByDisplayValue("Rafel")).toBeTruthy();
+  });
+
+  describe("locked contact fields", () => {
+    const locked = { lockedReason: "this member has verified their phone number" };
+
+    it("explains why phone and email are locked", () => {
+      render(<EditMemberProfileModal {...props(locked)} />);
+      expect(
+        screen.getByText(/this member has verified their phone number/),
+      ).toBeTruthy();
+    });
+
+    it("makes the contact inputs read-only", () => {
+      render(<EditMemberProfileModal {...props(locked)} />);
+      expect(screen.getByDisplayValue("rafael@test.com").props.editable).toBe(
+        false,
+      );
+      expect(screen.getByDisplayValue("+12025550123").props.editable).toBe(
+        false,
+      );
+    });
+
+    it("never submits locked contact fields, so a name edit still goes through", async () => {
+      const onSave = jest.fn().mockResolvedValue(undefined);
+      render(<EditMemberProfileModal {...props({ ...locked, onSave })} />);
+
+      fireEvent.changeText(screen.getByDisplayValue("Rafel"), "Rafael");
+      fireEvent.press(screen.getByText("Save Changes"));
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled());
+      // A legacy-format or today-invalid stored value is never resubmitted, so
+      // it cannot trip a guard meant for real contact edits.
+      expect(onSave).toHaveBeenCalledWith({ firstName: "Rafael" });
+    });
+  });
+
+  describe("phone", () => {
+    it("does not require a phone for a member who has none on record", async () => {
+      const onSave = jest.fn().mockResolvedValue(undefined);
+      render(
+        <EditMemberProfileModal
+          {...props({ onSave })}
+          member={{ ...MEMBER, phone: null }}
+        />,
+      );
+
+      fireEvent.changeText(screen.getByDisplayValue("Rafel"), "Rafael");
+      fireEvent.press(screen.getByText("Save Changes"));
+
+      await waitFor(() => expect(onSave).toHaveBeenCalledWith({ firstName: "Rafael" }));
+    });
+
+    it("refuses to submit removal of an existing phone", () => {
+      const onSave = jest.fn();
+      render(<EditMemberProfileModal {...props({ onSave })} />);
+
+      fireEvent.changeText(screen.getByDisplayValue("+12025550123"), "");
+      fireEvent.press(screen.getByText("Save Changes"));
+
+      expect(onSave).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("date of birth", () => {
+    it("clears the date of birth when the clear action is used", async () => {
+      const onSave = jest.fn().mockResolvedValue(undefined);
+      render(<EditMemberProfileModal {...props({ onSave })} />);
+
+      // The shared DatePicker only emits selected Dates on native — without
+      // this affordance, clearing would be reachable on web only.
+      fireEvent.press(screen.getByText("Clear date of birth"));
+      fireEvent.press(screen.getByText("Save Changes"));
+
+      await waitFor(() => expect(onSave).toHaveBeenCalledWith({ dateOfBirth: null }));
+    });
+
+    it("hides the clear action when there is no date to clear", () => {
+      render(
+        <EditMemberProfileModal
+          {...props()}
+          member={{ ...MEMBER, dateOfBirth: null }}
+        />,
+      );
+      expect(screen.queryByText("Clear date of birth")).toBeNull();
+    });
+
+    it("does not report an unchanged birthday as an edit", () => {
+      const onSave = jest.fn();
+      render(<EditMemberProfileModal {...props({ onSave })} />);
+
+      // The stored value is UTC midnight; the picker holds local midnight of
+      // the same calendar day. Reading either with the other's getters would
+      // shift the day and make an untouched birthday look edited — which,
+      // since the form submits dirty fields only, would then write a spurious
+      // audit row on every unrelated save.
+      fireEvent.press(screen.getByText("Save Changes"));
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it("treats the Unix epoch as a real date, not an empty one", () => {
+      render(
+        <EditMemberProfileModal
+          {...props()}
+          member={{ ...MEMBER, dateOfBirth: 0 }}
+        />,
+      );
+      // Timestamp 0 is 1970-01-01. A truthiness check anywhere in the chain
+      // would hide the clear action, proving the date had been read as empty.
+      expect(screen.getByText("Clear date of birth")).toBeTruthy();
+    });
+  });
+});

--- a/apps/mobile/features/admin/components/EditMemberProfileModal.tsx
+++ b/apps/mobile/features/admin/components/EditMemberProfileModal.tsx
@@ -226,7 +226,11 @@ export function EditMemberProfileModal({
         >
           <Pressable
             style={[styles.container, { backgroundColor: colors.surface }]}
-            onPress={(e) => e.stopPropagation()}
+            // Swallow taps on the sheet so they don't reach the overlay and
+            // close the modal. Optional-called because a press can reach this
+            // handler with no event object when the press target above it is
+            // disabled — which is exactly the state a half-filled form is in.
+            onPress={(e) => e?.stopPropagation?.()}
           >
             <View style={[styles.header, { borderBottomColor: colors.border }]}>
               <Text style={[styles.title, { color: colors.text }]}>

--- a/apps/mobile/features/admin/components/EditMemberProfileModal.tsx
+++ b/apps/mobile/features/admin/components/EditMemberProfileModal.tsx
@@ -1,0 +1,437 @@
+/**
+ * EditMemberProfileModal — admin correction of a member's profile (ADR-034).
+ *
+ * Exists for data entered on someone's behalf, typically typed off a paper
+ * Gold Card after a service. Phone and email are sign-in credentials rather
+ * than ordinary data, so the backend locks them on any account a person has
+ * actually claimed or that carries authority; when it does, `lockedReason`
+ * explains why and those two fields render read-only.
+ *
+ * The modal is presentational: the parent owns the mutation, `isSaving`, and
+ * error reporting, matching GroupTypeEditModal.
+ */
+import React, { useState, useEffect, useRef, useMemo } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Modal,
+  TouchableOpacity,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { Input, DatePicker } from "@components/ui";
+import { useTheme } from "@hooks/useTheme";
+import { useCommunityTheme } from "@hooks/useCommunityTheme";
+
+/**
+ * Values the admin may correct. `dateOfBirth` is the stored timestamp
+ * (UTC midnight of the calendar day) or null.
+ */
+export interface EditableMemberProfile {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string | null;
+  dateOfBirth: number | null;
+}
+
+/**
+ * Only the fields the admin actually changed. Everything else is omitted so a
+ * stale form can never revert another admin's concurrent correction — and so
+ * the audit trail never records an untouched field as a deliberate edit.
+ * `null` is an explicit clear.
+ */
+export interface MemberProfileEdits {
+  firstName?: string;
+  lastName?: string;
+  email?: string | null;
+  phone?: string | null;
+  dateOfBirth?: string | null;
+  reason?: string;
+}
+
+interface EditMemberProfileModalProps {
+  visible: boolean;
+  member: EditableMemberProfile | null;
+  /** Non-null when the backend will refuse phone/email changes. */
+  lockedReason: string | null;
+  onClose: () => void;
+  onSave: (edits: MemberProfileEdits) => Promise<void>;
+  isSaving: boolean;
+}
+
+/**
+ * Stored dateOfBirth (UTC midnight) → the Date the picker should display.
+ *
+ * The two converters here read different clocks ON PURPOSE, and the asymmetry
+ * is the whole point: the STORED value is UTC midnight of the calendar day
+ * (`new Date("YYYY-MM-DD")`, the convention `auth/helpers.parseAndValidateDate`
+ * established), whereas the shared DatePicker deals in LOCAL wall-clock Dates
+ * on every platform — its web branch builds `new Date(y, m - 1, d)` from local
+ * parts precisely so the two platforms agree. Reading either one with the
+ * other's getters shifts the birthday by a day, in one direction or the other
+ * depending on the sign of the UTC offset.
+ *
+ * Note there is deliberately no `Platform.OS` branch: the picker's web and
+ * native values mean the same thing, and branching would reintroduce the
+ * off-by-one this avoids.
+ */
+function timestampToPickerDate(timestamp: number | null): Date | null {
+  if (timestamp === null) return null;
+  const stored = new Date(timestamp);
+  return new Date(
+    stored.getUTCFullYear(),
+    stored.getUTCMonth(),
+    stored.getUTCDate(),
+  );
+}
+
+/** Picker Date (local wall-clock) → the YYYY-MM-DD the API expects. */
+function pickerDateToISODate(date: Date | null): string | null {
+  if (!date) return null;
+  const year = String(date.getFullYear()).padStart(4, "0");
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/** Stored timestamp → YYYY-MM-DD, for comparing against the picked value. */
+function timestampToISODate(timestamp: number | null): string | null {
+  if (timestamp === null) return null;
+  const stored = new Date(timestamp);
+  const year = String(stored.getUTCFullYear()).padStart(4, "0");
+  const month = String(stored.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(stored.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function EditMemberProfileModal({
+  visible,
+  member,
+  lockedReason,
+  onClose,
+  onSave,
+  isSaving,
+}: EditMemberProfileModalProps) {
+  const { colors } = useTheme();
+  const { primaryColor } = useCommunityTheme();
+
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [dateOfBirth, setDateOfBirth] = useState<Date | null>(null);
+  const [reason, setReason] = useState("");
+
+  // What the form opened with. Comparing against this is what makes the
+  // submission dirty-field-only.
+  const initialRef = useRef<EditableMemberProfile | null>(null);
+
+  // Reset ONLY on the transition to open — never on `member` identity.
+  //
+  // The parent rebuilds its `member` object on every render, and a render is
+  // guaranteed the moment saving starts. Depending on `member` here would
+  // overwrite every field the admin typed the instant they hit Save, so a
+  // backend rejection would leave the modal open with all their corrections
+  // silently replaced by the old values and no indication why.
+  const wasVisible = useRef(false);
+  useEffect(() => {
+    if (visible && !wasVisible.current) {
+      setFirstName(member?.firstName ?? "");
+      setLastName(member?.lastName ?? "");
+      setEmail(member?.email ?? "");
+      setPhone(member?.phone ?? "");
+      setDateOfBirth(timestampToPickerDate(member?.dateOfBirth ?? null));
+      setReason("");
+      initialRef.current = member;
+    }
+    wasVisible.current = visible;
+  }, [visible, member]);
+
+  const isLocked = lockedReason !== null;
+  // An empty phone means "none on file", not "remove it" — migrated records
+  // often have none, and requiring one to fix a name would be wrong. But an
+  // existing number cannot be cleared, since it is how the member signs in.
+  const hasStoredPhone = !!initialRef.current?.phone;
+
+  const edits = useMemo<MemberProfileEdits>(() => {
+    const initial = initialRef.current;
+    if (!initial) return {};
+
+    const result: MemberProfileEdits = {};
+
+    if (firstName.trim() !== (initial.firstName ?? "").trim()) {
+      result.firstName = firstName.trim();
+    }
+    if (lastName.trim() !== (initial.lastName ?? "").trim()) {
+      result.lastName = lastName.trim();
+    }
+
+    // Locked contact fields are never submitted at all, so a legacy-format or
+    // today-invalid stored value cannot trip a guard meant for real edits.
+    if (!isLocked) {
+      if (email.trim() !== (initial.email ?? "").trim()) {
+        result.email = email.trim() || null;
+      }
+      if (phone.trim() !== (initial.phone ?? "").trim()) {
+        result.phone = phone.trim() || null;
+      }
+    }
+
+    const pickedISO = pickerDateToISODate(dateOfBirth);
+    const initialISO = timestampToISODate(initial.dateOfBirth ?? null);
+    if (pickedISO !== initialISO) {
+      result.dateOfBirth = pickedISO;
+    }
+
+    if (reason.trim()) {
+      result.reason = reason.trim();
+    }
+
+    return result;
+  }, [firstName, lastName, email, phone, dateOfBirth, reason, isLocked]);
+
+  const changedFieldCount = Object.keys(edits).filter(
+    (k) => k !== "reason",
+  ).length;
+
+  const isValid =
+    firstName.trim().length > 0 &&
+    changedFieldCount > 0 &&
+    reason.length <= 500 &&
+    // Refuse to submit a removal the backend would reject anyway.
+    !(hasStoredPhone && !isLocked && phone.trim().length === 0);
+
+  const handleSave = async () => {
+    if (!isValid || isSaving) return;
+    await onSave(edits);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.overlay} onPress={onClose}>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+          style={styles.keyboardView}
+        >
+          <Pressable
+            style={[styles.container, { backgroundColor: colors.surface }]}
+            onPress={(e) => e.stopPropagation()}
+          >
+            <View style={[styles.header, { borderBottomColor: colors.border }]}>
+              <Text style={[styles.title, { color: colors.text }]}>
+                Edit Profile
+              </Text>
+              <TouchableOpacity
+                onPress={onClose}
+                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                accessibilityLabel="Close"
+              >
+                <Ionicons name="close" size={24} color={colors.textSecondary} />
+              </TouchableOpacity>
+            </View>
+
+            <ScrollView
+              style={styles.scroll}
+              keyboardShouldPersistTaps="handled"
+            >
+              <View style={styles.form}>
+                <Input
+                  label="First name"
+                  required
+                  value={firstName}
+                  onChangeText={setFirstName}
+                  placeholder="First name"
+                />
+
+                <Input
+                  label="Last name"
+                  value={lastName}
+                  onChangeText={setLastName}
+                  placeholder="Last name"
+                />
+
+                {isLocked && (
+                  <View style={styles.lockedBanner}>
+                    <Ionicons
+                      name="lock-closed-outline"
+                      size={18}
+                      color="#E65100"
+                    />
+                    <Text style={styles.lockedText}>
+                      Phone and email can&apos;t be changed here because{" "}
+                      {lockedReason}. They&apos;re sign-in details, so only the
+                      member can change them.
+                    </Text>
+                  </View>
+                )}
+
+                <Input
+                  label="Phone"
+                  required={hasStoredPhone && !isLocked}
+                  value={phone}
+                  onChangeText={setPhone}
+                  placeholder={
+                    hasStoredPhone ? "Phone number" : "No phone on file"
+                  }
+                  editable={!isLocked}
+                  keyboardType="phone-pad"
+                />
+
+                <Input
+                  label="Email"
+                  value={email}
+                  onChangeText={setEmail}
+                  placeholder="Email address"
+                  editable={!isLocked}
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                />
+
+                <DatePicker
+                  label="Date of birth"
+                  value={dateOfBirth}
+                  onChange={setDateOfBirth}
+                  maximumDate={new Date()}
+                  placeholder="Select a date"
+                />
+                {/*
+                  The shared DatePicker only emits selected Dates on iOS and
+                  Android — its clear affordance is the web <input>'s empty
+                  value, which native has no equivalent for. Without this,
+                  clearing a date of birth would work on web only.
+                */}
+                {dateOfBirth !== null && (
+                  <TouchableOpacity
+                    onPress={() => setDateOfBirth(null)}
+                    style={styles.clearDateButton}
+                  >
+                    <Text style={[styles.clearDateText, { color: primaryColor }]}>
+                      Clear date of birth
+                    </Text>
+                  </TouchableOpacity>
+                )}
+
+                <Input
+                  label="Reason (optional)"
+                  value={reason}
+                  onChangeText={setReason}
+                  placeholder="e.g. Corrected from Gold Card"
+                  multiline
+                  numberOfLines={2}
+                  error={
+                    reason.length > 500
+                      ? "Reason must be 500 characters or fewer"
+                      : undefined
+                  }
+                />
+              </View>
+            </ScrollView>
+
+            <View style={styles.footer}>
+              <TouchableOpacity
+                style={[
+                  styles.saveButton,
+                  { backgroundColor: primaryColor },
+                  (!isValid || isSaving) && styles.saveButtonDisabled,
+                ]}
+                onPress={handleSave}
+                disabled={!isValid || isSaving}
+              >
+                {isSaving ? (
+                  <ActivityIndicator size="small" color="#fff" />
+                ) : (
+                  <Text style={styles.saveButtonText}>Save Changes</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          </Pressable>
+        </KeyboardAvoidingView>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "flex-end",
+  },
+  keyboardView: {
+    justifyContent: "flex-end",
+  },
+  container: {
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingBottom: Platform.OS === "ios" ? 34 : 20,
+    maxHeight: "90%",
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    padding: 16,
+    borderBottomWidth: 1,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  scroll: {
+    flexGrow: 0,
+  },
+  form: {
+    padding: 16,
+  },
+  lockedBanner: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 8,
+    backgroundColor: "#FFF3E0",
+    padding: 12,
+    marginBottom: 16,
+    borderRadius: 8,
+  },
+  lockedText: {
+    flex: 1,
+    fontSize: 13,
+    color: "#E65100",
+    lineHeight: 18,
+  },
+  clearDateButton: {
+    paddingVertical: 8,
+    marginBottom: 16,
+  },
+  clearDateText: {
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  footer: {
+    paddingHorizontal: 16,
+    paddingTop: 8,
+  },
+  saveButton: {
+    borderRadius: 8,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  saveButtonDisabled: {
+    opacity: 0.6,
+  },
+  saveButtonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/features/admin/components/PersonDetailScreen.tsx
+++ b/apps/mobile/features/admin/components/PersonDetailScreen.tsx
@@ -26,13 +26,31 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { formatDistanceToNow, format } from "date-fns";
-import { useQuery, useAuthenticatedMutation, api } from "@services/api/convex";
+import {
+  useQuery,
+  useAuthenticatedMutation,
+  useAuthenticatedPaginatedQuery,
+  api,
+} from "@services/api/convex";
 import type { Id } from "@services/api/convex";
 import { useAuth } from "@/providers/AuthProvider";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { useTheme } from "@hooks/useTheme";
 import { formatError } from "@/utils/error-handling";
 import { NotificationsDisabledBadge } from "@components/ui/NotificationsDisabledBadge";
+import {
+  EditMemberProfileModal,
+  type MemberProfileEdits,
+} from "./EditMemberProfileModal";
+
+/** Field keys from the audit trail, rendered as human-readable labels. */
+const AUDIT_FIELD_LABELS: Record<string, string> = {
+  firstName: "First name",
+  lastName: "Last name",
+  email: "Email",
+  phone: "Phone",
+  dateOfBirth: "Date of birth",
+};
 
 // Role constants (matching backend)
 const COMMUNITY_ROLES = {
@@ -61,6 +79,8 @@ export function PersonDetailScreen() {
     currentPresent: boolean;
   } | null>(null);
   const [isUpdatingAttendance, setIsUpdatingAttendance] = useState(false);
+  const [isEditingProfile, setIsEditingProfile] = useState(false);
+  const [isSavingProfile, setIsSavingProfile] = useState(false);
 
   // Fetch member details using Convex
   const rawMember = useQuery(
@@ -114,8 +134,26 @@ export function PersonDetailScreen() {
       }
     : null;
 
+  // Edit history for this member — cursor-paginated so the append-only trail
+  // stays fully reachable however long it gets.
+  const {
+    results: auditEntries,
+    status: auditStatus,
+    loadMore: loadMoreAudits,
+  } = useAuthenticatedPaginatedQuery(
+    api.functions.admin.members.listMemberProfileAudits,
+    community?.id && userId
+      ? {
+          communityId: community.id as Id<"communities">,
+          targetUserId: userId as Id<"users">,
+        }
+      : "skip",
+    { initialNumItems: 10 },
+  );
+
   // Mutations
   const updateRoleMutation = useAuthenticatedMutation(api.functions.admin.members.updateMemberRole);
+  const updateMemberProfileMutation = useAuthenticatedMutation(api.functions.admin.members.updateMemberProfile);
   const transferPrimaryAdminMutation = useAuthenticatedMutation(api.functions.admin.members.transferPrimaryAdmin);
   const removeMemberMutation = useAuthenticatedMutation(api.functions.communities.removeMember);
   const updateAttendanceMutation = useAuthenticatedMutation(api.functions.memberFollowups.updateAttendance);
@@ -143,6 +181,34 @@ export function PersonDetailScreen() {
       }
     },
     [editingAttendance, userId, community?.id, updateAttendanceMutation]
+  );
+
+  const handleSaveProfile = useCallback(
+    async (edits: MemberProfileEdits) => {
+      if (!userId || !community?.id) return;
+      setIsSavingProfile(true);
+      try {
+        // Spread rather than naming each field: naming them would turn an
+        // untouched field back into an explicit `undefined` and defeat the
+        // point of submitting only what changed.
+        await updateMemberProfileMutation({
+          communityId: community.id as Id<"communities">,
+          targetUserId: userId as Id<"users">,
+          ...edits,
+        });
+        setIsEditingProfile(false);
+        // The edited member may be the signed-in user.
+        if (currentUser?.id === userId) {
+          await refreshUser();
+        }
+      } catch (error: any) {
+        // Leave the modal open on failure so the admin's typing survives.
+        Alert.alert("Error", formatError(error, "Failed to update profile"));
+      } finally {
+        setIsSavingProfile(false);
+      }
+    },
+    [userId, community?.id, updateMemberProfileMutation, currentUser?.id, refreshUser],
   );
 
   const handleMakeAdmin = useCallback(async () => {
@@ -414,6 +480,22 @@ export function PersonDetailScreen() {
               )}
             </View>
           </View>
+
+          {/*
+            `canEditProfile` comes from the same helper the mutation enforces,
+            so the button appears on exactly the records a save would accept.
+          */}
+          {isCurrentUserAdmin && rawMember?.canEditProfile && (
+            <TouchableOpacity
+              style={[styles.editProfileButton, { borderColor: primaryColor }]}
+              onPress={() => setIsEditingProfile(true)}
+            >
+              <Ionicons name="create-outline" size={18} color={primaryColor} />
+              <Text style={[styles.editProfileButtonText, { color: primaryColor }]}>
+                Edit Profile
+              </Text>
+            </TouchableOpacity>
+          )}
         </View>
 
         {/* Account Activity Section */}
@@ -585,6 +667,60 @@ export function PersonDetailScreen() {
           )}
         </View>
 
+        {/* Edit History Section — the ADR-034 audit trail */}
+        {isCurrentUserAdmin && auditEntries.length > 0 && (
+          <View style={[styles.section, { backgroundColor: colors.surface }]}>
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>Edit History</Text>
+            {auditEntries.map((entry: any) => {
+              const actorName = entry.actor
+                ? `${entry.actor.firstName} ${entry.actor.lastName}`.trim() || "An admin"
+                : "A removed admin";
+              // One row per edit, not per field, so a correction touching name
+              // and phone reads as a single event.
+              const fieldNames = entry.changes
+                .map((c: any) => AUDIT_FIELD_LABELS[c.field] ?? c.field)
+                .join(", ");
+              return (
+                <View key={entry.id} style={styles.auditRow}>
+                  <Text style={[styles.auditSummary, { color: colors.text }]}>
+                    {actorName} changed {fieldNames}
+                  </Text>
+                  {entry.changes.map((change: any, index: number) => (
+                    <Text
+                      key={`${entry.id}-${change.field}-${index}`}
+                      style={[styles.auditChange, { color: colors.textSecondary }]}
+                    >
+                      {AUDIT_FIELD_LABELS[change.field] ?? change.field}:{" "}
+                      {change.previousValue ?? "—"} → {change.newValue ?? "—"}
+                    </Text>
+                  ))}
+                  {entry.reason && (
+                    <Text style={[styles.auditReason, { color: colors.textSecondary }]}>
+                      &ldquo;{entry.reason}&rdquo;
+                    </Text>
+                  )}
+                  <Text style={[styles.auditDate, { color: colors.textTertiary }]}>
+                    {format(new Date(entry.createdAt), "d MMM yyyy, h:mm a")}
+                  </Text>
+                </View>
+              );
+            })}
+            {auditStatus === "CanLoadMore" && (
+              <TouchableOpacity
+                onPress={() => loadMoreAudits(10)}
+                style={styles.loadMoreAudits}
+              >
+                <Text style={[styles.loadMoreAuditsText, { color: primaryColor }]}>
+                  Show earlier changes
+                </Text>
+              </TouchableOpacity>
+            )}
+            {auditStatus === "LoadingMore" && (
+              <ActivityIndicator size="small" color={primaryColor} style={{ marginTop: 8 }} />
+            )}
+          </View>
+        )}
+
         {/* Admin Role Management Section - Only visible to Primary Admin */}
         {canManageAdmins && !isSelf && !member.is_primary_admin && (
           <View style={[styles.section, { backgroundColor: colors.surface }]}>
@@ -727,11 +863,72 @@ export function PersonDetailScreen() {
           </Pressable>
         </Pressable>
       </Modal>
+
+      <EditMemberProfileModal
+        visible={isEditingProfile}
+        member={
+          rawMember
+            ? {
+                firstName: rawMember.firstName,
+                lastName: rawMember.lastName,
+                email: rawMember.email,
+                phone: rawMember.phone,
+                dateOfBirth: rawMember.dateOfBirth,
+              }
+            : null
+        }
+        lockedReason={rawMember?.contactEditBlockedReason ?? null}
+        onClose={() => setIsEditingProfile(false)}
+        onSave={handleSaveProfile}
+        isSaving={isSavingProfile}
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
+  editProfileButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    marginTop: 16,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  editProfileButtonText: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  auditRow: {
+    paddingVertical: 10,
+    gap: 2,
+  },
+  auditSummary: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  auditChange: {
+    fontSize: 13,
+  },
+  auditReason: {
+    fontSize: 13,
+    fontStyle: "italic",
+    marginTop: 2,
+  },
+  auditDate: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  loadMoreAudits: {
+    paddingVertical: 10,
+    alignItems: "center",
+  },
+  loadMoreAuditsText: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
   container: {
     flex: 1,
   },

--- a/apps/mobile/features/admin/components/StatsContent.tsx
+++ b/apps/mobile/features/admin/components/StatsContent.tsx
@@ -41,15 +41,15 @@ type MemberModalType = "active" | "new" | null;
  * attendance queries. The backend buckets these days in the community's
  * timezone, so we must send the day the user actually picked.
  *
- * On web the DatePicker stores the value as UTC-midnight of the picked day
- * (its `<input type="date">` round-trips through `toISOString().slice(0,10)`),
- * so the UTC date is the picked day. On native the Date is in local time, so
- * we read local calendar components instead.
+ * Read local calendar components on EVERY platform. The shared DatePicker
+ * builds its web value from local parts too (`new Date(y, mo - 1, d)` in
+ * `fromLocalInputValue`), so a picked day is local midnight everywhere — and
+ * `toISOString()` on local midnight lands on the PREVIOUS day at any positive
+ * UTC offset. This function used to branch on `Platform.OS === "web"` back
+ * when the picker really did round-trip through UTC; that stopped being true
+ * and the branch silently became an off-by-one for non-US timezones.
  */
 function toDayString(date: Date): string {
-  if (Platform.OS === "web") {
-    return date.toISOString().slice(0, 10);
-  }
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, "0");
   const d = String(date.getDate()).padStart(2, "0");

--- a/apps/mobile/run-tests.js
+++ b/apps/mobile/run-tests.js
@@ -1,6 +1,23 @@
 // Wrapper script that patches Object.defineProperty before running Jest
 // This fixes React 19 compatibility issues with jest-expo
 
+// Pin the test timezone to a NON-UTC zone unless the caller chose one.
+//
+// At UTC, local time and UTC are the same clock, so a date bug that reads a
+// value with the wrong getters is *mathematically undetectable* — no assertion
+// can distinguish `getUTCDate()` from `getDate()` when the offset is zero. Left
+// at UTC, CI is structurally blind to an entire class of off-by-one-day bugs;
+// two have already shipped that way (the `StatsContent` attendance-day filter,
+// and the date-of-birth converter in the admin profile editor).
+//
+// America/New_York is the product's home timezone and has a negative offset,
+// which is the direction that breaks UTC-midnight values. Must be set here,
+// before Jest forks its workers: Node reads TZ once at startup, so setting
+// `process.env.TZ` inside a test file is silently ignored.
+if (!process.env.TZ) {
+  process.env.TZ = 'America/New_York';
+}
+
 // CRITICAL: This must be the FIRST thing that runs
 // Capture the original before anything else
 const originalDefineProperty = Object.defineProperty;

--- a/docs/architecture/decisions/ADR-034-admin-member-profile-edits.md
+++ b/docs/architecture/decisions/ADR-034-admin-member-profile-edits.md
@@ -1,0 +1,267 @@
+# ADR-034: Admin Member Profile Edits with an Audit Trail
+
+## Status
+
+Accepted (2026-08). Implemented.
+
+## Context
+
+Community members are frequently entered into Togather by someone else — most
+often an admin typing up a paper connect card (the "Gold Card") after a service,
+or a leader pre-creating a placeholder row through the assign-from-community
+invite flow. Data captured that way contains mistakes: a transposed digit in a
+phone number, a misspelled first name, a wrong email domain.
+
+Until now there was no way to fix it. A member could edit their own profile
+(`users.update`), but an admin looking at a member's detail page could only
+change roles or remove the person from the community. The workaround was to
+delete and re-enter the person, which loses their group memberships and
+attendance history.
+
+The obvious fix — let admins edit member records — carries two risks worth
+naming:
+
+1. **Account takeover.** Phone and email are credentials, not just data. A
+   phone receives sign-in OTPs, and an email is enough on its own: the
+   unauthenticated account-claim flow (`auth/accountClaim.ts`) looks a user up
+   by whatever address is on the record, mails a code there, and
+   `verify_and_link` links an arbitrary phone and returns access and refresh
+   tokens. Either field, in the wrong hands, is a full takeover — and since
+   both live on the global `users` row while admin roles are per-community, the
+   takeover reaches into communities the acting admin has no authority over.
+2. **Silent data drift.** Once several admins can change each other's members'
+   data, "who changed Rafael's number, and why?" becomes unanswerable.
+
+### Alternatives Considered
+
+1. **Reuse `users.update` with an admin branch** — the self-service mutation
+   has no notion of a community or an acting admin, so every guard would be
+   bolted on.
+2. **A generic `auditLogs` table for all admin actions** — broader than the
+   problem in front of us, and it would need a discriminated payload before it
+   had a second caller. The codebase already prefers domain-scoped audit tables
+   over one universal log: `financeAuditEvents` (ADR-032 §4) covers the finance
+   control plane and nothing else. This follows that precedent rather than
+   inventing a competing general mechanism.
+3. **Audit rows per changed field** — simpler shape, but an edit that fixes a
+   name and a phone together reads as two unrelated events in the UI.
+
+## Decision
+
+Add a dedicated admin mutation, `admin.members.updateMemberProfile`, that edits
+`firstName`, `lastName`, `email`, `phone` and `dateOfBirth`, and writes one
+`memberProfileAudits` row per edit containing every field that actually changed.
+
+### Audit Record
+
+One row per edit (not per field), so the UI can render "Reg Admin changed First
+name and Phone on 10 Aug" as a single event:
+
+```ts
+memberProfileAudits: {
+  communityId, targetUserId, actorUserId,
+  changes: [{ field, previousValue, newValue }],
+  reason?, createdAt,
+}
+```
+
+The trail is append-only and readable only by community admins, via
+`admin.members.listMemberProfileAudits` (cursor-paginated, so it stays fully
+reachable however long it gets). The single exception to append-only is
+`mergeDuplicateAccounts`, which re-keys `targetUserId` onto the surviving
+primary so a merged member's history follows the person rather than being
+stranded on a deactivated row.
+
+### Key Rules
+
+The decisive rule is that **contact details are only editable while nobody has
+claimed the account.** An unclaimed record is not yet anyone's identity — it is
+data an admin typed off a card, which is exactly what this feature is for. Once
+someone has signed in as the account it is theirs, and the fields that would let
+another person sign in as them are closed to admins entirely. That is a narrower
+rule than gating on roles, and it needs no cross-community reasoning to be safe.
+
+"Claimed" is deliberately broader than `phoneVerified`, because that flag alone
+does not mean what it appears to: `auth/login.ts` `legacyLogin` authenticates a
+migrated password holder and issues real tokens without ever setting it. The
+account counts as claimed if **any** ownership signal is present:
+
+1. `users.phoneVerified`
+2. `users.password` (legacy migrated accounts)
+3. `users.lastLogin`
+4. `userCommunities.lastLogin` — current sign-in paths stamp the *membership*
+   row, not the user row, so the user-row check alone misses almost everyone.
+
+The rules in full:
+
+1. **Admins edit members.** Community admin role required, as with every other
+   admin mutation, and the target's membership must be **status 1 (active)**.
+   Status 2 (left) and status 3 (blocked) rows are retained in People search, so
+   rejecting only status 3 would let a community keep editing the global record
+   of someone who had left.
+2. **Phone and email are editable only on an unclaimed account.** Otherwise
+   nobody may change them here; the member changes their own, through a flow
+   that proves ownership.
+3. **...and only when the account holds no authority anywhere.** All the
+   authority-bearing surfaces are enumerated in one function,
+   `describeAccountAuthority`, because a missed one silently reopens the
+   takeover path — **a feature that adds a new kind of role must add it there.**
+4. **Names and date of birth are not credentials**, so they follow the ordinary
+   role rules and stay correctable even on a claimed account.
+5. **Editing another admin's record requires Primary Admin**, mirroring
+   `updateMemberRole`. Editing your own is always allowed, since self-service
+   profile settings already permit it.
+6. **Changing a phone number leaves `phoneVerified` false.** An admin typing a
+   number is not proof the member owns it.
+7. **Phone and email must stay unique** across users — both are sign-in
+   identifiers, so a duplicate makes the account ambiguous.
+8. **First name cannot be cleared, and an existing phone cannot be removed.**
+   Members without a phone at all are common in migrated data, so a profile edit
+   never requires inventing one; but removing an existing number would lock the
+   member out of sign-in. Email and date of birth can be cleared.
+9. **No-op edits write nothing**, including no audit row. A reason alone is not
+   an edit.
+10. **A free-text reason is optional** (max 500 characters) and stored with the
+    edit.
+
+### Why an unclaimed account can still be powerful
+
+Rule 3 is not redundant with rule 2. An unclaimed record can carry real
+authority:
+
+- Legacy accounts were migrated with their roles intact and have never signed in.
+- Leaders are routinely entered before they first sign in — they are exactly the
+  population this feature serves.
+- A **placeholder** row (`users.isPlaceholder`) keeps a stable `_id` precisely so
+  that existing `roleAssignments` / `groupMembers` / `userCommunities` rows
+  transparently belong to the account once claimed (`auth/registration.ts`). A
+  placeholder is unclaimed by definition and can already hold roles.
+
+So unclaimed-ness never short-circuits the authority check; both run.
+
+### The enumerated authority surfaces
+
+`describeAccountAuthority` currently covers ten, each verified against a real
+call site that grants a capability:
+
+| Surface | Grants |
+| --- | --- |
+| `users.isSuperuser` | Full platform access; bypasses every `platformRoles` check |
+| `users.isStaff` | Equivalent to superuser everywhere it is tested |
+| `users.platformRoles[]` | `poster_admin` (`posters.ts`), `dev_maintainer` (`devAssistant/access.ts`) |
+| `users.roles >= 3` (**global**) | `messaging/flagging.ts` `isUserAdmin` — cross-community flag review and message moderation, with no membership behind it |
+| `userCommunities` roles >= 3, status 1 | Community admin / primary admin |
+| `communityFinanceRoles` | Community finance admin (ADR-033) |
+| `groupMembers` role `leader`, active, non-archived group | Group leadership (`requireGroupLeaderOrCommunityAdmin`) |
+| `fundRoles`, `revokedAt` unset | Fund finance roles (ADR-032) |
+| `teamManagers` + still an active group member | Serving-team roster authority (ADR-025) |
+| `chatChannelMembers` role owner/admin/moderator, active | Delete others' messages, change channel roles, remove members |
+
+Two of these need care rather than a plain row lookup, and both are tested:
+
+- **Stale rows must not count.** An admin role in a community the member has
+  *left* (status 2) confers nothing, a `revokedAt` fund role confers nothing,
+  and leading an *archived* group confers nothing. Locking a member's contact
+  details on a dead role would be a permanent, unexplainable block.
+- **`teamManagers` rows are never cleaned up on exit**, so `isTeamManager`
+  re-verifies active group membership on every check. The guard mirrors that;
+  the row alone is not authority.
+
+## Consequences
+
+**Positive**
+
+- Bad data captured on someone's behalf is fixable without losing history.
+- Every change has an attributable actor, timestamp and before/after value.
+- Both takeover paths — sign-in OTP and account claim — are closed on any
+  account a person has actually claimed, without needing to reason about roles
+  in other communities.
+
+### Known limitation — the enumeration is the boundary
+
+The safety of admin-written contact details rests on an enumeration of every
+table that grants authority, and that enumeration is only correct as of today.
+Nothing in the type system will flag the eleventh surface.
+
+This is a sharper risk here than it looks. Porting this design onto the current
+codebase found **ten** surfaces where an earlier version of it had four — the
+extra six (superuser, staff, platform roles, community finance roles, fund
+roles, team managers) all postdate that design. The codebase is actively growing
+authority surfaces, so the list should be read as a floor, not a ceiling.
+
+One surface is knowingly **not** covered: `meetings.hostUserIds` grants edit and
+cancel rights over a meeting (`lib/meetingPermissions.ts` `isMeetingHost`), but
+Convex cannot index array-contains, so "which meetings does this user host?" has
+no efficient answer. Checking it would mean scanning `meetings` on every profile
+edit. It is excluded deliberately, and recorded here rather than left implied.
+
+The structural fix is to stop relying on the enumeration: require the
+*recipient* of a new phone or email to verify it before the change takes effect,
+so an admin-written contact detail is never on its own sufficient to claim an
+account. That reduces this rule from a security boundary to a UX nicety. It is
+deliberately out of scope here, and worth doing before the surface grows further.
+
+**Negative**
+
+- The audit table grows unbounded; there is no retention policy yet. Volume is
+  low (admin corrections, not member self-service), so this is acceptable for now.
+- An admin cannot fix a typo in a claimed member's email, even a harmless one.
+  The member does it themselves; the alternative is leaving a takeover path open.
+- An unclaimed leader with a mistyped number is stuck: they cannot sign in to fix
+  it, and admins cannot fix it for them. The escape is to remove the leadership
+  role, correct the number, then restore the role — deliberately awkward, because
+  the alternative is letting any admin claim a leader's account. This bites the
+  feature's own use case hardest, since leaders are exactly the people entered
+  before they first sign in. If it proves common in practice, the verification
+  flow above is the right answer, not a looser guard.
+- On an unclaimed account, an admin can still set the contact details and then
+  claim it. That is inherent to entering people on their behalf — the record
+  holds only what admins typed — and the audit trail names who did it.
+- Members are not notified when an admin edits their profile. If that becomes
+  desirable, the audit row is the natural trigger.
+
+### Side effects and adjacent fixes
+
+- `searchText` is rebuilt whenever a name, email or phone changes, so the member
+  stays findable by their corrected details.
+- Renames schedule `syncUserProfileToChannels`, which refreshes the denormalized
+  display name held in `chatChannelMembers`.
+- **`registerNewUser` now persists `phoneVerified`.** Its existing-user and
+  create-race branches both issued real tokens off a verified phone and reported
+  `phoneVerified: true` while never writing it. The response claimed a state the
+  database did not have; this guard was simply the first consumer to notice.
+  Fixed at the source rather than by adding a fifth ownership signal.
+
+### Offline support
+
+Not offline-capable, per the ADR-028 rubric. This is an admin desk workflow with
+connectivity, and every write is server-authorized against role and claim state,
+so a queued offline edit could not know whether it would be accepted. Read
+caching would likewise be misleading: `canEditProfile` is a live permission
+answer, not content.
+
+### Dates
+
+`dateOfBirth` is stored as **UTC midnight** of the calendar day — the convention
+`auth/helpers.parseAndValidateDate` established via `new Date("YYYY-MM-DD")` —
+while the shared `DatePicker` deals in **local wall-clock** Dates on both
+platforms. The mutation therefore speaks in `YYYY-MM-DD` strings rather than
+timestamps: a calendar date has no timezone, so there is nothing for client and
+server to disagree about. The client-side converters read UTC getters for the
+stored value and local getters for the picker value, and deliberately do *not*
+branch on `Platform.OS` — the picker's web and native values mean the same
+thing, and a platform branch is how the equivalent conversion in `StatsContent`
+silently became an off-by-one (fixed alongside this work).
+
+## Implementation
+
+| Area | Location |
+| --- | --- |
+| Schema | `apps/convex/schema.ts` (`memberProfileAudits`) |
+| Backend | `apps/convex/functions/admin/members.ts` |
+| Merge re-key | `apps/convex/functions/admin/duplicates.ts` |
+| Auth fix | `apps/convex/functions/auth/registration.ts` |
+| Backend tests | `apps/convex/__tests__/admin-member-profile-edit.test.ts` |
+| UI — edit form | `apps/mobile/features/admin/components/EditMemberProfileModal.tsx` |
+| UI — entry point and history | `apps/mobile/features/admin/components/PersonDetailScreen.tsx` |
+| UI tests | `apps/mobile/features/admin/__tests__/EditMemberProfileModal.test.tsx` |

--- a/docs/architecture/decisions/ADR-034-admin-member-profile-edits.md
+++ b/docs/architecture/decisions/ADR-034-admin-member-profile-edits.md
@@ -30,7 +30,7 @@ naming:
    both live on the global `users` row while admin roles are per-community, the
    takeover reaches into communities the acting admin has no authority over.
 2. **Silent data drift.** Once several admins can change each other's members'
-   data, "who changed Rafael's number, and why?" becomes unanswerable.
+   data, "who changed this member's number, and why?" becomes unanswerable.
 
 ### Alternatives Considered
 


### PR DESCRIPTION
> **Note:** this description was briefly edited to include inline grid editing, which is **not** part of this PR — it was written after this merged. Restored below to what actually shipped here. The inline editing follows in a separate PR.

## Why

Reported internally: an admin entered a member's phone number incorrectly from a paper Gold Card and had no way to correct it.

Before this, you couldn't. The member detail screen offered role changes or removal, so fixing a typo meant deleting and re-creating the person — losing their group memberships and attendance history.

Now there's an **Edit Profile** button on the member detail screen covering first name, last name, phone, email and date of birth, plus an **Edit History** section showing who changed what, when, and why.

## The security rule — this is the whole design

**Phone and email are credentials, not data.**

- Phone receives sign-in OTPs.
- Email is sufficient on its own: `auth/accountClaim.ts` exposes an *unauthenticated* `verify_and_link` that mails a code to whatever address is on the record and hands back access tokens.

Both live on the **global `users` row** while admin roles are **per-community** — so an unrestricted admin edit reaches into communities that admin has no authority over.

> Phone and email are editable **only while nobody has claimed the account**, and **only when the account holds no authority anywhere**.

Names and dates of birth aren't credentials, so they stay correctable under ordinary role rules. The reported case — a phone typed off a card onto an account nobody has signed into yet — is squarely inside the editable set.

**"Claimed" is deliberately broader than `phoneVerified`**, which doesn't mean what its name suggests: `legacyLogin` issues real JWTs without ever setting it. Any of a verified phone, a stored password, `users.lastLogin`, or `userCommunities.lastLogin` counts.

### Authority is enumerated in one place

`describeAccountAuthority` covers **ten** surfaces — `isSuperuser`, `isStaff`, `platformRoles`, global `users.roles >= 3`, community admin, community finance roles, group leadership, fund roles, serving-team managers, and channel owner/admin/moderator. Stale roles deliberately don't count: an admin role in a community the member has left, a revoked fund role, or leadership of an archived group would otherwise lock someone's contact details permanently for no reason.

`meetings.hostUserIds` is knowingly **not** covered — Convex can't index array-contains, so it would mean scanning `meetings` on every edit. Recorded in the ADR rather than left implied.

## Two pre-existing bugs fixed

1. **`registerNewUser` reported `phoneVerified: true` without persisting it** (existing-user and create-race branches). Both issue real tokens off a verified phone, so the response claimed a state the database didn't have — this guard was just the first consumer to notice. Fixed at the source. The placeholder-claim and create paths were checked and are already correct.
2. **`mergeDuplicateAccounts` would have stranded audit rows** on the deactivated secondary, where the history query could never reach them. Now re-keyed to the primary so the trail follows the person.

## Testing

**68 new tests**, all guards mutation-tested rather than assumed — each was disabled in turn and the suite re-run to confirm a test actually fails.

That caught two tests that proved nothing:
- One where the intended mutation silently didn't apply.
- The date-of-birth converter, which was **undetectable at UTC** — local time and UTC are the same clock at zero offset, so no assertion can tell `getUTCDate()` from `getDate()`. `run-tests.js` now pins TZ to `America/New_York` (the product's home zone, negative offset). With it pinned the mutation fails 6 tests. Verified the full mobile suite passes under it unchanged: **251 files, 2662 tests**.

## Two adjacent fixes, separate commits

- `StatsContent.toDayString` branched on `Platform.OS === "web"` and read UTC getters, from when DatePicker stored web values as UTC midnight. That stopped being true, and the branch silently became an off-by-one for positive UTC offsets — invisible from a US-Eastern machine, which is why it survived.
- Shared `Input` now forwards `editable` / `keyboardType` / `autoCapitalize` / `autoCorrect` / `maxLength`, which it previously dropped.

## Known limitation (in the ADR)

The enumeration **is** the security boundary, and nothing in the type system flags the eleventh surface. Porting this design onto the current codebase found ten where an earlier version had four — the extra six all postdate it. The durable fix is to require the *recipient* of a new phone or email to verify it before the change takes effect, demoting this rule from a security boundary to a convenience. Deliberately out of scope; worth doing before the surface grows.

## Docs

`docs/architecture/decisions/ADR-034-admin-member-profile-edits.md` — design, alternatives, the ten surfaces, and the limitation above. Offline support assessed against the ADR-028 rubric and deliberately not added (admin desk workflow, server-authorized writes).

## Not verified before merge

The modal was not visually checked in a running app — the E2E suite that passed is the existing one, not this screen.