### PR TITLE
feat(leader-tools): edit name, email and phone inline in the People grid

### DIFF
--- a/apps/convex/__tests__/admin-member-profile-edit.test.ts
+++ b/apps/convex/__tests__/admin-member-profile-edit.test.ts
@@ -351,6 +351,186 @@ describe("updateMemberProfile — editing", () => {
 });
 
 // ============================================================================
+// communityPeople denormalization (the People grid)
+// ============================================================================
+
+describe("communityPeople denormalization", () => {
+  /** Seed a communityPeople row mirroring the member, as the grid would have. */
+  async function seedGridRow(
+    t: ReturnType<typeof convexTest>,
+    s: TestSetup,
+    communityId?: Id<"communities">,
+  ) {
+    return await t.run(async (ctx) => {
+      return await ctx.db.insert("communityPeople", {
+        communityId: communityId ?? s.communityId,
+        groupId: s.groupId,
+        userId: s.memberId,
+        firstName: "Jorden",
+        lastName: "Reyes",
+        email: "jordan@test.com",
+        phone: "+12025550123",
+        searchText: "Jorden Reyes jordan@test.com +12025550123",
+        addedAt: Date.now(),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      } as any);
+    });
+  }
+
+  test("a name correction updates the grid's denormalized copy and its searchText", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    const rowId = await seedGridRow(t, s);
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      firstName: "Jordan",
+    });
+
+    const row = await t.run(async (ctx) => await ctx.db.get(rowId));
+    expect((row as any)?.firstName).toBe("Jordan");
+    // Without this, searching the grid for the corrected name would fail.
+    expect((row as any)?.searchText).toContain("Jordan");
+    expect((row as any)?.searchText).not.toContain("Jorden");
+  });
+
+  test("a phone correction updates the grid's denormalized copy", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    const rowId = await seedGridRow(t, s);
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      phone: "+12025559999",
+    });
+
+    const row = await t.run(async (ctx) => await ctx.db.get(rowId));
+    expect((row as any)?.phone).toBe("+12025559999");
+  });
+
+  test("rows in OTHER communities are updated too, since users fields are global", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const otherCommunityId = await t.run(async (ctx) => {
+      const id = await ctx.db.insert("communities", {
+        name: "Other",
+        slug: "other-grid",
+        isPublic: true,
+        timezone: "America/New_York",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("userCommunities", {
+        userId: s.memberId,
+        communityId: id,
+        roles: COMMUNITY_ROLES.MEMBER,
+        status: 1,
+        createdAt: Date.now(),
+      });
+      return id;
+    });
+
+    const hereRowId = await seedGridRow(t, s);
+    const thereRowId = await seedGridRow(t, s, otherCommunityId);
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      firstName: "Jordan",
+    });
+
+    const here = await t.run(async (ctx) => await ctx.db.get(hereRowId));
+    const there = await t.run(async (ctx) => await ctx.db.get(thereRowId));
+    expect((here as any)?.firstName).toBe("Jordan");
+    // The edited fields live on the global `users` row, so a row in a
+    // community the edit was NOT made from goes stale just the same.
+    expect((there as any)?.firstName).toBe("Jordan");
+  });
+
+  test("a date-of-birth-only edit leaves the grid rows untouched", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    const rowId = await seedGridRow(t, s);
+    const before = await t.run(async (ctx) => await ctx.db.get(rowId));
+
+    await editProfile(t, {
+      token: s.adminToken,
+      communityId: s.communityId,
+      targetUserId: s.memberId,
+      dateOfBirth: "1990-04-12",
+    });
+
+    // dateOfBirth is not mirrored on communityPeople, so there is nothing to
+    // sync and the row should not be rewritten.
+    const after = await t.run(async (ctx) => await ctx.db.get(rowId));
+    expect((after as any)?.updatedAt).toBe((before as any)?.updatedAt);
+  });
+});
+
+// ============================================================================
+// Per-row edit permissions (used by the People grid)
+// ============================================================================
+
+describe("getMemberProfileEditPermissions", () => {
+  test("reports an unclaimed member as fully editable", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const perms = await t.query(
+      api.functions.admin.members.getMemberProfileEditPermissions,
+      {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+      },
+    );
+    expect(perms.canEditProfile).toBe(true);
+    expect(perms.contactEditBlockedReason).toBeNull();
+  });
+
+  test("reports the lock reason for a claimed member", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(s.memberId, { phoneVerified: true });
+    });
+
+    const perms = await t.query(
+      api.functions.admin.members.getMemberProfileEditPermissions,
+      {
+        token: s.adminToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+      },
+    );
+    // Names stay editable; only the contact cells lock.
+    expect(perms.canEditProfile).toBe(true);
+    expect(perms.contactEditBlockedReason).toMatch(/verified their phone/i);
+  });
+
+  test("a non-admin cannot read edit permissions", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    const memberTokens = await generateTokens(s.memberId, s.communityId);
+
+    await expect(
+      t.query(api.functions.admin.members.getMemberProfileEditPermissions, {
+        token: memberTokens.accessToken,
+        communityId: s.communityId,
+        targetUserId: s.memberId,
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ============================================================================
 // Date of birth
 // ============================================================================
 

--- a/apps/convex/functions/admin/index.ts
+++ b/apps/convex/functions/admin/index.ts
@@ -32,6 +32,7 @@ export {
   getCommunityMemberById,
   updateMemberRole,
   updateMemberProfile,
+  getMemberProfileEditPermissions,
   listMemberProfileAudits,
   transferPrimaryAdmin,
   getUserGroupHistory,

--- a/apps/convex/functions/admin/members.ts
+++ b/apps/convex/functions/admin/members.ts
@@ -1162,19 +1162,24 @@ export const updateMemberProfile = mutation({
       (c) => c.field === "email" || c.field === "phone",
     );
 
+    // The merged post-edit values, used for both search indexes below.
+    const mergedFirstName =
+      (updates.firstName as string | undefined) ?? target.firstName;
+    const mergedLastName =
+      "lastName" in updates
+        ? (updates.lastName as string | undefined)
+        : target.lastName;
+    const mergedEmail =
+      "email" in updates ? (updates.email as string | undefined) : target.email;
+    const mergedPhone = (updates.phone as string | undefined) ?? target.phone;
+
     // Keep the member findable by their corrected details.
     if (nameChanged || contactChanged) {
       updates.searchText = buildSearchText({
-        firstName: (updates.firstName as string | undefined) ?? target.firstName,
-        lastName:
-          "lastName" in updates
-            ? (updates.lastName as string | undefined)
-            : target.lastName,
-        email:
-          "email" in updates
-            ? (updates.email as string | undefined)
-            : target.email,
-        phone: (updates.phone as string | undefined) ?? target.phone,
+        firstName: mergedFirstName,
+        lastName: mergedLastName,
+        email: mergedEmail,
+        phone: mergedPhone,
       });
     }
 
@@ -1182,6 +1187,53 @@ export const updateMemberProfile = mutation({
       ...updates,
       updatedAt: now(),
     });
+
+    // Refresh the denormalized copies the People grid reads.
+    //
+    // `communityPeople` mirrors these four fields off the `users` doc so the
+    // grid can render and full-text search without a join. They are rebuilt
+    // from `users` only when a score recompute happens to run, so without this
+    // an admin's correction would appear to do nothing on that screen — and
+    // searching for the corrected name would fail — until something unrelated
+    // triggered a recompute.
+    //
+    // Scoped by walking the user's memberships rather than a `by_user` index,
+    // which `communityPeople` does not have. The fields being corrected live on
+    // the global `users` row, so every community's rows go stale, not just the
+    // one the edit was made from.
+    if (nameChanged || contactChanged) {
+      const cpFields = {
+        firstName: mergedFirstName,
+        lastName: mergedLastName,
+        email: mergedEmail,
+        phone: mergedPhone,
+        // Matches the format built by the score-recompute upsert — a plain
+        // space-joined string, NOT the lowercased `users.searchText` shape.
+        searchText: [mergedFirstName, mergedLastName, mergedEmail, mergedPhone]
+          .filter(Boolean)
+          .join(" "),
+        updatedAt: now(),
+      };
+
+      const allMemberships = await ctx.db
+        .query("userCommunities")
+        .withIndex("by_user", (q) => q.eq("userId", args.targetUserId))
+        .collect();
+
+      for (const membership of allMemberships) {
+        const rows = await ctx.db
+          .query("communityPeople")
+          .withIndex("by_community_user", (q) =>
+            q
+              .eq("communityId", membership.communityId)
+              .eq("userId", args.targetUserId),
+          )
+          .collect();
+        for (const row of rows) {
+          await ctx.db.patch(row._id, cpFields);
+        }
+      }
+    }
 
     const timestamp = now();
     await ctx.db.insert("memberProfileAudits", {
@@ -1207,6 +1259,37 @@ export const updateMemberProfile = mutation({
       changed: true,
       changedFields: changes.map((c) => c.field),
     };
+  },
+});
+
+/**
+ * Whether the caller may edit one member's profile, and whether the contact
+ * fields are locked.
+ *
+ * Exists for the People grid, which renders many rows and must not pay for
+ * this on every one: `describeAccountAuthority` alone is several indexed reads
+ * per member, so folding it into the list query would cost hundreds of reads
+ * per page load to support an occasional edit. The grid instead calls this for
+ * a single row, on demand, when someone actually clicks into a contact cell.
+ *
+ * Same helper as the mutation and the member detail query, so all three agree.
+ */
+export const getMemberProfileEditPermissions = query({
+  args: {
+    token: v.string(),
+    communityId: v.id("communities"),
+    targetUserId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx, args.token);
+    await requireCommunityAdmin(ctx, args.communityId, userId);
+
+    return await getProfileEditPermissions(
+      ctx,
+      args.communityId,
+      args.targetUserId,
+      userId,
+    );
   },
 });
 

--- a/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
+++ b/apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx
@@ -30,6 +30,7 @@ import {
 } from "@services/api/convex";
 import { Id } from "@services/api/convex";
 import { useAuth } from "@providers/AuthProvider";
+import { formatError } from "@/utils/error-handling";
 import { DEFAULT_PRIMARY_COLOR } from "@utils/styles";
 import { useCommunityTheme } from "@hooks/useCommunityTheme";
 import { Avatar } from "@/components/ui/Avatar";
@@ -170,6 +171,25 @@ const BUILTIN_EDITABLE_COLUMNS = new Set([
   "archived",
 ]);
 
+/**
+ * Profile columns editable inline by community ADMINS only (ADR-034).
+ *
+ * Kept separate from BUILTIN_EDITABLE_COLUMNS because these write the global
+ * `users` row through `admin.members.updateMemberProfile`, which requires
+ * community admin — stricter than the `requireCommunityLeader` guarding
+ * zipCode and the custom fields. A leader who is not an admin still gets the
+ * rest of the grid; these four cells stay read-only for them.
+ */
+const ADMIN_EDITABLE_PROFILE_COLUMNS = new Set([
+  "firstName",
+  "lastName",
+  "email",
+  "phone",
+]);
+
+/** The subset that are sign-in credentials and need a per-row permission check. */
+const CONTACT_PROFILE_COLUMNS = new Set(["email", "phone"]);
+
 type DropdownPosition = {
   top: number;
   left: number;
@@ -285,6 +305,22 @@ export function FollowupDesktopTable({
     null,
   );
   const [inlineFieldValue, setInlineFieldValue] = useState("");
+
+  /**
+   * A contact cell (email/phone) the admin clicked, awaiting its permission
+   * check. Phone and email are sign-in credentials, so whether they are
+   * editable depends on the target account — see ADR-034.
+   *
+   * Checked per row ON DEMAND rather than returned by the list query:
+   * resolving it costs several indexed reads per member, so folding it into
+   * the grid's paginated query would mean hundreds of extra reads on every
+   * page load to support an edit that usually never happens.
+   */
+  const [pendingContactEdit, setPendingContactEdit] = useState<{
+    userId: string;
+    editKey: string;
+    currentValue: string;
+  } | null>(null);
 
   // Dropdowns — portal-based
   const [assigneeDropdownFor, setAssigneeDropdownFor] = useState<string | null>(
@@ -734,13 +770,18 @@ export function FollowupDesktopTable({
   }, [customFields]);
 
   // Editable columns (built-in + all custom field slots)
+  const canEditProfiles = user?.is_admin === true || user?.is_primary_admin === true;
+
   const editableColumns = useMemo(() => {
     const set = new Set(BUILTIN_EDITABLE_COLUMNS);
     for (const cf of customFields) {
       set.add(cf.slot);
     }
+    if (canEditProfiles) {
+      for (const key of ADMIN_EDITABLE_PROFILE_COLUMNS) set.add(key);
+    }
     return set;
-  }, [customFields]);
+  }, [customFields, canEditProfiles]);
 
   // Column widths (resizable)
   const [colWidths, setColWidths] = useState<Record<string, number>>({});
@@ -926,6 +967,12 @@ export function FollowupDesktopTable({
       if (opt.status !== undefined) overrides.status = opt.status ?? undefined;
       if ((opt as any).zipCode !== undefined)
         overrides.zipCode = (opt as any).zipCode ?? undefined;
+      // Inline profile edits (ADR-034). This merge whitelists keys, so a new
+      // optimistic field is silently dropped unless it is named here.
+      for (const key of ["firstName", "lastName", "email", "phone"] as const) {
+        if ((opt as any)[key] !== undefined)
+          overrides[key] = (opt as any)[key] ?? undefined;
+      }
       for (const [key, val] of Object.entries(opt)) {
         if (key.startsWith("custom")) overrides[key] = val ?? undefined;
       }
@@ -1108,6 +1155,47 @@ export function FollowupDesktopTable({
   const setActiveMut = useAuthenticatedMutation(
     api.functions.communityPeople.setActive,
   );
+  // Inline profile edits (ADR-034) — admin-only, writes the global users row.
+  const updateMemberProfileMut = useAuthenticatedMutation(
+    api.functions.admin.members.updateMemberProfile,
+  );
+
+  // Resolves only while a contact cell is waiting on its permission check.
+  const contactEditPermissions = useAuthenticatedQuery(
+    api.functions.admin.members.getMemberProfileEditPermissions,
+    pendingContactEdit && (groupData?.communityId ?? communityId)
+      ? {
+          communityId: (groupData?.communityId ??
+            communityId) as Id<"communities">,
+          targetUserId: pendingContactEdit.userId as Id<"users">,
+        }
+      : "skip",
+  );
+
+  // When the check lands, either open the cell for editing or explain why not.
+  useEffect(() => {
+    if (!pendingContactEdit || contactEditPermissions === undefined) return;
+
+    const { canEditProfile, contactEditBlockedReason } =
+      contactEditPermissions as {
+        canEditProfile: boolean;
+        profileEditBlockedReason: string | null;
+        contactEditBlockedReason: string | null;
+      };
+
+    if (!canEditProfile || contactEditBlockedReason) {
+      Alert.alert(
+        "Can't edit this here",
+        canEditProfile
+          ? `Phone and email can't be changed because ${contactEditBlockedReason}. They're sign-in details, so only the member can change them.`
+          : (contactEditBlockedReason ?? "This profile can't be edited."),
+      );
+    } else {
+      setEditingInlineField(pendingContactEdit.editKey);
+      setInlineFieldValue(pendingContactEdit.currentValue);
+    }
+    setPendingContactEdit(null);
+  }, [pendingContactEdit, contactEditPermissions]);
   const assigneeMutationQueueRef = useRef<Record<string, Promise<void>>>({});
 
   // Bulk remove mutations
@@ -1392,6 +1480,58 @@ export function FollowupDesktopTable({
         }
         return next;
       });
+    }
+  };
+
+  /**
+   * Commit an inline profile-field edit (ADR-034).
+   *
+   * Sends ONLY this one field, which is what the mutation wants: it treats
+   * every omitted argument as untouched, so a cell edit can never revert a
+   * change another admin made to a different field, and the audit trail
+   * records exactly what was changed.
+   *
+   * Unlike `handleZipCodeSave`, failures are surfaced to the user rather than
+   * only logged. A rejection here is usually meaningful and actionable —
+   * "another account already uses this phone number", or the contact-edit
+   * lock — and silently reverting the cell would look like the grid was
+   * broken.
+   */
+  const handleProfileFieldSave = async (
+    member: FollowupMember,
+    field: "firstName" | "lastName" | "email" | "phone",
+    value: string,
+  ) => {
+    const trimmed = value.trim();
+    const previous = (member as any)[field] ?? "";
+    if (trimmed === (previous ?? "")) return;
+
+    const targetCommunityId = groupData?.communityId ?? communityId;
+    if (!targetCommunityId) return;
+
+    const memberId = member.groupMemberId;
+    setOptimistic((prev) => ({
+      ...prev,
+      [memberId]: { ...prev[memberId], [field]: trimmed || null },
+    }));
+
+    try {
+      await updateMemberProfileMut({
+        communityId: targetCommunityId as Id<"communities">,
+        targetUserId: member.userId as Id<"users">,
+        // `null` clears email; first name and phone reject empty server-side.
+        [field]: field === "email" ? trimmed || null : trimmed,
+      } as any);
+    } catch (err: any) {
+      setOptimistic((prev) => {
+        const next = { ...prev };
+        if (next[memberId]) {
+          delete (next[memberId] as any)[field];
+          if (Object.keys(next[memberId]).length === 0) delete next[memberId];
+        }
+        return next;
+      });
+      Alert.alert("Couldn't save", formatError(err, "Failed to update profile"));
     }
   };
 
@@ -1684,6 +1824,13 @@ export function FollowupDesktopTable({
       }
       if (opt.status !== undefined) overrides.status = opt.status ?? undefined;
       if (opt.isActive !== undefined) overrides.isActive = opt.isActive;
+      // Inline profile edits (ADR-034). Applied here as well as in
+      // `displayMembers` — this is a second, independent copy of the merge, so
+      // a field handled in only one of them updates inconsistently.
+      for (const key of ["firstName", "lastName", "email", "phone"] as const) {
+        if ((opt as any)[key] !== undefined)
+          overrides[key] = (opt as any)[key] ?? undefined;
+      }
       // Apply custom field overrides
       for (const [key, val] of Object.entries(opt)) {
         if (key.startsWith("custom")) overrides[key] = val ?? undefined;
@@ -1725,34 +1872,102 @@ export function FollowupDesktopTable({
         return <Text style={[s.cellText, { color: colors.text }]}>{formatShortDate(item.addedAt)}</Text>;
 
       case "firstName":
-        return (
-          <View style={s.nameCellRow}>
-            <Avatar
-              name={`${item.firstName} ${item.lastName ?? ""}`}
-              imageUrl={item.avatarUrl}
-              size={24}
-            />
-            <Text style={[s.cellText, { color: colors.text }]}>{item.firstName}</Text>
-            {item.isLeader && (
-              <View style={s.leaderBadge}>
-                <Text style={s.leaderBadgeText}>Leader</Text>
-              </View>
-            )}
-          </View>
-        );
-
       case "lastName":
-        return <Text style={[s.cellText, { color: colors.text }]}>{item.lastName ?? ""}</Text>;
-
       case "email":
-        return (
-          <Text style={[s.cellText, s.cellTextSmall, { color: colors.text }]} numberOfLines={1}>
-            {item.email ?? ""}
-          </Text>
-        );
+      case "phone": {
+        const field = col.key as
+          | "firstName"
+          | "lastName"
+          | "email"
+          | "phone";
+        const editKey = `${item.groupMemberId}:${field}`;
+        const stored = ((item as any)[field] ?? "") as string;
+        const isContactField = CONTACT_PROFILE_COLUMNS.has(field);
+        const isSmall = field === "email";
 
-      case "phone":
-        return <Text style={[s.cellText, { color: colors.text }]}>{item.phone ?? ""}</Text>;
+        // The first-name cell carries the avatar and Leader badge, so its
+        // display state stays richer than the others.
+        const displayContent =
+          field === "firstName" ? (
+            <View style={s.nameCellRow}>
+              <Avatar
+                name={`${item.firstName} ${item.lastName ?? ""}`}
+                imageUrl={item.avatarUrl}
+                size={24}
+              />
+              <Text style={[s.cellText, { color: colors.text }]}>{item.firstName}</Text>
+              {item.isLeader && (
+                <View style={s.leaderBadge}>
+                  <Text style={s.leaderBadgeText}>Leader</Text>
+                </View>
+              )}
+            </View>
+          ) : (
+            <Text
+              style={[
+                s.cellText,
+                isSmall && s.cellTextSmall,
+                { color: colors.text },
+                !stored && { color: colors.textTertiary, fontStyle: "italic" as const },
+              ]}
+              numberOfLines={1}
+            >
+              {stored || (canEditProfiles ? "Click to add" : "")}
+            </Text>
+          );
+
+        if (!canEditProfiles) return displayContent;
+
+        if (editingInlineField === editKey) {
+          const commit = () => {
+            handleProfileFieldSave(item, field, inlineFieldValue);
+            setEditingInlineField(null);
+          };
+          return (
+            <TextInput
+              style={[
+                s.inlineInput,
+                { color: colors.text, borderColor: primaryColor, backgroundColor: colors.background },
+              ]}
+              value={inlineFieldValue}
+              onChangeText={setInlineFieldValue}
+              onBlur={commit}
+              onSubmitEditing={commit}
+              autoFocus
+              keyboardType={
+                field === "phone"
+                  ? "phone-pad"
+                  : field === "email"
+                    ? "email-address"
+                    : "default"
+              }
+              autoCapitalize={isContactField ? "none" : "words"}
+            />
+          );
+        }
+
+        return (
+          <TouchableOpacity
+            style={s.editableCellTouchable}
+            onPress={() => {
+              if (isContactField) {
+                // Don't open the editor until we know it's allowed — phone and
+                // email are credentials and may be locked on this account.
+                setPendingContactEdit({
+                  userId: item.userId,
+                  editKey,
+                  currentValue: stored,
+                });
+                return;
+              }
+              setEditingInlineField(editKey);
+              setInlineFieldValue(stored);
+            }}
+          >
+            {displayContent}
+          </TouchableOpacity>
+        );
+      }
 
       case "zipCode": {
         const zipEditKey = `${item.groupMemberId}:zipCode`;

--- a/docs/architecture/decisions/ADR-034-admin-member-profile-edits.md
+++ b/docs/architecture/decisions/ADR-034-admin-member-profile-edits.md
@@ -220,10 +220,44 @@ deliberately out of scope here, and worth doing before the surface grows further
 - Members are not notified when an admin edits their profile. If that becomes
   desirable, the audit row is the natural trigger.
 
+### Two entry points
+
+The same mutation backs both:
+
+1. **Member detail screen** — an Edit Profile modal, with the Edit History
+   below it. Best when correcting several fields at once, or when you want to
+   record a reason.
+2. **The People grid** — inline cell editing, matching the ZIP code cell that
+   was already editable there. Best for the common case: you are looking at the
+   row, you can see the wrong digit, you fix it in place.
+
+The grid's four profile columns are **admin-only**, unlike ZIP code and the
+custom fields, which any community leader may edit (`requireCommunityLeader`).
+That asymmetry is deliberate — these columns write the global `users` row and
+two of them are sign-in credentials, so they follow the profile mutation's
+`requireCommunityAdmin` rather than the grid's looser default.
+
+Contact cells resolve their lock **per row, on demand**, when clicked. The
+alternative — returning `canEditProfile` with every row of the list query —
+would be simpler but costs several indexed reads per member, so a 50-row page
+would pay hundreds of extra reads on every load to support an edit that usually
+never happens. A cheap approximation (checking only the claim signals, which
+are already on the row) was rejected because it would reintroduce exactly the
+query/mutation disagreement this design exists to avoid: an unclaimed account
+that holds a role would show an editable cell whose save always fails.
+
 ### Side effects and adjacent fixes
 
 - `searchText` is rebuilt whenever a name, email or phone changes, so the member
   stays findable by their corrected details.
+- **`communityPeople` rows are re-synced.** That table mirrors `firstName`,
+  `lastName`, `email`, `phone` and its own `searchText` off the `users` doc so
+  the People grid can render and full-text search without a join, and those
+  copies are otherwise only rebuilt when a score recompute happens to run.
+  Without this, a correction would appear to do nothing on that screen and
+  searching for the corrected name would fail. Every community's rows are
+  updated, not just the one the edit was made from, because the edited fields
+  live on the global `users` row.
 - Renames schedule `syncUserProfileToChannels`, which refreshes the denormalized
   display name held in `chatChannelMembers`.
 - **`registerNewUser` now persists `phoneVerified`.** Its existing-user and
@@ -264,4 +298,5 @@ silently became an off-by-one (fixed alongside this work).
 | Backend tests | `apps/convex/__tests__/admin-member-profile-edit.test.ts` |
 | UI — edit form | `apps/mobile/features/admin/components/EditMemberProfileModal.tsx` |
 | UI — entry point and history | `apps/mobile/features/admin/components/PersonDetailScreen.tsx` |
+| UI — inline grid editing | `apps/mobile/features/leader-tools/components/FollowupDesktopTable.tsx` |
 | UI tests | `apps/mobile/features/admin/__tests__/EditMemberProfileModal.test.tsx` |


### PR DESCRIPTION
Follow-up to #802, which added profile editing behind a modal on the member detail screen. This puts the same edit where people actually notice the mistake.

## Why

Correcting a Gold Card typo currently means leaving the People grid, opening the member's detail screen, and opening a modal. But you're already looking at the row with the wrong digit in it — and the ZIP CODE cell right next to it has been inline-editable all along.

Click straight into **FIRST NAME**, **LAST NAME**, **EMAIL** or **PHONE** and type. Commit on blur or Enter, optimistic update, rollback on rejection — the existing `zipCode` cell pattern.

## A bug in what already merged

**`communityPeople` denormalization goes stale.** That table mirrors `firstName` / `lastName` / `email` / `phone` (and its own `searchText`) off the `users` doc so the grid can render and full-text search without a join. Those copies are otherwise rebuilt only when a score recompute happens to run.

So on `main` today: an admin corrects a name in the #802 modal, and **the People grid keeps showing the old one** — and searching for the corrected name fails — until something unrelated triggers a recompute.

`updateMemberProfile` now re-syncs those rows, across *every* community the person belongs to, since the edited fields live on the global `users` row. This is worth landing on its own merits, independently of the inline editing.

## Three decisions worth reviewing

**The four profile columns are admin-only**, while ZIP code and the custom fields beside them are editable by any community *leader* (`requireCommunityLeader`). Deliberate asymmetry: these write the global `users` row and two of them are sign-in credentials, so they follow `updateMemberProfile`'s `requireCommunityAdmin`. A non-admin leader keeps the rest of the grid and sees these four read-only.

**Contact cells resolve their lock per row, on demand** — on click, not on page load. Phone and email are credentials, so whether they're editable depends on the target account (#802's rule: unclaimed, and holding no authority anywhere). Two alternatives rejected:

- *Return `canEditProfile` with every row.* Simpler, but it's several indexed reads **per member** — a 50-row page pays hundreds of extra reads on every load to support an edit that usually never happens.
- *Approximate it from data already on the row* (the claim signals). Cheap, but it reintroduces exactly the query/mutation disagreement caught in review on #802: an unclaimed account that holds a role would show an editable cell whose save always fails.

Names skip the check and open instantly.

**Inline failures are surfaced, not swallowed.** The existing `handleZipCodeSave` logs to console and silently reverts. For these fields a rejection is usually actionable — "another account already uses this phone number", or the contact-edit lock — and a cell that quietly snaps back reads as the grid being broken.

## Implementation notes

- Sends **only** the one edited field. The mutation treats every omitted argument as untouched, so a cell edit can't revert another admin's concurrent change to a different field, and the audit row records exactly what changed.
- The optimistic overlay is applied in **two** independent places in this file (`displayMembers` and `renderCellContent`), both whitelisting keys by name. A field handled in only one updates inconsistently, so both are extended.
- The first-name cell keeps its avatar and Leader badge in the display state.

## Scope

**Desktop grid only.** The mobile card view (`FollowupMobileCards`) has no inline-editing infrastructure — no editing-cell state, no TextInput cells — so a mobile equivalent would be a separate piece of work, not a small addition here.

## Testing

8 new backend tests (76 total for this feature): the denormalization sync for names and for phone, that rows in *other* communities are updated too, that a date-of-birth-only edit doesn't touch grid rows at all, and the new per-row permissions query including its authorization.

Full suites green — 3499 convex, 2662 mobile; both typecheck clean. One convex test failed once across four runs and passed on the other three; it did not reproduce and is unrelated to this diff (the known convex-test transaction-state flake that `drainScheduledFunctions` documents). Flagging it rather than leaving it unmentioned.

## Not yet verified

Not visually checked in a running app. This is a fair amount of new interaction on a screen I haven't seen running, and it deserves a look in staging before merge — more so than #802 did.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKEi91kiW1WEC78At7EYwK)_