### PR TITLE
fix(demo): leave no demo data behind when a church goes live

### DIFF
--- a/apps/convex/__tests__/demo-community.test.ts
+++ b/apps/convex/__tests__/demo-community.test.ts
@@ -714,29 +714,91 @@ describe("demo v3: feedback fixes", () => {
     expect(progress?.completed).toBe(1);
   });
 
-  test("go-live purge removes seeded DMs but keeps everything real", async () => {
+  test("go-live removes every DM, including staff-to-staff ones", async () => {
+    // Deliberate reversal: DMs used to survive if no seeded member was in
+    // them. A DM is a conversation, not structure, and staff-to-staff demo
+    // chatter is demo-era scratch work like everything else.
     const t = convexTest(schema, modules);
-    const { token } = await createUser(t, "DmPurge", "+15555550176");
+    const { userId, token } = await createUser(t, "DmPurge", "+15555550176");
+    const { userId: mateId, token: mateToken } = await createUser(
+      t,
+      "DmMate",
+      "+15555550177",
+    );
 
     const demo = await t.mutation(api.functions.demo.createDemoCommunity, {
       token,
       name: "DM Purge Church",
+    });
+    await t.mutation(api.functions.demo.joinDemoCommunity, {
+      token: mateToken,
+      code: demo.demoCode,
+    });
+
+    // A DM between two REAL staff accounts — no seeded member involved.
+    const staffDm = await t.run(async (ctx) => {
+      const channelId = await ctx.db.insert("chatChannels", {
+        communityId: demo.communityId,
+        isAdHoc: true,
+        channelType: "dm",
+        name: "",
+        createdById: userId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        memberCount: 2,
+      });
+      for (const uid of [userId, mateId]) {
+        await ctx.db.insert("chatChannelMembers", {
+          channelId,
+          userId: uid,
+          role: "member",
+          joinedAt: Date.now(),
+          isMuted: false,
+        });
+      }
+      await ctx.db.insert("chatMessages", {
+        channelId,
+        communityId: demo.communityId,
+        senderId: userId,
+        content: "shall we go live today?",
+        contentType: "text",
+        createdAt: Date.now(),
+        isDeleted: false,
+      });
+      return channelId;
     });
 
     await t.mutation(internal.functions.demo.purgeDemoData, {
       communityId: demo.communityId,
     });
 
-    const adHoc = await t.run(async (ctx) =>
-      ctx.db
+    const after = await t.run(async (ctx) => ({
+      adHoc: await ctx.db
         .query("chatChannels")
         .withIndex("by_community_isAdHoc", (q) =>
           q.eq("communityId", demo.communityId).eq("isAdHoc", true),
         )
         .collect(),
-    );
-    expect(adHoc).toHaveLength(0);
-  });
+      staffDm: await ctx.db.get(staffDm),
+      staffDmMembers: (await ctx.db.query("chatChannelMembers").collect()).filter(
+        (m) => m.channelId === staffDm,
+      ),
+      staffDmMessages: (await ctx.db.query("chatMessages").collect()).filter(
+        (m) => m.channelId === staffDm,
+      ),
+      // …but both real accounts are untouched.
+      creator: await ctx.db.get(userId),
+      mate: await ctx.db.get(mateId),
+    }));
+
+    expect(after.adHoc).toHaveLength(0);
+    expect(after.staffDm).toBeNull();
+    expect(after.staffDmMembers).toHaveLength(0);
+    expect(after.staffDmMessages).toHaveLength(0);
+    expect(after.creator).not.toBeNull();
+    expect(after.mate).not.toBeNull();
+  }, 20000);
 });
 
 describe("joinDemoCommunity", () => {
@@ -1959,13 +2021,23 @@ describe("go-live leaves no demo content behind", () => {
     const t = convexTest(schema, modules);
     const { demo } = await goLiveDemo(t, "Event Purge Church", "+15555550231");
 
-    const before = await t.run(async (ctx) =>
-      (await ctx.db.query("meetings").collect()).filter(
+    // Guard against vacuous assertions: prove each of these actually exists
+    // before the purge, so a seeding change can't quietly turn the
+    // post-conditions below into no-ops.
+    const before = await t.run(async (ctx) => ({
+      meetings: (await ctx.db.query("meetings").collect()).filter(
         (m) => m.communityId === demo.communityId,
-      ),
-    );
-    // The demo really does seed events (guards against a vacuous assertion).
-    expect(before.length).toBeGreaterThan(0);
+      ).length,
+      cwes: (await ctx.db.query("communityWideEvents").collect()).filter(
+        (c) => c.communityId === demo.communityId,
+      ).length,
+      rsvps: (await ctx.db.query("meetingRsvps").collect()).length,
+      attendances: (await ctx.db.query("meetingAttendances").collect()).length,
+    }));
+    expect(before.meetings).toBeGreaterThan(0);
+    expect(before.cwes).toBeGreaterThan(0);
+    expect(before.rsvps).toBeGreaterThan(0);
+    expect(before.attendances).toBeGreaterThan(0);
 
     await t.mutation(internal.functions.demo.purgeDemoData, {
       communityId: demo.communityId,
@@ -1978,15 +2050,15 @@ describe("go-live leaves no demo content behind", () => {
       cwes: (await ctx.db.query("communityWideEvents").collect()).filter(
         (c) => c.communityId === demo.communityId,
       ),
-      rsvps: await ctx.db.query("meetingRsvps").collect(),
-      attendances: await ctx.db.query("meetingAttendances").collect(),
+      rsvps: (await ctx.db.query("meetingRsvps").collect()).length,
+      attendances: (await ctx.db.query("meetingAttendances").collect()).length,
     }));
 
     expect(after.meetings).toHaveLength(0);
     expect(after.cwes).toHaveLength(0);
-    expect(after.rsvps).toHaveLength(0);
-    expect(after.attendances).toHaveLength(0);
-  });
+    expect(after.rsvps).toBe(0);
+    expect(after.attendances).toBe(0);
+  }, 20000);
 
   test("test content the STAFF created during the demo is cleared too", async () => {
     const t = convexTest(schema, modules);
@@ -2071,7 +2143,7 @@ describe("go-live leaves no demo content behind", () => {
     expect(after.messages).toHaveLength(0);
     expect(after.prayers).toHaveLength(0);
     expect(after.meetings).toHaveLength(0);
-  });
+  }, 20000);
 
   test("the structure the church built survives the content wipe", async () => {
     const t = convexTest(schema, modules);
@@ -2080,6 +2152,23 @@ describe("go-live leaves no demo content behind", () => {
       "Structure Church",
       "+15555550233",
     );
+
+    // Exact counts, not "> 0" — a purge that deleted all but one group would
+    // pass a >0 assertion while destroying the church's structure.
+    const before = await t.run(async (ctx) => ({
+      groups: (
+        await ctx.db
+          .query("groups")
+          .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+          .collect()
+      ).length,
+      groupTypes: (
+        await ctx.db
+          .query("groupTypes")
+          .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+          .collect()
+      ).length,
+    }));
 
     // A channel the staff added themselves (guided mission 2) is structure,
     // not content — it must outlive the purge even though it is emptied.
@@ -2135,17 +2224,55 @@ describe("go-live leaves no demo content behind", () => {
       };
     });
 
-    expect(after.groups).toBeGreaterThan(0);
-    expect(after.groupTypes).toBeGreaterThan(0);
+    expect(after.groups).toBe(before.groups);
+    expect(after.groupTypes).toBe(before.groupTypes);
     expect(after.landing).toBe(true);
     expect(after.creatorStillPrimaryAdmin).toBe(COMMUNITY_ROLES.PRIMARY_ADMIN);
     expect(after.customChannel).not.toBeNull();
+    expect(after.customChannel?.isArchived).toBe(false);
+    // memberCount is recomputed from the rows that survive, not left stale.
+    expect(after.customChannel?.memberCount).toBe(0);
     expect(after.community?.name).toBe("Structure Church");
-  });
+  }, 20000);
 
   test("emptied channels show no stale last-message preview", async () => {
     const t = convexTest(schema, modules);
-    const { demo } = await goLiveDemo(t, "Preview Church", "+15555550234");
+    const { userId, demo } = await goLiveDemo(t, "Preview Church", "+15555550234");
+
+    // A STAFF-authored message is what makes this test discriminating: seeded
+    // messages were already removed by the old per-user purge, so a channel
+    // fronted by one of those would clear either way. This one survived the
+    // old purge and left its preview stuck on the inbox.
+    await t.run(async (ctx) => {
+      const announcement = (
+        await ctx.db
+          .query("groups")
+          .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+          .collect()
+      ).find((g) => g.isAnnouncementGroup)!;
+      const main = (
+        await ctx.db
+          .query("chatChannels")
+          .withIndex("by_group", (q) => q.eq("groupId", announcement._id))
+          .collect()
+      ).find((c) => c.channelType === "main")!;
+      const at = Date.now();
+      await ctx.db.insert("chatMessages", {
+        channelId: main._id,
+        communityId: demo.communityId,
+        senderId: userId,
+        content: "testing the chat",
+        contentType: "text",
+        createdAt: at,
+        isDeleted: false,
+      });
+      await ctx.db.patch(main._id, {
+        lastMessageAt: at,
+        lastMessagePreview: "testing the chat",
+        lastMessageSenderId: userId,
+        lastMessageSenderName: "Live Tester",
+      });
+    });
 
     await t.mutation(internal.functions.demo.purgeDemoData, {
       communityId: demo.communityId,
@@ -2171,24 +2298,371 @@ describe("go-live leaves no demo content behind", () => {
     expect(channels.length).toBeGreaterThan(0);
     expect(channels.every((c) => c.lastMessagePreview === undefined)).toBe(true);
     expect(channels.every((c) => c.lastMessageAt === undefined)).toBe(true);
+    expect(channels.every((c) => c.lastMessageSenderId === undefined)).toBe(true);
     expect(channels.every((c) => c.lastMessageSenderName === undefined)).toBe(
       true,
     );
-  });
+  }, 20000);
 
-  test("running the purge twice is a no-op the second time", async () => {
+  test("a church's OWN 'getting-started' channel is not mistaken for the tour", async () => {
     const t = convexTest(schema, modules);
-    const { demo } = await goLiveDemo(t, "Idempotent Church", "+15555550235");
+    const { userId, demo } = await goLiveDemo(t, "Slug Clash Church", "+15555550238");
+
+    // The tour's slug is not reserved, so a church can create a channel that
+    // collides with it. Matching the tour on slug alone would delete this.
+    const imposterId = await t.run(async (ctx) => {
+      const groups = await ctx.db
+        .query("groups")
+        .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+        .collect();
+      const announcement = groups.find((g) => g.isAnnouncementGroup)!;
+      // Rename the real tour out of the way so the slug is free to reuse.
+      const realTour = (
+        await ctx.db
+          .query("chatChannels")
+          .withIndex("by_group", (q) => q.eq("groupId", announcement._id))
+          .collect()
+      ).find((c) => c.slug === "getting-started")!;
+      await ctx.db.patch(realTour._id, { slug: "getting-started-tour" });
+
+      return await ctx.db.insert("chatChannels", {
+        groupId: announcement._id,
+        slug: "getting-started",
+        channelType: "custom",
+        name: "Getting Started",
+        createdById: userId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        isEnabled: true,
+        memberCount: 1,
+      });
+    });
 
     await t.mutation(internal.functions.demo.purgeDemoData, {
       communityId: demo.communityId,
     });
-    const second = await t.mutation(internal.functions.demo.purgeDemoData, {
+
+    const after = await t.run(async (ctx) => ({
+      imposter: await ctx.db.get(imposterId),
+      // The real tour is flagged, so it goes regardless of its slug.
+      tourLeft: (await ctx.db.query("chatChannels").collect()).filter(
+        (c) => c.isDemoSeed,
+      ),
+    }));
+
+    expect(after.imposter).not.toBeNull();
+    expect(after.imposter?.name).toBe("Getting Started");
+    expect(after.tourLeft).toHaveLength(0);
+  }, 20000);
+
+  test("a legacy demo's unflagged tour channel is still removed", async () => {
+    const t = convexTest(schema, modules);
+    const { demo } = await goLiveDemo(t, "Legacy Tour Church", "+15555550239");
+
+    // Demos created before chatChannels.isDemoSeed existed carry no flag —
+    // those fall back to "every message is bot-authored".
+    await t.run(async (ctx) => {
+      const groups = await ctx.db
+        .query("groups")
+        .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+        .collect();
+      const announcement = groups.find((g) => g.isAnnouncementGroup)!;
+      const tour = (
+        await ctx.db
+          .query("chatChannels")
+          .withIndex("by_group", (q) => q.eq("groupId", announcement._id))
+          .collect()
+      ).find((c) => c.slug === "getting-started")!;
+      await ctx.db.patch(tour._id, { isDemoSeed: undefined });
+    });
+
+    await t.mutation(internal.functions.demo.purgeDemoData, {
       communityId: demo.communityId,
     });
 
+    const tourLeft = await t.run(async (ctx) =>
+      (await ctx.db.query("chatChannels").collect()).filter(
+        (c) => c.slug === "getting-started",
+      ),
+    );
+    expect(tourLeft).toHaveLength(0);
+  }, 20000);
+
+  test("purging one demo leaves a neighbouring community completely untouched", async () => {
+    // Several sweeps query by a non-community key (by_message, by_prayer,
+    // by_meeting, by_plan, by_channel). If a community filter is ever dropped
+    // upstream of one of those, this is what catches it.
+    const t = convexTest(schema, modules);
+    const { demo: victim } = await goLiveDemo(t, "Sweep Church", "+15555550241");
+    const { userId: neighbourUserId, demo: neighbour } = await goLiveDemo(
+      t,
+      "Neighbour Church",
+      "+15555550242",
+    );
+
+    const snapshot = async () =>
+      await t.run(async (ctx) => {
+        const groups = (await ctx.db.query("groups").collect()).filter(
+          (g) => g.communityId === neighbour.communityId,
+        );
+        const channelIds = new Set<string>();
+        for (const g of groups) {
+          for (const c of (await ctx.db.query("chatChannels").collect()).filter(
+            (c) => c.groupId === g._id,
+          )) {
+            channelIds.add(String(c._id));
+          }
+        }
+        const neighbourMeetingIds = new Set(
+          (await ctx.db.query("meetings").collect())
+            .filter((m) => m.communityId === neighbour.communityId)
+            .map((m) => String(m._id)),
+        );
+        return {
+          groups: groups.length,
+          channels: channelIds.size,
+          messages: (await ctx.db.query("chatMessages").collect()).filter(
+            (m) => m.communityId === neighbour.communityId,
+          ).length,
+          meetings: (await ctx.db.query("meetings").collect()).filter(
+            (m) => m.communityId === neighbour.communityId,
+          ).length,
+          rsvps: (await ctx.db.query("meetingRsvps").collect()).filter((r) =>
+            neighbourMeetingIds.has(String(r.meetingId)),
+          ).length,
+          prayers: (await ctx.db.query("prayers").collect()).filter(
+            (p) => p.communityId === neighbour.communityId,
+          ).length,
+          plans: (await ctx.db.query("eventPlans").collect()).filter(
+            (p) => p.communityId === neighbour.communityId,
+          ).length,
+          members: (await ctx.db.query("userCommunities").collect()).filter(
+            (m) => m.communityId === neighbour.communityId,
+          ).length,
+          user: await ctx.db.get(neighbourUserId),
+        };
+      });
+
+    const before = await snapshot();
+    // The neighbour is a real, populated community — otherwise this proves
+    // nothing.
+    expect(before.messages).toBeGreaterThan(0);
+    expect(before.meetings).toBeGreaterThan(0);
+    expect(before.prayers).toBeGreaterThan(0);
+    expect(before.members).toBeGreaterThan(1);
+    expect(before.rsvps).toBeGreaterThan(0);
+
+    await t.mutation(internal.functions.demo.purgeDemoData, {
+      communityId: victim.communityId,
+    });
+
+    const after = await snapshot();
+    expect(after.groups).toBe(before.groups);
+    expect(after.channels).toBe(before.channels);
+    expect(after.messages).toBe(before.messages);
+    expect(after.meetings).toBe(before.meetings);
+    expect(after.prayers).toBe(before.prayers);
+    expect(after.plans).toBe(before.plans);
+    expect(after.rsvps).toBe(before.rsvps);
+    expect(after.members).toBe(before.members);
+    expect(after.user).not.toBeNull();
+
+    // …while the purged community really was emptied.
+    const victimMeetings = await t.run(async (ctx) =>
+      (await ctx.db.query("meetings").collect()).filter(
+        (m) => m.communityId === victim.communityId,
+      ),
+    );
+    expect(victimMeetings).toHaveLength(0);
+  }, 30000);
+
+  test("a repeat purge can never touch a live community's real data", async () => {
+    // The hazard this pins: purgeDemoData takes only a community id and
+    // deletes every message, event and prayer under it. Before the guard, a
+    // second run — a Stripe redelivery, or a mistyped id in the dashboard —
+    // would wipe the real church data written since go-live.
+    const t = convexTest(schema, modules);
+    const { userId, demo } = await goLiveDemo(t, "Idempotent Church", "+15555550235");
+
+    const first = await t.mutation(internal.functions.demo.purgeDemoData, {
+      communityId: demo.communityId,
+    });
+    expect(first.purged).toBe(100);
+
+    // The church is live now and starts using it for real.
+    const structureBefore = await t.run(async (ctx) => {
+      const groups = await ctx.db
+        .query("groups")
+        .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+        .collect();
+      const announcement = groups.find((g) => g.isAnnouncementGroup)!;
+      const main = (
+        await ctx.db
+          .query("chatChannels")
+          .withIndex("by_group", (q) => q.eq("groupId", announcement._id))
+          .collect()
+      ).find((c) => c.channelType === "main")!;
+      await ctx.db.insert("chatMessages", {
+        channelId: main._id,
+        communityId: demo.communityId,
+        senderId: userId,
+        content: "Easter service is on! Invite your neighbours 🎉",
+        contentType: "text",
+        createdAt: Date.now(),
+        isDeleted: false,
+      });
+      await ctx.db.insert("meetings", {
+        groupId: announcement._id,
+        createdById: userId,
+        hostUserIds: [userId],
+        title: "Easter Service",
+        scheduledAt: Date.now() + 86400000,
+        meetingType: 1,
+        status: "scheduled",
+        shortId: "easter01",
+        rsvpEnabled: true,
+        visibility: "community",
+        locationMode: "tbd",
+        communityId: demo.communityId,
+        searchText: "easter service",
+        createdAt: Date.now(),
+        reminderSent: false,
+        attendanceConfirmationSent: false,
+      });
+      await ctx.db.insert("prayers", {
+        communityId: demo.communityId,
+        authorUserId: userId,
+        isAnonymous: false,
+        bodyText: "Please pray for my mother's surgery.",
+        status: "active",
+        prayedForCount: 3,
+        moderationStatus: "approved",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      return { groups: groups.length };
+    });
+
+    const second = await t.mutation(internal.functions.demo.purgeDemoData, {
+      communityId: demo.communityId,
+    });
     expect(second.purged).toBe(0);
-  });
+
+    const after = await t.run(async (ctx) => ({
+      messages: (await ctx.db.query("chatMessages").collect()).filter(
+        (m) => m.communityId === demo.communityId,
+      ),
+      meetings: (await ctx.db.query("meetings").collect()).filter(
+        (m) => m.communityId === demo.communityId,
+      ),
+      prayers: (await ctx.db.query("prayers").collect()).filter(
+        (p) => p.communityId === demo.communityId,
+      ),
+      groups: (await ctx.db.query("groups").collect()).filter(
+        (g) => g.communityId === demo.communityId,
+      ).length,
+    }));
+
+    // Every piece of post-go-live church data is untouched.
+    expect(after.messages).toHaveLength(1);
+    expect(after.messages[0].content).toContain("Easter service is on!");
+    expect(after.meetings).toHaveLength(1);
+    expect(after.meetings[0].title).toBe("Easter Service");
+    expect(after.prayers).toHaveLength(1);
+    expect(after.groups).toBe(structureBefore.groups);
+  }, 20000);
+});
+
+describe("a redelivered go-live webhook never re-runs the conversion", () => {
+  test("a same-subscription Stripe redelivery leaves live church data intact", async () => {
+    // Stripe is at-least-once and support can re-send an event by hand weeks
+    // later. The duplicate-subscription race guard does NOT catch a same-id
+    // redelivery, so handleCheckoutCompleted has to refuse it itself —
+    // otherwise it re-schedules the purge over a live community.
+    const t = convexTest(schema, modules);
+    const { userId, token } = await createUser(t, "Redeliver", "+15555550240");
+
+    const demo = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name: "Redelivery Church",
+      smallGroupCount: 2,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await t.mutation(internal.functions.ee.billing.handleCheckoutCompleted, {
+      stripeCustomerId: "cus_redeliver",
+      stripeSubscriptionId: "sub_redeliver",
+      communityId: demo.communityId,
+      demoConversion: true,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // Weeks of real church life happen.
+    await t.run(async (ctx) => {
+      const announcement = (
+        await ctx.db
+          .query("groups")
+          .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+          .collect()
+      ).find((g) => g.isAnnouncementGroup)!;
+      const main = (
+        await ctx.db
+          .query("chatChannels")
+          .withIndex("by_group", (q) => q.eq("groupId", announcement._id))
+          .collect()
+      ).find((c) => c.channelType === "main")!;
+      await ctx.db.insert("chatMessages", {
+        channelId: main._id,
+        communityId: demo.communityId,
+        senderId: userId,
+        content: "Welcome to everyone who joined on Sunday!",
+        contentType: "text",
+        createdAt: Date.now(),
+        isDeleted: false,
+      });
+      await ctx.db.insert("prayers", {
+        communityId: demo.communityId,
+        authorUserId: userId,
+        isAnonymous: false,
+        bodyText: "Praying for our city.",
+        status: "active",
+        prayedForCount: 12,
+        moderationStatus: "approved",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    const slugAfterConversion = await t.run(
+      async (ctx) => (await ctx.db.get(demo.communityId))!.slug,
+    );
+
+    // Stripe redelivers the SAME event.
+    await t.mutation(internal.functions.ee.billing.handleCheckoutCompleted, {
+      stripeCustomerId: "cus_redeliver",
+      stripeSubscriptionId: "sub_redeliver",
+      communityId: demo.communityId,
+      demoConversion: true,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const after = await t.run(async (ctx) => ({
+      messages: (await ctx.db.query("chatMessages").collect()).filter(
+        (m) => m.communityId === demo.communityId,
+      ),
+      prayers: (await ctx.db.query("prayers").collect()).filter(
+        (p) => p.communityId === demo.communityId,
+      ),
+      community: await ctx.db.get(demo.communityId),
+    }));
+
+    expect(after.messages).toHaveLength(1);
+    expect(after.prayers).toHaveLength(1);
+    // And the redelivery didn't re-suffix the slug it already cleaned up.
+    expect(after.community?.slug).toBe(slugAfterConversion);
+    expect(after.community?.isDemo).toBe(false);
+  }, 20000);
 });
 
 describe("go-live drops the demo- prefix from the public URL", () => {

--- a/apps/convex/__tests__/demo-community.test.ts
+++ b/apps/convex/__tests__/demo-community.test.ts
@@ -660,7 +660,7 @@ describe("demo v3: feedback fixes", () => {
       logo: "r2:uploads/logo.png",
     });
 
-    await t.mutation(internal.functions.demo.purgeDemoSeedUsers, {
+    await t.mutation(internal.functions.demo.purgeDemoData, {
       communityId: demo.communityId,
     });
 
@@ -723,7 +723,7 @@ describe("demo v3: feedback fixes", () => {
       name: "DM Purge Church",
     });
 
-    await t.mutation(internal.functions.demo.purgeDemoSeedUsers, {
+    await t.mutation(internal.functions.demo.purgeDemoData, {
       communityId: demo.communityId,
     });
 
@@ -958,7 +958,7 @@ describe("demo conversion (go live)", () => {
   // pipelines back to back: createDemoCommunity's own seedMemberActivity ->
   // communityScoreComputation chain (batched cross-group attendance +
   // per-group scoring across ~100 seeded members), and
-  // handleCheckoutCompleted's purgeDemoSeedUsers (deletes ~100 placeholder
+  // handleCheckoutCompleted's purgeDemoData (deletes ~100 placeholder
   // members and everything keyed to them, one query/delete at a time). That
   // is genuinely a lot of real synchronous work, not a hang: baseline is
   // ~1.5s, but it measurably scales with CPU contention — reproduced at
@@ -1066,7 +1066,7 @@ describe("demo conversion (go live)", () => {
 
 describe("demo conversion race + purge safety (codex review)", () => {
   // Same shape as "checkout completion" above — one drain covers
-  // createDemoCommunity's score-computation chain plus purgeDemoSeedUsers
+  // createDemoCommunity's score-computation chain plus purgeDemoData
   // (scheduled by the first, winning checkout). Reproduced at 5.3-6.0s
   // under the same forced 2x-oversubscribed parallel load; see the comment
   // above.
@@ -1134,7 +1134,7 @@ describe("demo conversion race + purge safety (codex review)", () => {
       return inviteeId;
     });
 
-    await t.mutation(internal.functions.demo.purgeDemoSeedUsers, {
+    await t.mutation(internal.functions.demo.purgeDemoData, {
       communityId: demo.communityId,
     });
 
@@ -1684,7 +1684,7 @@ describe("demo v4: unread suppression + go-live purge of new tables", () => {
     // Run the scheduled member-health seeding so go-live has to clean it up.
     await t.finishAllScheduledFunctions(vi.runAllTimers);
 
-    await t.mutation(internal.functions.demo.purgeDemoSeedUsers, {
+    await t.mutation(internal.functions.demo.purgeDemoData, {
       communityId: result.communityId,
     });
 
@@ -1875,10 +1875,10 @@ describe("demo v5: review-fix follow-ups", () => {
       await ctx.db.patch(seededEdited!._id, { linkUrl: EDITED_URL });
     });
 
-    await t.mutation(internal.functions.demo.purgeDemoSeedUsers, {
+    await t.mutation(internal.functions.demo.purgeDemoData, {
       communityId: edited.communityId,
     });
-    await t.mutation(internal.functions.demo.purgeDemoSeedUsers, {
+    await t.mutation(internal.functions.demo.purgeDemoData, {
       communityId: untouched.communityId,
     });
 
@@ -1927,4 +1927,327 @@ describe("demo v5: review-fix follow-ups", () => {
       expect(hour).toBe(9);
     }
   });
+});
+
+describe("go-live leaves no demo content behind", () => {
+  /**
+   * Going live is a hand-over, not a merge: the church keeps the STRUCTURE it
+   * built (groups, channels, group types, branding, staff accounts) and loses
+   * every piece of CONTENT that was created while the community was a demo —
+   * ours and theirs alike. These tests pin that contract, because the residue
+   * they cover was invisible to the old "delete the seeded users" purge: seeded
+   * events are authored by the real creator's account, so nothing keyed to a
+   * placeholder user ever reached them.
+   */
+  async function goLiveDemo(
+    t: ReturnType<typeof convexTest>,
+    name: string,
+    phone: string,
+  ) {
+    const { userId, token } = await createUser(t, "Live", phone);
+    const demo = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name,
+      smallGroupCount: 2,
+      zipCode: "11201",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    return { userId, token, demo };
+  }
+
+  test("every seeded event is gone — not just its cover photo", async () => {
+    const t = convexTest(schema, modules);
+    const { demo } = await goLiveDemo(t, "Event Purge Church", "+15555550231");
+
+    const before = await t.run(async (ctx) =>
+      (await ctx.db.query("meetings").collect()).filter(
+        (m) => m.communityId === demo.communityId,
+      ),
+    );
+    // The demo really does seed events (guards against a vacuous assertion).
+    expect(before.length).toBeGreaterThan(0);
+
+    await t.mutation(internal.functions.demo.purgeDemoData, {
+      communityId: demo.communityId,
+    });
+
+    const after = await t.run(async (ctx) => ({
+      meetings: (await ctx.db.query("meetings").collect()).filter(
+        (m) => m.communityId === demo.communityId,
+      ),
+      cwes: (await ctx.db.query("communityWideEvents").collect()).filter(
+        (c) => c.communityId === demo.communityId,
+      ),
+      rsvps: await ctx.db.query("meetingRsvps").collect(),
+      attendances: await ctx.db.query("meetingAttendances").collect(),
+    }));
+
+    expect(after.meetings).toHaveLength(0);
+    expect(after.cwes).toHaveLength(0);
+    expect(after.rsvps).toHaveLength(0);
+    expect(after.attendances).toHaveLength(0);
+  });
+
+  test("test content the STAFF created during the demo is cleared too", async () => {
+    const t = convexTest(schema, modules);
+    const { userId, demo } = await goLiveDemo(
+      t,
+      "Staff Purge Church",
+      "+15555550232",
+    );
+
+    // The guided tour tells staff to try things — a message, an event, a
+    // prayer. All of it is demo-era scratch work and must not reach the
+    // congregation.
+    await t.run(async (ctx) => {
+      const groups = await ctx.db
+        .query("groups")
+        .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+        .collect();
+      const announcement = groups.find((g) => g.isAnnouncementGroup)!;
+      const main = (
+        await ctx.db
+          .query("chatChannels")
+          .withIndex("by_group", (q) => q.eq("groupId", announcement._id))
+          .collect()
+      ).find((c) => c.channelType === "main")!;
+
+      await ctx.db.insert("chatMessages", {
+        channelId: main._id,
+        communityId: demo.communityId,
+        senderId: userId,
+        content: "testing testing 123",
+        contentType: "text",
+        createdAt: Date.now(),
+        isDeleted: false,
+      });
+      await ctx.db.insert("prayers", {
+        communityId: demo.communityId,
+        authorUserId: userId,
+        isAnonymous: false,
+        bodyText: "just trying out the prayer wall",
+        status: "active",
+        prayedForCount: 0,
+        moderationStatus: "approved",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("meetings", {
+        groupId: announcement._id,
+        createdById: userId,
+        hostUserIds: [userId],
+        title: "my test event",
+        scheduledAt: Date.now() + 86400000,
+        meetingType: 1,
+        status: "scheduled",
+        shortId: "tstevt01",
+        rsvpEnabled: true,
+        visibility: "group",
+        locationMode: "tbd",
+        communityId: demo.communityId,
+        searchText: "my test event",
+        createdAt: Date.now(),
+        reminderSent: false,
+        attendanceConfirmationSent: false,
+      });
+    });
+
+    await t.mutation(internal.functions.demo.purgeDemoData, {
+      communityId: demo.communityId,
+    });
+
+    const after = await t.run(async (ctx) => ({
+      messages: (await ctx.db.query("chatMessages").collect()).filter(
+        (m) => m.communityId === demo.communityId,
+      ),
+      prayers: (await ctx.db.query("prayers").collect()).filter(
+        (p) => p.communityId === demo.communityId,
+      ),
+      meetings: (await ctx.db.query("meetings").collect()).filter(
+        (m) => m.communityId === demo.communityId,
+      ),
+    }));
+
+    expect(after.messages).toHaveLength(0);
+    expect(after.prayers).toHaveLength(0);
+    expect(after.meetings).toHaveLength(0);
+  });
+
+  test("the structure the church built survives the content wipe", async () => {
+    const t = convexTest(schema, modules);
+    const { userId, demo } = await goLiveDemo(
+      t,
+      "Structure Church",
+      "+15555550233",
+    );
+
+    // A channel the staff added themselves (guided mission 2) is structure,
+    // not content — it must outlive the purge even though it is emptied.
+    const customChannelId = await t.run(async (ctx) => {
+      const groups = await ctx.db
+        .query("groups")
+        .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+        .collect();
+      const announcement = groups.find((g) => g.isAnnouncementGroup)!;
+      return await ctx.db.insert("chatChannels", {
+        groupId: announcement._id,
+        slug: "serve-team",
+        channelType: "custom",
+        name: "Serve Team",
+        createdById: userId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        isEnabled: true,
+        memberCount: 1,
+      });
+    });
+
+    await t.mutation(internal.functions.demo.purgeDemoData, {
+      communityId: demo.communityId,
+    });
+
+    const after = await t.run(async (ctx) => {
+      const groups = await ctx.db
+        .query("groups")
+        .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+        .collect();
+      const groupTypes = await ctx.db
+        .query("groupTypes")
+        .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+        .collect();
+      const landing = (
+        await ctx.db.query("communityLandingPages").collect()
+      ).find((l) => l.communityId === demo.communityId);
+      const membership = await ctx.db
+        .query("userCommunities")
+        .withIndex("by_user_community", (q) =>
+          q.eq("userId", userId).eq("communityId", demo.communityId),
+        )
+        .first();
+      return {
+        groups: groups.length,
+        groupTypes: groupTypes.length,
+        landing: !!landing,
+        creatorStillPrimaryAdmin: membership?.roles,
+        customChannel: await ctx.db.get(customChannelId),
+        community: await ctx.db.get(demo.communityId),
+      };
+    });
+
+    expect(after.groups).toBeGreaterThan(0);
+    expect(after.groupTypes).toBeGreaterThan(0);
+    expect(after.landing).toBe(true);
+    expect(after.creatorStillPrimaryAdmin).toBe(COMMUNITY_ROLES.PRIMARY_ADMIN);
+    expect(after.customChannel).not.toBeNull();
+    expect(after.community?.name).toBe("Structure Church");
+  });
+
+  test("emptied channels show no stale last-message preview", async () => {
+    const t = convexTest(schema, modules);
+    const { demo } = await goLiveDemo(t, "Preview Church", "+15555550234");
+
+    await t.mutation(internal.functions.demo.purgeDemoData, {
+      communityId: demo.communityId,
+    });
+
+    const channels = await t.run(async (ctx) => {
+      const groups = await ctx.db
+        .query("groups")
+        .withIndex("by_community", (q) => q.eq("communityId", demo.communityId))
+        .collect();
+      const all = [];
+      for (const g of groups) {
+        all.push(
+          ...(await ctx.db
+            .query("chatChannels")
+            .withIndex("by_group", (q) => q.eq("groupId", g._id))
+            .collect()),
+        );
+      }
+      return all;
+    });
+
+    expect(channels.length).toBeGreaterThan(0);
+    expect(channels.every((c) => c.lastMessagePreview === undefined)).toBe(true);
+    expect(channels.every((c) => c.lastMessageAt === undefined)).toBe(true);
+    expect(channels.every((c) => c.lastMessageSenderName === undefined)).toBe(
+      true,
+    );
+  });
+
+  test("running the purge twice is a no-op the second time", async () => {
+    const t = convexTest(schema, modules);
+    const { demo } = await goLiveDemo(t, "Idempotent Church", "+15555550235");
+
+    await t.mutation(internal.functions.demo.purgeDemoData, {
+      communityId: demo.communityId,
+    });
+    const second = await t.mutation(internal.functions.demo.purgeDemoData, {
+      communityId: demo.communityId,
+    });
+
+    expect(second.purged).toBe(0);
+  });
+});
+
+describe("go-live drops the demo- prefix from the public URL", () => {
+  test("checkout renames demo-grace-fellowship to grace-fellowship", async () => {
+    const t = convexTest(schema, modules);
+    const { token } = await createUser(t, "Slug", "+15555550236");
+
+    const demo = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name: "Grace Fellowship Slug",
+    });
+    expect(demo.demoCode).toBe("demo-grace-fellowship-slug");
+
+    await t.mutation(internal.functions.ee.billing.handleCheckoutCompleted, {
+      stripeCustomerId: "cus_slug",
+      stripeSubscriptionId: "sub_slug",
+      communityId: demo.communityId,
+      demoConversion: true,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const community = await t.run(async (ctx) => ctx.db.get(demo.communityId));
+    expect(community?.isDemo).toBe(false);
+    expect(community?.slug).toBe("grace-fellowship-slug");
+    // searchText embeds the slug, so it has to move with it.
+    expect(community?.searchText).toContain("grace-fellowship-slug");
+    expect(community?.searchText).not.toContain("demo-");
+  }, 20000);
+
+  test("a taken slug falls back to a suffixed one instead of colliding", async () => {
+    const t = convexTest(schema, modules);
+    const { token } = await createUser(t, "Collide", "+15555550237");
+
+    const demo = await t.mutation(api.functions.demo.createDemoCommunity, {
+      token,
+      name: "Taken Name",
+    });
+    // Somebody already owns the de-prefixed slug.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("communities", {
+        name: "Taken Name",
+        slug: "taken-name",
+        isPublic: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    await t.mutation(internal.functions.ee.billing.handleCheckoutCompleted, {
+      stripeCustomerId: "cus_collide",
+      stripeSubscriptionId: "sub_collide",
+      communityId: demo.communityId,
+      demoConversion: true,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const community = await t.run(async (ctx) => ctx.db.get(demo.communityId));
+    expect(community?.slug).not.toBe("taken-name");
+    expect(community?.slug).not.toContain("demo-");
+    expect(community?.slug?.startsWith("taken-name-")).toBe(true);
+  }, 20000);
 });

--- a/apps/convex/functions/demo.ts
+++ b/apps/convex/functions/demo.ts
@@ -36,7 +36,7 @@
 import { v } from "convex/values";
 import { internalMutation, mutation, query } from "../_generated/server";
 import { internal } from "../_generated/api";
-import { Id } from "../_generated/dataModel";
+import { Doc, Id } from "../_generated/dataModel";
 import { MutationCtx, QueryCtx } from "../_generated/server";
 import { requireAuth } from "../lib/auth";
 import { now, generateShortId, buildSearchText, getMediaUrl } from "../lib/utils";
@@ -378,7 +378,7 @@ const GETTING_STARTED_MESSAGES: string[] = [
     (m, i) => `${MISSION_NUMBER_EMOJI[i]} ${m.instruction}`,
   ),
   "Any time, head to Admin → Settings to change your name, logo, and brand color — the whole app re-themes instantly. ✨",
-  "When you're ready for the real thing, tap Go live on the banner — your groups, channels, branding, and teammates stay. Everything written in here clears out: these demo members, all these conversations and events, and anything you tried out yourself. Play freely — nothing you do here follows you into the real thing. 🎉",
+  "When you're ready for the real thing, tap Go live on the banner — your groups, channels, branding, and teammates stay. Everything written in here clears out: these demo members, all these conversations and events, and anything you tried out yourself. Play freely — nothing you write here follows you into the real thing. 🎉",
 ];
 
 const PRAYER_REQUESTS = [
@@ -938,31 +938,37 @@ async function createDemoMeeting(
   });
 }
 
+/** Name of the seeded guided-tour channel; also identifies it on go-live. */
+const DEMO_TOUR_CHANNEL_NAME = "🎓 Getting Started";
+
 /** Prefix that marks a community slug as a demo (and doubles as its code). */
 const DEMO_SLUG_PREFIX = "demo-";
 
 /**
- * Generate a unique demo slug like "demo-grace-fellowship". The slug doubles
- * as the shareable demo code, so keep it readable; add a random suffix only on
- * collision.
+ * `base` if no community holds it, else `base-XXXX` with random suffixes until
+ * one is free (collisions are vanishingly rare). Slugs are user-visible URLs,
+ * so the unsuffixed form is always preferred.
  */
-async function uniqueDemoSlug(ctx: MutationCtx, name: string): Promise<string> {
-  const base = `${DEMO_SLUG_PREFIX}${nameToSlug(name) || "church"}`;
-  const existing = await ctx.db
-    .query("communities")
-    .withIndex("by_slug", (q) => q.eq("slug", base))
-    .first();
-  if (!existing) return base;
-
-  // Retry with random suffixes until free (collisions are vanishingly rare).
-  for (;;) {
-    const candidate = `${base}-${generateShortId().slice(-4)}`;
-    const taken = await ctx.db
+async function uniqueSlug(ctx: MutationCtx, base: string): Promise<string> {
+  const isFree = async (candidate: string) =>
+    !(await ctx.db
       .query("communities")
       .withIndex("by_slug", (q) => q.eq("slug", candidate))
-      .first();
-    if (!taken) return candidate;
+      .first());
+
+  if (await isFree(base)) return base;
+  for (;;) {
+    const candidate = `${base}-${generateShortId().slice(-4)}`;
+    if (await isFree(candidate)) return candidate;
   }
+}
+
+/**
+ * Generate a unique demo slug like "demo-grace-fellowship". The slug doubles
+ * as the shareable demo code, so keep it readable.
+ */
+async function uniqueDemoSlug(ctx: MutationCtx, name: string): Promise<string> {
+  return uniqueSlug(ctx, `${DEMO_SLUG_PREFIX}${nameToSlug(name) || "church"}`);
 }
 
 /**
@@ -975,6 +981,12 @@ async function uniqueDemoSlug(ctx: MutationCtx, name: string): Promise<string> {
  * `togather.nyc/demo-grace-fellowship` forever — there is no admin-facing slug
  * rename to undo it.
  *
+ * The old slug stops resolving: it doubles as the demo CODE, so any
+ * `togather.nyc/demo-x` link already shared with staff dies at go-live. That's
+ * acceptable — the code only ever circulated inside the church's own team, and
+ * joining by code is closed to live communities anyway (joinDemoCommunity
+ * rejects a non-demo).
+ *
  * Returns null when there's nothing to do (already prefix-free, or the church
  * renamed the slug itself). Falls back to a suffixed variant if the clean slug
  * is taken, so conversion can never fail on a collision.
@@ -986,18 +998,7 @@ export async function liveSlugForDemo(
   if (!currentSlug?.startsWith(DEMO_SLUG_PREFIX)) return null;
   const base = currentSlug.slice(DEMO_SLUG_PREFIX.length);
   if (!base) return null;
-
-  const isFree = async (candidate: string) =>
-    !(await ctx.db
-      .query("communities")
-      .withIndex("by_slug", (q) => q.eq("slug", candidate))
-      .first());
-
-  if (await isFree(base)) return base;
-  for (;;) {
-    const candidate = `${base}-${generateShortId().slice(-4)}`;
-    if (await isFree(candidate)) return candidate;
-  }
+  return await uniqueSlug(ctx, base);
 }
 
 /**
@@ -1987,7 +1988,7 @@ export const createDemoCommunity = mutation({
       groupId: announcement.groupId,
       slug: "getting-started",
       channelType: "custom",
-      name: "🎓 Getting Started",
+      name: DEMO_TOUR_CHANNEL_NAME,
       description: "Guided tour: the best things to try in your demo.",
       createdById: userId,
       createdAt: timestamp,
@@ -1995,6 +1996,7 @@ export const createDemoCommunity = mutation({
       isArchived: false,
       isEnabled: true,
       memberCount: 0,
+      isDemoSeed: true, // deleted on go-live; see purgeDemoData
     });
     await seedConversation(ctx, {
       channelId: gettingStartedChannelId,
@@ -2575,6 +2577,33 @@ export const getDemoStatus = query({
 // ============================================================================
 
 /**
+ * Is this the demo's "🎓 Getting Started" tour channel, which promises in its
+ * own bot messages to clean itself up on go-live?
+ *
+ * Identified by the `isDemoSeed` flag stamped at creation. The slug is NOT
+ * reserved, so a church can create its own "getting-started" channel in the
+ * announcement group — matching on slug alone would silently delete it.
+ *
+ * Demos created BEFORE that flag existed carry no flag, so they fall back to
+ * the seeded NAME as well as the slug and group. The original fallback here
+ * was "every message is bot-authored", but the tour channel is an ordinary
+ * custom channel with the creator enrolled — one staff reply (which the tour
+ * invites) would break it and strand the channel forever. The emoji-prefixed
+ * name is both stabler and far harder to collide with by accident.
+ */
+function isDemoTourChannel(
+  channel: Doc<"chatChannels">,
+  group: Doc<"groups">,
+): boolean {
+  if (channel.isDemoSeed) return true;
+  return (
+    channel.slug === "getting-started" &&
+    channel.name === DEMO_TOUR_CHANNEL_NAME &&
+    group.isAnnouncementGroup === true
+  );
+}
+
+/**
  * Hand a demo community over to the church as a clean, live community.
  *
  * Going live is a HAND-OVER, not a merge. The church keeps everything it
@@ -2604,17 +2633,39 @@ export const getDemoStatus = query({
  * goes. So a channel the staff created survives (emptied), while the messages
  * inside it do not.
  *
+ * KNOWN GAP: a standalone `availabilityRequests` row (one created for link
+ * sharing, with no channelId) is unreachable from here — that table is indexed
+ * only by channel, message and public token, so it can't be enumerated by
+ * community or group. Its `/a/<token>` link keeps resolving after go-live and
+ * renders plan ids this purge deleted. Closing it needs a by_community index,
+ * which is a schema change deliberately left out of this one.
+ *
  * Scheduled by ee/billing.handleCheckoutCompleted when the demo-conversion
- * checkout finishes. Idempotent: rows are deleted as they're found, so a
- * webhook retry that schedules it twice finds nothing the second time.
+ * checkout finishes.
+ *
+ * REFUSES TO RUN TWICE, and that guard is load-bearing rather than defensive
+ * tidiness: this mutation takes a community id and deletes every message,
+ * event and prayer under it, so a second run against a community that is now
+ * LIVE would destroy the church's real data with no undo. `isDemo` cannot be
+ * the guard — billing flips it to false in the same transaction that schedules
+ * us. `demoCreatedById` is: set at demo creation, left in place through
+ * conversion, and cleared here as the final write. A community that was never
+ * a demo, or whose demo residue is already gone, is refused. The webhook path
+ * is guarded separately in handleCheckoutCompleted; this is the backstop for
+ * every other way an internalMutation can be reached, including a mistyped
+ * community id in the Convex dashboard.
  */
 export const purgeDemoData = internalMutation({
   args: { communityId: v.id("communities") },
   handler: async (ctx, args) => {
-    const groups = await ctx.db
-      .query("groups")
-      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
-      .collect();
+    const community = await ctx.db.get(args.communityId);
+    if (!community?.demoCreatedById) {
+      console.warn(
+        `[demo] Refusing to purge community ${args.communityId}: no demo residue ` +
+          `(never a demo, or already purged)`,
+      );
+      return { purged: 0 };
+    }
 
     // ========================================================================
     // 1. Content sweep — every row written during the demo, whoever wrote it.
@@ -2637,9 +2688,18 @@ export const purgeDemoData = internalMutation({
       for (const q of children) {
         for (const row of await q.collect()) await ctx.db.delete(row._id);
       }
-      // `attendanceConfirmationTokens` has no by-meeting index, but it is only
-      // written by the post-event confirmation cron — which never runs against
-      // a demo's future events — so there is nothing here to orphan.
+      // Cancel the reminder / attendance jobs this meeting scheduled at
+      // creation, matching the canonical delete path in meetings/index.ts.
+      // They already no-op on a missing meeting; this just avoids leaving
+      // dangling scheduler entries behind.
+      if (meeting.reminderJobId) await ctx.scheduler.cancel(meeting.reminderJobId);
+      if (meeting.attendanceConfirmationJobId) {
+        await ctx.scheduler.cancel(meeting.attendanceConfirmationJobId);
+      }
+      // `attendanceConfirmationTokens` is deliberately NOT swept: it has no
+      // by-meeting index, so it can't be reached from here. Rows only exist
+      // for an event whose date passed during the demo, and they self-expire
+      // within 24h — the worst case is one dead confirmation link.
       await ctx.db.delete(meeting._id);
     }
 
@@ -2652,12 +2712,52 @@ export const purgeDemoData = internalMutation({
       .collect();
     for (const cwe of cwes) await ctx.db.delete(cwe._id);
 
+    // ---- The notification bell ----
+    // Highest-visibility residue if skipped: the feed query reads by_user with
+    // NO community filter, and every payload deep-links to a meeting, message
+    // or prayer this sweep is deleting. Staff would wake up on day one of the
+    // live community to "You've been assigned to Drums" pointing at nothing.
+    const notifications = await ctx.db
+      .query("notifications")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    for (const row of notifications) await ctx.db.delete(row._id);
+
+    const broadcasts = await ctx.db
+      .query("adminBroadcasts")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    for (const row of broadcasts) await ctx.db.delete(row._id);
+
     // ---- Prayer wall ----
     const prayers = await ctx.db
       .query("prayers")
       .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
       .collect();
     for (const prayer of prayers) {
+      // Reactions are keyed by (targetType, targetId) — a plain string id, so
+      // they aren't type-linked and have to be cleared for the prayer AND each
+      // of its follow-ups before those rows go.
+      const followUps = await ctx.db
+        .query("prayerFollowUps")
+        .withIndex("by_prayer", (q) => q.eq("prayerId", prayer._id))
+        .collect();
+      const reactionTargets: Array<["prayer" | "followUp", string]> = [
+        ["prayer", prayer._id],
+        ...followUps.map(
+          (f) => ["followUp", f._id] as ["prayer" | "followUp", string],
+        ),
+      ];
+      for (const [targetType, targetId] of reactionTargets) {
+        const reactions = await ctx.db
+          .query("prayerReactions")
+          .withIndex("by_target", (q) =>
+            q.eq("targetType", targetType).eq("targetId", targetId),
+          )
+          .collect();
+        for (const row of reactions) await ctx.db.delete(row._id);
+      }
+
       const children = [
         ctx.db.query("prayerResponses").withIndex("by_prayer", (q) => q.eq("prayerId", prayer._id)),
         ctx.db.query("prayerFollowUps").withIndex("by_prayer", (q) => q.eq("prayerId", prayer._id)),
@@ -2679,12 +2779,33 @@ export const purgeDemoData = internalMutation({
       .withIndex("by_community_date", (q) => q.eq("communityId", args.communityId))
       .collect();
     for (const plan of plans) {
+      // Task completions hang off the TASK, not the plan, so collect the task
+      // ids before deleting them (howToDocChecks.by_task exists for exactly
+      // this cascade — see its schema comment).
+      const planTasks = await ctx.db
+        .query("eventTasks")
+        .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+        .collect();
+      for (const task of planTasks) {
+        const perTask = [
+          ctx.db.query("eventTaskCompletions").withIndex("by_task", (q) => q.eq("taskId", task._id)),
+          ctx.db.query("sharedTaskCompletions").withIndex("by_task", (q) => q.eq("taskId", task._id)),
+          ctx.db.query("howToDocChecks").withIndex("by_task", (q) => q.eq("taskId", task._id)),
+        ];
+        for (const q of perTask) {
+          for (const row of await q.collect()) await ctx.db.delete(row._id);
+        }
+        await ctx.db.delete(task._id);
+      }
+
       const children = [
         ctx.db.query("neededRoles").withIndex("by_plan", (q) => q.eq("planId", plan._id)),
         ctx.db.query("roleAssignments").withIndex("by_plan", (q) => q.eq("planId", plan._id)),
         ctx.db.query("eventItems").withIndex("by_plan", (q) => q.eq("planId", plan._id)),
-        ctx.db.query("eventTasks").withIndex("by_plan", (q) => q.eq("planId", plan._id)),
         ctx.db.query("eventAvailability").withIndex("by_plan", (q) => q.eq("planId", plan._id)),
+        ctx.db.query("personalServingTasks").withIndex("by_plan_user", (q) => q.eq("planId", plan._id)),
+        ctx.db.query("assignmentRequestLog").withIndex("by_plan", (q) => q.eq("planId", plan._id)),
+        ctx.db.query("sharedTaskCompletions").withIndex("by_plan", (q) => q.eq("planId", plan._id)),
       ];
       for (const q of children) {
         for (const row of await q.collect()) await ctx.db.delete(row._id);
@@ -2706,7 +2827,7 @@ export const purgeDemoData = internalMutation({
       await ctx.db.delete(team._id);
     }
 
-    /** Delete a channel's conversation, leaving the channel row itself. */
+    /** Delete everything hanging off a channel, leaving the channel row itself. */
     const emptyChannel = async (channelId: Id<"chatChannels">) => {
       const messages = await ctx.db
         .query("chatMessages")
@@ -2717,6 +2838,7 @@ export const purgeDemoData = internalMutation({
           ctx.db.query("chatMessageReactions").withIndex("by_message", (q) => q.eq("messageId", message._id)),
           ctx.db.query("chatMessageFlags").withIndex("by_message", (q) => q.eq("messageId", message._id)),
           ctx.db.query("chatPushNotificationQueue").withIndex("by_message", (q) => q.eq("messageId", message._id)),
+          ctx.db.query("chatThreadSubscriptions").withIndex("by_thread", (q) => q.eq("threadId", message._id)),
         ];
         for (const q of attached) {
           for (const row of await q.collect()) await ctx.db.delete(row._id);
@@ -2737,10 +2859,12 @@ export const purgeDemoData = internalMutation({
         await ctx.db.delete(poll._id);
       }
       // Read state and typing indicators describe a conversation that no
-      // longer exists; leaving them would show phantom unread badges.
+      // longer exists; leaving them would show phantom unread badges. Pending
+      // join requests are demo-era asks about a now-empty channel.
       const perChannel = [
         ctx.db.query("chatReadState").withIndex("by_channel", (q) => q.eq("channelId", channelId)),
         ctx.db.query("chatTypingIndicators").withIndex("by_channel", (q) => q.eq("channelId", channelId)),
+        ctx.db.query("channelJoinRequests").withIndex("by_channel_user", (q) => q.eq("channelId", channelId)),
       ];
       for (const q of perChannel) {
         for (const row of await q.collect()) await ctx.db.delete(row._id);
@@ -2800,6 +2924,15 @@ export const purgeDemoData = internalMutation({
           .withIndex("by_groupMember", (q) => q.eq("groupMemberId", row._id))
           .collect();
         for (const f of followupRows) await ctx.db.delete(f._id);
+        // The score doc denormalizes the member's name and avatar and is read
+        // with NO join (memberFollowups.list / listAssignedToMe), so an orphan
+        // renders a deleted placeholder straight into a leader's queue. Every
+        // other membership-delete path in the repo cascades this; so must we.
+        const scoreRows = await ctx.db
+          .query("memberFollowupScores")
+          .withIndex("by_groupMember", (q) => q.eq("groupMemberId", row._id))
+          .collect();
+        for (const sc of scoreRows) await ctx.db.delete(sc._id);
         await ctx.db.delete(row._id);
       }
 
@@ -2833,17 +2966,19 @@ export const purgeDemoData = internalMutation({
         .collect();
       for (const f of authoredFollowups) await ctx.db.delete(f._id);
 
+      // Must run before section 3's memberCount recompute, which counts the
+      // rows left behind here.
       const channelRows = await ctx.db
         .query("chatChannelMembers")
         .withIndex("by_user", (q) => q.eq("userId", user._id))
         .collect();
       for (const row of channelRows) await ctx.db.delete(row._id);
 
-      // The content sweep above already removed every message, RSVP, prayer,
-      // and roster row in this community. Anything still keyed to a seed
-      // member therefore lives OUTSIDE it, which can't happen — seeded
-      // accounts never leave their demo — so there is nothing left to delete
-      // here beyond the account itself.
+      // No per-author deletion of messages, RSVPs, prayers or roster rows is
+      // needed here: every message lives in a channel that is either ad-hoc or
+      // group-owned and both are swept; meetings cascade to their RSVPs and
+      // attendance; plans cascade to roleAssignments and eventAvailability
+      // (both have a required planId); and prayers are swept by community.
       await ctx.db.delete(membership._id);
       purgedUserIds.add(String(user._id));
       await ctx.db.delete(user._id);
@@ -2858,6 +2993,10 @@ export const purgeDemoData = internalMutation({
     // community's real landing page (the same default handleCheckoutCompleted
     // would otherwise create), so /c/[slug] and its join form keep working.
 
+    const groups = await ctx.db
+      .query("groups")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
     for (const group of groups) {
       // Seeded group avatars are placeholder stock photos on a third-party
       // host — drop them so the now-live community isn't left depending on
@@ -2918,28 +3057,37 @@ export const purgeDemoData = internalMutation({
         .collect();
       for (const row of series) await ctx.db.delete(row._id);
 
+      // Tasks and reach-out requests point at members and messages this purge
+      // deletes (tasks.targetMemberId, reachOutRequests.leadersMessageId), and
+      // both render in leader tools.
+      const groupTasks = await ctx.db
+        .query("tasks")
+        .withIndex("by_group", (q) => q.eq("groupId", group._id))
+        .collect();
+      for (const task of groupTasks) {
+        const events = await ctx.db
+          .query("taskEvents")
+          .withIndex("by_task", (q) => q.eq("taskId", task._id))
+          .collect();
+        for (const row of events) await ctx.db.delete(row._id);
+        await ctx.db.delete(task._id);
+      }
+
+      const reachOuts = await ctx.db
+        .query("reachOutRequests")
+        .withIndex("by_group", (q) => q.eq("groupId", group._id))
+        .collect();
+      for (const row of reachOuts) await ctx.db.delete(row._id);
+
       const channels = await ctx.db
         .query("chatChannels")
         .withIndex("by_group", (q) => q.eq("groupId", group._id))
         .collect();
       for (const channel of channels) {
+        const isTourChannel = isDemoTourChannel(channel, group);
+
         await emptyChannel(channel._id);
 
-        const joinRequests = await ctx.db
-          .query("channelJoinRequests")
-          .withIndex("by_channel_user", (q) => q.eq("channelId", channel._id))
-          .collect();
-        for (const row of joinRequests) await ctx.db.delete(row._id);
-
-        // The Getting Started tour is demo-only and removes itself on go-live,
-        // as its bot messages promise. Match it narrowly — the announcement
-        // group's tour channel — so a real "Getting Started" channel a church
-        // happened to create (the slug isn't reserved) is never mistaken for
-        // it and deleted. (Its messages are already gone, so the old
-        // "all messages are bot-authored" check can no longer distinguish
-        // them; the group + slug pair is what identifies the tour.)
-        const isTourChannel =
-          channel.slug === "getting-started" && group.isAnnouncementGroup;
         // An event-chat channel belongs to one event. Every event in the
         // community was just deleted, so keeping the channel would leave a
         // thread hanging off nothing.
@@ -2970,6 +3118,10 @@ export const purgeDemoData = internalMutation({
         });
       }
     }
+
+    // Last write: drops the "still holds demo residue" marker, so this mutation
+    // can never run against this community again.
+    await ctx.db.patch(args.communityId, { demoCreatedById: undefined });
 
     console.log(
       `[demo] Purged ${purged} placeholder members and all demo content from community ${args.communityId}`,

--- a/apps/convex/functions/demo.ts
+++ b/apps/convex/functions/demo.ts
@@ -13,9 +13,12 @@
  * This is the front door for creating a community: churches start in demo
  * mode and go live from inside the app by adding payment ($1/month per active
  * member — see functions/memberActivity.ts and ee/billing.convertDemoToLive).
- * Conversion flips isDemo off and purges the seeded placeholder members plus
- * demo-only scaffolding (purgeDemoSeedUsers) while keeping groups, branding,
- * and real accounts.
+ * Conversion flips isDemo off, drops the "demo-" prefix from the community's
+ * public slug, and hands over a clean community: purgeDemoData keeps the
+ * structure the church built (groups, channels, group types, branding, staff
+ * accounts) and deletes every row written during the demo — seeded members,
+ * messages, events, prayers, and service plans, the church's own test content
+ * included.
  *
  * Collaboration: the creator gets a demo code (the community slug). Anyone who
  * joins with the code becomes a community admin too, so a whole staff team can
@@ -115,10 +118,11 @@ function demoMemberName(i: number): { firstName: string; lastName: string } {
 
 // Demo-only external imagery so the app doesn't feel like an empty shell of
 // initials (getMediaUrl passes absolute https URLs through untouched).
-// Portraits live on seeded member rows (deleted on go-live); stock covers/
-// avatars live on groups/events that SURVIVE go-live, so purgeDemoSeedUsers
-// strips them (via isDemoStockUrl) rather than leaving a live community
-// depending on these third-party hosts in production.
+// Portraits live on seeded member rows and stock covers on seeded events —
+// both deleted outright on go-live. Stock avatars also land on GROUPS, which
+// survive go-live as structure, so purgeDemoData strips those (via
+// isDemoStockUrl) rather than leaving a live community depending on these
+// third-party hosts in production.
 const DEMO_PORTRAIT_HOST = "https://randomuser.me/api/portraits/";
 const DEMO_STOCK_HOST = "https://picsum.photos/";
 
@@ -374,7 +378,7 @@ const GETTING_STARTED_MESSAGES: string[] = [
     (m, i) => `${MISSION_NUMBER_EMOJI[i]} ${m.instruction}`,
   ),
   "Any time, head to Admin → Settings to change your name, logo, and brand color — the whole app re-themes instantly. ✨",
-  "When you're ready for the real thing, tap Go live on the banner — your groups, branding, and teammates stay; these demo members and I clean ourselves up. 🎉",
+  "When you're ready for the real thing, tap Go live on the banner — your groups, channels, branding, and teammates stay. Everything written in here clears out: these demo members, all these conversations and events, and anything you tried out yourself. Play freely — nothing you do here follows you into the real thing. 🎉",
 ];
 
 const PRAYER_REQUESTS = [
@@ -934,13 +938,16 @@ async function createDemoMeeting(
   });
 }
 
+/** Prefix that marks a community slug as a demo (and doubles as its code). */
+const DEMO_SLUG_PREFIX = "demo-";
+
 /**
  * Generate a unique demo slug like "demo-grace-fellowship". The slug doubles
  * as the shareable demo code, so keep it readable; add a random suffix only on
  * collision.
  */
 async function uniqueDemoSlug(ctx: MutationCtx, name: string): Promise<string> {
-  const base = `demo-${nameToSlug(name) || "church"}`;
+  const base = `${DEMO_SLUG_PREFIX}${nameToSlug(name) || "church"}`;
   const existing = await ctx.db
     .query("communities")
     .withIndex("by_slug", (q) => q.eq("slug", base))
@@ -955,6 +962,41 @@ async function uniqueDemoSlug(ctx: MutationCtx, name: string): Promise<string> {
       .withIndex("by_slug", (q) => q.eq("slug", candidate))
       .first();
     if (!taken) return candidate;
+  }
+}
+
+/**
+ * The slug a converting demo should carry into production, with the "demo-"
+ * prefix dropped.
+ *
+ * The slug is the community's PUBLIC address: `togather.nyc/<slug>` resolves to
+ * the landing page a church texts to visitors, and go-live is what makes that
+ * page public. Left alone, every paying church would advertise itself at
+ * `togather.nyc/demo-grace-fellowship` forever — there is no admin-facing slug
+ * rename to undo it.
+ *
+ * Returns null when there's nothing to do (already prefix-free, or the church
+ * renamed the slug itself). Falls back to a suffixed variant if the clean slug
+ * is taken, so conversion can never fail on a collision.
+ */
+export async function liveSlugForDemo(
+  ctx: MutationCtx,
+  currentSlug: string | undefined,
+): Promise<string | null> {
+  if (!currentSlug?.startsWith(DEMO_SLUG_PREFIX)) return null;
+  const base = currentSlug.slice(DEMO_SLUG_PREFIX.length);
+  if (!base) return null;
+
+  const isFree = async (candidate: string) =>
+    !(await ctx.db
+      .query("communities")
+      .withIndex("by_slug", (q) => q.eq("slug", candidate))
+      .first());
+
+  if (await isFree(base)) return base;
+  for (;;) {
+    const candidate = `${base}-${generateShortId().slice(-4)}`;
+    if (await isFree(candidate)) return candidate;
   }
 }
 
@@ -1247,7 +1289,7 @@ export const createDemoCommunity = mutation({
         firstName: person.firstName,
         lastName: person.lastName,
         isPlaceholder: true, // never a real login; see users.isPlaceholder
-        isDemoSeed: true, // purged on go-live; see purgeDemoSeedUsers
+        isDemoSeed: true, // purged on go-live; see purgeDemoData
         isActive: true,
         profilePhoto: photo,
         searchText: buildSearchText(person),
@@ -2050,9 +2092,10 @@ export const createDemoCommunity = mutation({
  * from that activity — so Admin → People shows a realistic spread immediately
  * and it exactly matches what the daily score cron recomputes.
  *
- * The past gatherings are marked isDemoActivitySeed so purgeDemoSeedUsers
- * deletes them on go-live; otherwise their empty past sessions would drag down
- * real members' attendance scores for up to 60 days.
+ * The past gatherings are marked isDemoActivitySeed to separate them from the
+ * demo's normal upcoming events in queries; purgeDemoData deletes both kinds
+ * on go-live, so their empty past sessions can't drag down real members'
+ * attendance scores for the 60 days that follow.
  */
 export const seedMemberActivity = internalMutation({
   args: {
@@ -2532,46 +2575,122 @@ export const getDemoStatus = query({
 // ============================================================================
 
 /**
- * Remove the seeded placeholder members (and everything they authored) plus the
- * demo-only scaffolding (rostering, the giving link) after a demo converts to a
- * live community. Groups, channels, branding, settings, events, and the real
- * staff accounts all stay — only the fake people and demo props go.
+ * Hand a demo community over to the church as a clean, live community.
+ *
+ * Going live is a HAND-OVER, not a merge. The church keeps everything it
+ * BUILT — the community row and its branding, group types, groups, channels,
+ * serving-team structure, the landing page, and every real staff account with
+ * its roles. It loses everything that was WRITTEN while the community was a
+ * demo: the seeded placeholder members, every message, event, RSVP, prayer,
+ * and service plan, and the demo-only props (the Getting Started tour, the
+ * placeholder giving link, the stock photography).
+ *
+ * That content sweep is deliberately author-agnostic. Deleting only what the
+ * placeholder members authored is what used to leave a converted church
+ * staring at eleven events it never scheduled: `createDemoMeeting` stamps the
+ * REAL creator's id on every seeded event, so nothing keyed to a placeholder
+ * user ever reached them. It also swept up the church's own throwaway test
+ * content — the "testing testing 123" the tour asks staff to send — straight
+ * into the feed their congregation is about to be invited into. Both classes
+ * are demo-era scratch work, so both go.
+ *
+ * The trade this makes: a church that scheduled a REAL event or posted a REAL
+ * prayer request during the demo loses it, with no undo. That is the accepted
+ * cost of a guaranteed-clean hand-over, and the Go Live screen says so before
+ * anyone pays.
+ *
+ * Structure vs. content is the line: a container or a setting is structure and
+ * stays; anything with a position in a feed or on a calendar is content and
+ * goes. So a channel the staff created survives (emptied), while the messages
+ * inside it do not.
  *
  * Scheduled by ee/billing.handleCheckoutCompleted when the demo-conversion
- * checkout finishes. Idempotent: placeholders and demo-flagged rows are deleted
- * as they're found, so a webhook retry that schedules it twice finds nothing
- * the second time.
+ * checkout finishes. Idempotent: rows are deleted as they're found, so a
+ * webhook retry that schedules it twice finds nothing the second time.
  */
-export const purgeDemoSeedUsers = internalMutation({
+export const purgeDemoData = internalMutation({
   args: { communityId: v.id("communities") },
   handler: async (ctx, args) => {
-    const memberships = await ctx.db
-      .query("userCommunities")
+    const groups = await ctx.db
+      .query("groups")
       .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
       .collect();
 
-    // ---- Rostering scaffolding (independent of any single user) ----
-    // Seeded event plans + their children.
-    const demoPlans = (
-      await ctx.db
-        .query("eventPlans")
-        .withIndex("by_community_date", (q) => q.eq("communityId", args.communityId))
-        .collect()
-    ).filter((p) => p.isDemoSeed);
-    for (const plan of demoPlans) {
-      const kids = [
+    // ========================================================================
+    // 1. Content sweep — every row written during the demo, whoever wrote it.
+    // ========================================================================
+
+    // ---- Events and everything hanging off them ----
+    const meetings = await ctx.db
+      .query("meetings")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    for (const meeting of meetings) {
+      const children = [
+        ctx.db.query("meetingRsvps").withIndex("by_meeting", (q) => q.eq("meetingId", meeting._id)),
+        ctx.db.query("meetingAttendances").withIndex("by_meeting", (q) => q.eq("meetingId", meeting._id)),
+        ctx.db.query("meetingGuests").withIndex("by_meeting", (q) => q.eq("meetingId", meeting._id)),
+        ctx.db.query("eventInvites").withIndex("by_meeting", (q) => q.eq("meetingId", meeting._id)),
+        ctx.db.query("eventBlasts").withIndex("by_meeting", (q) => q.eq("meetingId", meeting._id)),
+        ctx.db.query("meetingReports").withIndex("by_meeting", (q) => q.eq("meetingId", meeting._id)),
+      ];
+      for (const q of children) {
+        for (const row of await q.collect()) await ctx.db.delete(row._id);
+      }
+      // `attendanceConfirmationTokens` has no by-meeting index, but it is only
+      // written by the post-event confirmation cron — which never runs against
+      // a demo's future events — so there is nothing here to orphan.
+      await ctx.db.delete(meeting._id);
+    }
+
+    // Community-wide events. Indexed by scheduledAt rather than status so a
+    // cancelled one is swept up too — the seeded "Serve Day" is "scheduled",
+    // but a church may have cancelled one while exploring.
+    const cwes = await ctx.db
+      .query("communityWideEvents")
+      .withIndex("by_scheduledAt", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    for (const cwe of cwes) await ctx.db.delete(cwe._id);
+
+    // ---- Prayer wall ----
+    const prayers = await ctx.db
+      .query("prayers")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    for (const prayer of prayers) {
+      const children = [
+        ctx.db.query("prayerResponses").withIndex("by_prayer", (q) => q.eq("prayerId", prayer._id)),
+        ctx.db.query("prayerFollowUps").withIndex("by_prayer", (q) => q.eq("prayerId", prayer._id)),
+        ctx.db.query("prayerReports").withIndex("by_prayer", (q) => q.eq("prayerId", prayer._id)),
+        ctx.db.query("prayerNotificationEvents").withIndex("by_prayer_type", (q) => q.eq("prayerId", prayer._id)),
+      ];
+      for (const q of children) {
+        for (const row of await q.collect()) await ctx.db.delete(row._id);
+      }
+      await ctx.db.delete(prayer._id);
+    }
+
+    // ---- Service planning ----
+    // Plans are content (a specific Sunday) and all go. Serving TEAMS are
+    // structure (a roster of roles), so only the ones this module seeded are
+    // removed — a team the church built itself is theirs to keep.
+    const plans = await ctx.db
+      .query("eventPlans")
+      .withIndex("by_community_date", (q) => q.eq("communityId", args.communityId))
+      .collect();
+    for (const plan of plans) {
+      const children = [
         ctx.db.query("neededRoles").withIndex("by_plan", (q) => q.eq("planId", plan._id)),
         ctx.db.query("roleAssignments").withIndex("by_plan", (q) => q.eq("planId", plan._id)),
         ctx.db.query("eventItems").withIndex("by_plan", (q) => q.eq("planId", plan._id)),
         ctx.db.query("eventTasks").withIndex("by_plan", (q) => q.eq("planId", plan._id)),
         ctx.db.query("eventAvailability").withIndex("by_plan", (q) => q.eq("planId", plan._id)),
       ];
-      for (const q of kids) {
+      for (const q of children) {
         for (const row of await q.collect()) await ctx.db.delete(row._id);
       }
       await ctx.db.delete(plan._id);
     }
-    // Seeded serving teams + their roles.
     const demoTeams = (
       await ctx.db
         .query("teams")
@@ -2587,8 +2706,50 @@ export const purgeDemoSeedUsers = internalMutation({
       await ctx.db.delete(team._id);
     }
 
-    // Seeded DMs/group DMs involve demo members — delete the whole ad-hoc
-    // channel (members + messages) rather than leaving one-sided orphans.
+    /** Delete a channel's conversation, leaving the channel row itself. */
+    const emptyChannel = async (channelId: Id<"chatChannels">) => {
+      const messages = await ctx.db
+        .query("chatMessages")
+        .withIndex("by_channel", (q) => q.eq("channelId", channelId))
+        .collect();
+      for (const message of messages) {
+        const attached = [
+          ctx.db.query("chatMessageReactions").withIndex("by_message", (q) => q.eq("messageId", message._id)),
+          ctx.db.query("chatMessageFlags").withIndex("by_message", (q) => q.eq("messageId", message._id)),
+          ctx.db.query("chatPushNotificationQueue").withIndex("by_message", (q) => q.eq("messageId", message._id)),
+        ];
+        for (const q of attached) {
+          for (const row of await q.collect()) await ctx.db.delete(row._id);
+        }
+        await ctx.db.delete(message._id);
+      }
+      // Polls are keyed to the channel, and their votes to the poll.
+      const polls = await ctx.db
+        .query("polls")
+        .withIndex("by_channel", (q) => q.eq("channelId", channelId))
+        .collect();
+      for (const poll of polls) {
+        const votes = await ctx.db
+          .query("pollVotes")
+          .withIndex("by_poll", (q) => q.eq("pollId", poll._id))
+          .collect();
+        for (const vote of votes) await ctx.db.delete(vote._id);
+        await ctx.db.delete(poll._id);
+      }
+      // Read state and typing indicators describe a conversation that no
+      // longer exists; leaving them would show phantom unread badges.
+      const perChannel = [
+        ctx.db.query("chatReadState").withIndex("by_channel", (q) => q.eq("channelId", channelId)),
+        ctx.db.query("chatTypingIndicators").withIndex("by_channel", (q) => q.eq("channelId", channelId)),
+      ];
+      for (const q of perChannel) {
+        for (const row of await q.collect()) await ctx.db.delete(row._id);
+      }
+    };
+
+    // ---- DMs and group DMs ----
+    // Ad-hoc channels ARE the conversation — there is no structure to keep, so
+    // the whole channel goes, including staff-to-staff demo chatter.
     const adHocChannels = await ctx.db
       .query("chatChannels")
       .withIndex("by_community_isAdHoc", (q) =>
@@ -2596,32 +2757,27 @@ export const purgeDemoSeedUsers = internalMutation({
       )
       .collect();
     for (const channel of adHocChannels) {
+      await emptyChannel(channel._id);
       const channelMembers = await ctx.db
         .query("chatChannelMembers")
         .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
         .collect();
-      let involvesSeedMember = false;
-      for (const member of channelMembers) {
-        const user = await ctx.db.get(member.userId);
-        if (user?.isDemoSeed) {
-          involvesSeedMember = true;
-          break;
-        }
-      }
-      if (!involvesSeedMember) continue; // real-user DMs survive go-live
-
       for (const member of channelMembers) await ctx.db.delete(member._id);
-      const channelMessages = await ctx.db
-        .query("chatMessages")
-        .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
-        .collect();
-      for (const message of channelMessages) await ctx.db.delete(message._id);
       await ctx.db.delete(channel._id);
     }
 
+    // ========================================================================
+    // 2. Seeded placeholder accounts.
+    // ========================================================================
+
+    const memberships = await ctx.db
+      .query("userCommunities")
+      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
+      .collect();
+
     let purged = 0;
-    // Track which users we delete so we can scrub only THEIR entries from
-    // shared caches (e.g. pcoServingCounts) without touching real data.
+    // Track who we delete so we can scrub only THEIR entries from shared
+    // caches (e.g. pcoServingCounts) without touching real data.
     const purgedUserIds = new Set<string>();
     for (const membership of memberships) {
       const user = await ctx.db.get(membership.userId);
@@ -2683,55 +2839,25 @@ export const purgeDemoSeedUsers = internalMutation({
         .collect();
       for (const row of channelRows) await ctx.db.delete(row._id);
 
-      const messages = await ctx.db
-        .query("chatMessages")
-        .withIndex("by_sender", (q) => q.eq("senderId", user._id))
-        .collect();
-      for (const row of messages) await ctx.db.delete(row._id);
-
-      const rsvps = await ctx.db
-        .query("meetingRsvps")
-        .withIndex("by_user", (q) => q.eq("userId", user._id))
-        .collect();
-      for (const row of rsvps) await ctx.db.delete(row._id);
-
-      const prayers = await ctx.db
-        .query("prayers")
-        .withIndex("by_author", (q) => q.eq("authorUserId", user._id))
-        .collect();
-      for (const row of prayers) await ctx.db.delete(row._id);
-
-      // Belt-and-suspenders: any rostering rows keyed to this seed member.
-      // (The plan/team cascade above already removed the seeded ones, but a
-      // member could linger on a plan the church kept.)
-      const seedAssignments = await ctx.db
-        .query("roleAssignments")
-        .withIndex("by_user", (q) => q.eq("userId", user._id))
-        .collect();
-      for (const row of seedAssignments) await ctx.db.delete(row._id);
-
-      const seedAvailability = await ctx.db
-        .query("eventAvailability")
-        .withIndex("by_user", (q) => q.eq("userId", user._id))
-        .collect();
-      for (const row of seedAvailability) await ctx.db.delete(row._id);
-
+      // The content sweep above already removed every message, RSVP, prayer,
+      // and roster row in this community. Anything still keyed to a seed
+      // member therefore lives OUTSIDE it, which can't happen — seeded
+      // accounts never leave their demo — so there is nothing left to delete
+      // here beyond the account itself.
       await ctx.db.delete(membership._id);
       purgedUserIds.add(String(user._id));
       await ctx.db.delete(user._id);
       purged++;
     }
 
+    // ========================================================================
+    // 3. Demo props, and repair of the state the sweep invalidated.
+    // ========================================================================
+
     // The seeded landing page SURVIVES go-live — it becomes the live
     // community's real landing page (the same default handleCheckoutCompleted
     // would otherwise create), so /c/[slug] and its join form keep working.
 
-    // Recompute the denormalized channel state the purge invalidated, drop
-    // demo-only props (stock avatars, giving link, tour channel).
-    const groups = await ctx.db
-      .query("groups")
-      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
-      .collect();
     for (const group of groups) {
       // Seeded group avatars are placeholder stock photos on a third-party
       // host — drop them so the now-live community isn't left depending on
@@ -2784,94 +2910,69 @@ export const purgeDemoSeedUsers = internalMutation({
         }
       }
 
+      // Recurring-event definitions are demo content too — a live community
+      // should not inherit a series that regenerates seeded gatherings.
+      const series = await ctx.db
+        .query("eventSeries")
+        .withIndex("by_group", (q) => q.eq("groupId", group._id))
+        .collect();
+      for (const row of series) await ctx.db.delete(row._id);
+
       const channels = await ctx.db
         .query("chatChannels")
         .withIndex("by_group", (q) => q.eq("groupId", group._id))
         .collect();
       for (const channel of channels) {
+        await emptyChannel(channel._id);
+
+        const joinRequests = await ctx.db
+          .query("channelJoinRequests")
+          .withIndex("by_channel_user", (q) => q.eq("channelId", channel._id))
+          .collect();
+        for (const row of joinRequests) await ctx.db.delete(row._id);
+
         // The Getting Started tour is demo-only and removes itself on go-live,
         // as its bot messages promise. Match it narrowly — the announcement
-        // group's tour channel whose messages are ALL bot-authored — so a
-        // real "Getting Started" channel a church happened to create (the slug
-        // isn't reserved) is never mistaken for it and deleted.
-        if (channel.slug === "getting-started" && group.isAnnouncementGroup) {
-          const tourMessages = await ctx.db
-            .query("chatMessages")
+        // group's tour channel — so a real "Getting Started" channel a church
+        // happened to create (the slug isn't reserved) is never mistaken for
+        // it and deleted. (Its messages are already gone, so the old
+        // "all messages are bot-authored" check can no longer distinguish
+        // them; the group + slug pair is what identifies the tour.)
+        const isTourChannel =
+          channel.slug === "getting-started" && group.isAnnouncementGroup;
+        // An event-chat channel belongs to one event. Every event in the
+        // community was just deleted, so keeping the channel would leave a
+        // thread hanging off nothing.
+        const isOrphanedEventChat = channel.meetingId !== undefined;
+
+        if (isTourChannel || isOrphanedEventChat) {
+          const channelMembers = await ctx.db
+            .query("chatChannelMembers")
             .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
             .collect();
-          const allBotAuthored = tourMessages.every(
-            (m) => m.senderId === undefined,
-          );
-          if (allBotAuthored) {
-            const tourMembers = await ctx.db
-              .query("chatChannelMembers")
-              .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
-              .collect();
-            for (const member of tourMembers) await ctx.db.delete(member._id);
-            for (const message of tourMessages) await ctx.db.delete(message._id);
-            await ctx.db.delete(channel._id);
-            continue;
-          }
+          for (const member of channelMembers) await ctx.db.delete(member._id);
+          await ctx.db.delete(channel._id);
+          continue;
         }
 
+        // Every conversation in the community is gone, so the denormalized
+        // inbox preview must be cleared outright rather than recomputed.
         const remaining = await ctx.db
           .query("chatChannelMembers")
           .withIndex("by_channel", (q) => q.eq("channelId", channel._id))
           .collect();
-        const lastMessage = await ctx.db
-          .query("chatMessages")
-          .withIndex("by_channel_createdAt", (q) => q.eq("channelId", channel._id))
-          .order("desc")
-          .first();
         await ctx.db.patch(channel._id, {
           memberCount: remaining.filter((m) => m.leftAt === undefined).length,
-          lastMessageAt: lastMessage?.createdAt,
-          lastMessagePreview: lastMessage?.content.slice(0, 100),
-          lastMessageSenderId: lastMessage?.senderId,
-          lastMessageSenderName: lastMessage?.senderName,
+          lastMessageAt: undefined,
+          lastMessagePreview: undefined,
+          lastMessageSenderId: undefined,
+          lastMessageSenderName: undefined,
         });
       }
     }
 
-    // Strip placeholder stock covers from the events that survive go-live
-    // (meetings + the community-wide event are authored by the real creator,
-    // so they aren't deleted with the seed members).
-    const survivingMeetings = await ctx.db
-      .query("meetings")
-      .withIndex("by_community", (q) => q.eq("communityId", args.communityId))
-      .collect();
-    for (const meeting of survivingMeetings) {
-      // The PAST attendance-history gatherings (isDemoActivitySeed) are pure
-      // scoring scaffolding — delete them and their attendance rows. Left in
-      // place, their empty past sessions would depress real members' attendance
-      // scores for up to 60 days after going live.
-      if (meeting.isDemoActivitySeed) {
-        const attendances = await ctx.db
-          .query("meetingAttendances")
-          .withIndex("by_meeting", (q) => q.eq("meetingId", meeting._id))
-          .collect();
-        for (const a of attendances) await ctx.db.delete(a._id);
-        await ctx.db.delete(meeting._id);
-        continue;
-      }
-      if (isDemoStockUrl(meeting.coverImage)) {
-        await ctx.db.patch(meeting._id, { coverImage: undefined });
-      }
-    }
-    const cwes = await ctx.db
-      .query("communityWideEvents")
-      .withIndex("by_community_status", (q) =>
-        q.eq("communityId", args.communityId).eq("status", "scheduled"),
-      )
-      .collect();
-    for (const cwe of cwes) {
-      if (isDemoStockUrl(cwe.coverImage)) {
-        await ctx.db.patch(cwe._id, { coverImage: undefined });
-      }
-    }
-
     console.log(
-      `[demo] Purged ${purged} placeholder members from community ${args.communityId}`,
+      `[demo] Purged ${purged} placeholder members and all demo content from community ${args.communityId}`,
     );
     return { purged };
   },

--- a/apps/convex/functions/ee/billing.ts
+++ b/apps/convex/functions/ee/billing.ts
@@ -36,6 +36,7 @@ import { DOMAIN_CONFIG } from "@togather/shared/config";
 import { getNextFirstOfMonth } from "../../lib/utils";
 import { addUserToAnnouncementGroup } from "../communities";
 import { countBillableActiveUsers } from "../memberActivity";
+import { liveSlugForDemo } from "../demo";
 import { notifyCommunityAdmins } from "../../lib/notifications/send";
 
 /** Per-active-user pricing: $1/month per billable active member. Fee-free. */
@@ -772,6 +773,10 @@ export const handleCheckoutCompleted = internalMutation({
         await countBillableActiveUsers(ctx, communityId),
       );
 
+      // Going live makes /c/<slug> public, so the "demo-" prefix has to come
+      // off before anyone shares the link. See demo.liveSlugForDemo.
+      const liveSlug = await liveSlugForDemo(ctx, existing?.slug);
+
       await ctx.db.patch(communityId, {
         isDemo: false,
         demoCreatedById: undefined,
@@ -781,6 +786,15 @@ export const handleCheckoutCompleted = internalMutation({
         billingModel: "per_active_user",
         subscriptionPriceMonthly: billableActiveUsers, // $1 × active members
         isPublic: true,
+        ...(liveSlug
+          ? {
+              slug: liveSlug,
+              // searchText embeds the slug, so it has to move with it.
+              searchText: `${existing?.name ?? ""} ${liveSlug}`
+                .trim()
+                .toLowerCase(),
+            }
+          : {}),
         updatedAt: now,
       });
 
@@ -810,7 +824,7 @@ export const handleCheckoutCompleted = internalMutation({
 
       await ctx.scheduler.runAfter(
         0,
-        internal.functions.demo.purgeDemoSeedUsers,
+        internal.functions.demo.purgeDemoData,
         { communityId },
       );
       return;

--- a/apps/convex/functions/ee/billing.ts
+++ b/apps/convex/functions/ee/billing.ts
@@ -737,18 +737,34 @@ export const handleCheckoutCompleted = internalMutation({
 
     if (args.demoConversion) {
       // Demo-conversion flow — the community and its admins already exist;
-      // leave demo mode, switch to per-active-user billing, and purge the
-      // seeded placeholder members (scheduled so a large purge can't fail the
-      // webhook transaction).
+      // leave demo mode, take the "demo-" prefix off the now-public slug,
+      // switch to per-active-user billing, and purge every trace of the demo
+      // (scheduled so a large purge can't fail the webhook transaction).
+
+      const existing = await ctx.db.get(communityId);
+
+      // Redelivery guard. Stripe is at-least-once, and support can re-send an
+      // event from the dashboard weeks later, so this handler MUST NOT re-run
+      // the conversion. It used to be safe to fall through — the old purge
+      // only deleted rows flagged as demo seed, which were already gone — but
+      // purgeDemoData now wipes ALL content in the community, so a second run
+      // would delete the live church's real events, prayers and messages.
+      // The patch below and the purge schedule commit in one transaction, so
+      // isDemo === false proves the first conversion completed in full.
+      if (!existing?.isDemo) {
+        console.warn(
+          `[billing] Ignoring repeat demo-conversion checkout for community ${communityId} ` +
+            `(already live; subscription ${args.stripeSubscriptionId})`,
+        );
+        return;
+      }
 
       // Race guard: with multiple co-admins in a demo, two "Go live" checkouts
       // can both be created before either completes (getDemoConversionInfo
       // only rejects once a subscription is recorded). First completion wins;
       // any later completion for a DIFFERENT subscription is a duplicate that
       // would silently double-bill the church — cancel it instead of letting
-      // it overwrite the tracked subscription. Same-id retries (Stripe is
-      // at-least-once) fall through and re-apply idempotently.
-      const existing = await ctx.db.get(communityId);
+      // it overwrite the tracked subscription.
       if (
         existing?.stripeSubscriptionId &&
         existing.stripeSubscriptionId !== args.stripeSubscriptionId
@@ -779,7 +795,10 @@ export const handleCheckoutCompleted = internalMutation({
 
       await ctx.db.patch(communityId, {
         isDemo: false,
-        demoCreatedById: undefined,
+        // demoCreatedById is deliberately left set: it is the marker that says
+        // "this community still holds demo residue", and purgeDemoData clears
+        // it as the last thing it does. See the guard at the top of that
+        // mutation.
         stripeCustomerId: args.stripeCustomerId,
         stripeSubscriptionId: args.stripeSubscriptionId,
         subscriptionStatus: "active",

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -655,7 +655,7 @@ export default defineSchema({
     updatedAt: v.number(),
     createdBy: v.id("users"),
     // True only for the placeholder "Partner with us" giving link seeded into a
-    // demo community (functions/demo.ts). Removed on go-live by purgeDemoSeedUsers.
+    // demo community (functions/demo.ts). Removed on go-live by purgeDemoData.
     isDemoSeed: v.optional(v.boolean()),
   }).index("by_group", ["groupId"]),
 
@@ -830,10 +830,10 @@ export default defineSchema({
     // without a wall-clock heuristic.
     isDemoSeed: v.optional(v.boolean()),
     // True only for the PAST "attendance-history" meetings the demo seeds to
-    // give the 100 placeholder members realistic health scores. Unlike normal
-    // demo events (which survive go-live), these are deleted by
-    // purgeDemoSeedUsers — otherwise their empty past sessions would depress
-    // real members' attendance scores for up to 60 days after going live.
+    // give the 100 placeholder members realistic health scores. Separates them
+    // from the demo's normal upcoming events in queries and admin views; both
+    // kinds are deleted on go-live (purgeDemoData wipes every meeting in the
+    // community), so this flag is no longer what decides their fate.
     isDemoActivitySeed: v.optional(v.boolean()),
   })
     .index("by_legacyId", ["legacyId"])
@@ -2828,7 +2828,7 @@ export default defineSchema({
     createdById: v.id("users"),
     updatedAt: v.number(),
     // True only for serving teams seeded into a demo community
-    // (functions/demo.ts). Removed on go-live by purgeDemoSeedUsers.
+    // (functions/demo.ts). Removed on go-live by purgeDemoData.
     isDemoSeed: v.optional(v.boolean()),
   })
     .index("by_group", ["groupId"])
@@ -2940,7 +2940,7 @@ export default defineSchema({
     createdById: v.id("users"),
     updatedAt: v.number(),
     // True only for event plans seeded into a demo community
-    // (functions/demo.ts). Removed on go-live by purgeDemoSeedUsers.
+    // (functions/demo.ts). Removed on go-live by purgeDemoData.
     isDemoSeed: v.optional(v.boolean()),
   })
     .index("by_group", ["groupId"])
@@ -2985,7 +2985,7 @@ export default defineSchema({
     pcoAssignmentId: v.optional(v.string()),
     // True only for role assignments seeded into a demo community
     // (functions/demo.ts). Lets getDemoProgress tell a seeded assignment from
-    // one the church created; removed on go-live by purgeDemoSeedUsers.
+    // one the church created; removed on go-live by purgeDemoData.
     isDemoSeed: v.optional(v.boolean()),
   })
     .index("by_plan", ["planId"])

--- a/apps/convex/schema.ts
+++ b/apps/convex/schema.ts
@@ -1699,6 +1699,13 @@ export default defineSchema({
     communityId: v.optional(v.id("communities")),
     /** Convenience flag: true for ad-hoc dm/group_dm channels. */
     isAdHoc: v.optional(v.boolean()),
+    /**
+     * True only for the "🎓 Getting Started" tour channel seeded into a demo
+     * community (functions/demo.ts). Deleted on go-live by purgeDemoData —
+     * the flag is what identifies the tour, so a channel a church happened to
+     * create with the same slug is never mistaken for it.
+     */
+    isDemoSeed: v.optional(v.boolean()),
     /** For 1:1 DMs: deterministic key for dedup, sorted "userIdA::userIdB". */
     dmPairKey: v.optional(v.string()),
     slug: v.optional(v.string()), // URL-friendly, unique per group, immutable (optional for migration)

--- a/apps/mobile/features/onboarding/components/GoLiveScreen.tsx
+++ b/apps/mobile/features/onboarding/components/GoLiveScreen.tsx
@@ -8,9 +8,15 @@
  * "Active Members" card). It is entirely automatic — there is no manual
  * override.
  * The screen shows the current billable count and starts a Stripe checkout
- * (functions/ee/billing.convertDemoToLive). When the webhook confirms
- * payment, the community leaves demo mode and its 100 seeded demo members
- * are removed — groups, branding, settings, and staff accounts stay.
+ * (functions/ee/billing.convertDemoToLive). When the webhook confirms payment,
+ * the community leaves demo mode, drops the "demo-" prefix from its public URL,
+ * and everything written during the demo is deleted — seeded members, chats,
+ * events, prayers, AND the church's own test content (functions/demo.purgeDemoData).
+ * Groups, channels, branding, settings, and staff accounts stay.
+ *
+ * That wipe is irreversible, so this screen states it plainly BEFORE checkout:
+ * a church that scheduled a real event in here would otherwise lose it without
+ * warning.
  */
 import { useState } from "react";
 import {
@@ -152,8 +158,8 @@ export function GoLiveScreen() {
                 {community?.name ?? "Your community"} is live!
               </Text>
               <Text style={[styles.message, { color: colors.textSecondary }]}>
-                Demo mode is off and the seeded demo members have been removed.
-                Time to invite your community.
+                Demo mode is off, the demo data is cleared, and your public link
+                has dropped its "demo-" prefix. Time to invite your community.
               </Text>
             </View>
           ) : (
@@ -190,10 +196,38 @@ export function GoLiveScreen() {
               </Text>
               <Text style={[styles.message, { color: colors.textSecondary }]}>
                 Going live keeps everything you've set up — your name, branding,
-                groups, and the teammates you've invited — and removes the {" "}
-                seeded demo members and their conversations, so you start clean
-                with your real community.
+                groups, channels, and the teammates you've invited — and clears
+                everything written while you were exploring, so your community
+                arrives to a clean slate.
               </Text>
+
+              {/* The wipe is irreversible and includes the church's OWN test
+                  content, so it is spelled out before the pay button, not in a
+                  footnote after it. */}
+              <View
+                style={[
+                  styles.notice,
+                  {
+                    backgroundColor: colors.surfaceSecondary,
+                    borderColor: colors.borderLight,
+                    alignItems: "flex-start",
+                  },
+                ]}
+              >
+                <Ionicons
+                  name="sparkles-outline"
+                  size={18}
+                  color={colors.textSecondary}
+                  style={{ marginTop: 1 }}
+                />
+                <Text style={[styles.noticeText, { color: colors.textSecondary }]}>
+                  The 100 demo members, every demo conversation and event, and
+                  anything you tried out yourself will be deleted — including
+                  test messages, events and prayer requests you created. This
+                  can't be undone, so if there's something in here you want to
+                  keep, write it down first.
+                </Text>
+              </View>
 
               {/* Pricing headline */}
               <View

--- a/apps/mobile/features/onboarding/components/GoLiveScreen.tsx
+++ b/apps/mobile/features/onboarding/components/GoLiveScreen.tsx
@@ -208,24 +208,26 @@ export function GoLiveScreen() {
                 style={[
                   styles.notice,
                   {
-                    backgroundColor: colors.surfaceSecondary,
-                    borderColor: colors.borderLight,
+                    backgroundColor: colors.warning + "14",
+                    borderColor: colors.warning + "40",
                     alignItems: "flex-start",
                   },
                 ]}
               >
                 <Ionicons
-                  name="sparkles-outline"
+                  name="alert-circle"
                   size={18}
-                  color={colors.textSecondary}
+                  color={colors.warning}
                   style={{ marginTop: 1 }}
                 />
                 <Text style={[styles.noticeText, { color: colors.textSecondary }]}>
                   The 100 demo members, every demo conversation and event, and
                   anything you tried out yourself will be deleted — including
-                  test messages, events and prayer requests you created. This
-                  can't be undone, so if there's something in here you want to
-                  keep, write it down first.
+                  test messages, events, prayer requests and service plans you
+                  created. Your public link also changes: it drops the "demo-"
+                  prefix, so any demo link you've already shared will stop
+                  working. None of this can be undone, so if there's something
+                  in here you want to keep, write it down first.
                 </Text>
               </View>
 

--- a/apps/web/src/pages/guides/CreateCommunity.tsx
+++ b/apps/web/src/pages/guides/CreateCommunity.tsx
@@ -123,11 +123,12 @@ export function CreateCommunity() {
           whole app. It's also where admins tap <Term>Go live</Term> when
           they're ready for the real thing.
         </Callout>
-        <Callout tone="tip" title="Nothing you do here follows you">
-          Break things. Everything written inside the demo — the sample
+        <Callout tone="tip" title="Nothing you write here follows you">
+          Break things. Everything <em>written</em> inside the demo — the sample
           members, their conversations and events, and anything you try
           yourself — is cleared when you go live, so there's no wrong move and
-          nothing to tidy up afterwards.
+          nothing to tidy up afterwards. What you <em>build</em> does stay: your
+          branding, groups, channels and landing page all carry over.
         </Callout>
         <DeepLink href={appLinks.demo}>Create your community</DeepLink>
       </Section>
@@ -184,16 +185,17 @@ export function CreateCommunity() {
         <Callout tone="warn" title="The clean slate includes your own test content">
           The wipe covers the 100 demo members and their chats, events, RSVPs,
           prayer requests and service plans — <em>and</em> anything you created
-          while exploring, like a test message, a test event, or a practice
-          prayer request. It can't be undone. If you set something up in the
-          demo that you want to keep, write it down and recreate it once you're
-          live.
+          while exploring, including a test message, a test event, a practice
+          prayer request, or a Sunday you rostered. It can't be undone. If you
+          set something up in the demo that you want to keep, write it down and
+          recreate it once you're live.
         </Callout>
         <P>
           Your public web address loses its demo prefix at the same moment:{" "}
           <Term>togather.nyc/demo-grace-fellowship</Term> becomes{" "}
           <Term>togather.nyc/grace-fellowship</Term>, so the link you share with
-          visitors never says "demo".
+          visitors never says "demo". The old address stops working, so wait
+          until you're live before printing your landing-page link on anything.
         </P>
         <P>
           Pricing is simple: <Term>$1 per active member per month</Term>. An

--- a/apps/web/src/pages/guides/CreateCommunity.tsx
+++ b/apps/web/src/pages/guides/CreateCommunity.tsx
@@ -123,6 +123,12 @@ export function CreateCommunity() {
           whole app. It's also where admins tap <Term>Go live</Term> when
           they're ready for the real thing.
         </Callout>
+        <Callout tone="tip" title="Nothing you do here follows you">
+          Break things. Everything written inside the demo — the sample
+          members, their conversations and events, and anything you try
+          yourself — is cleared when you go live, so there's no wrong move and
+          nothing to tidy up afterwards.
+        </Callout>
         <DeepLink href={appLinks.demo}>Create your community</DeepLink>
       </Section>
 
@@ -169,10 +175,25 @@ export function CreateCommunity() {
       <Section id="go-live" title="Go live: $1 per active member">
         <P>
           When your team is ready, tap <Term>Go live</Term> on the demo banner.
-          Going live keeps everything you've set up — name, branding, groups,
-          channels, and your staff accounts — and removes the seeded demo
-          members and their conversations, so you start clean with your real
-          congregation.
+          Going live keeps the community you built — name, branding, group
+          types, groups, channels, your landing page, and your staff accounts —
+          and clears everything that was written inside the demo, so your
+          congregation arrives to a clean slate rather than to sample people
+          and events they were never part of.
+        </P>
+        <Callout tone="warn" title="The clean slate includes your own test content">
+          The wipe covers the 100 demo members and their chats, events, RSVPs,
+          prayer requests and service plans — <em>and</em> anything you created
+          while exploring, like a test message, a test event, or a practice
+          prayer request. It can't be undone. If you set something up in the
+          demo that you want to keep, write it down and recreate it once you're
+          live.
+        </Callout>
+        <P>
+          Your public web address loses its demo prefix at the same moment:{" "}
+          <Term>togather.nyc/demo-grace-fellowship</Term> becomes{" "}
+          <Term>togather.nyc/grace-fellowship</Term>, so the link you share with
+          visitors never says "demo".
         </P>
         <P>
           Pricing is simple: <Term>$1 per active member per month</Term>. An


### PR DESCRIPTION
## The bug

Converting a demo to a live community deleted the fake **people** but kept everything they were props for. A church that paid on Tuesday opened its calendar to eleven events it never scheduled:

```
Northside Small Group Weekly Meeting · Downtown Small Group Weekly Meeting
Worship Team Weekly Meeting · Welcome Team Weekly Meeting
Production Team Weekly Meeting · Kids Team Weekly Meeting
Prayer Team Weekly Meeting · New Members Class Weekly Meeting
Serve Day ×3  +  the "Serve Day" community-wide event
```

…all with **zero attendees**, because the 60+ RSVPs *were* correctly deleted along with the seed members. Fake data with the social proof stripped out, on a calendar the real congregation was about to be invited into.

### Why they survived

`createDemoMeeting` stamps the **real creator's** user id on every seeded event (`createdById: userId`). The old purge worked by deleting rows keyed to *placeholder* users, so it walked straight past all of them. Every one carries `isDemoSeed: true` — the flag existed, nothing ever read it for deletion. `purgeDemoSeedUsers`' own docstring rationalised this as intentional ("events … stay"), while the Go Live screen promised the opposite: *"removes the seeded demo members and their conversations, so you start clean."*

Two more classes of residue rode along: the demo's `communityWideEvents` row, and every piece of throwaway test content the guided tour actively instructs staff to create.

## The fix

Going live is now a **hand-over, not a merge**.

| Kept — what the church BUILT | Deleted — what was WRITTEN in the demo |
| --- | --- |
| Community row, branding, settings | Seeded placeholder members |
| Group types, groups | Every message, in every channel |
| Channels (incl. staff-created) | Every event + RSVPs, attendance, invites, blasts, guests |
| Serving-team structure + roles | Community-wide events |
| Landing page | Every prayer + responses/follow-ups/reports/reactions |
| Staff accounts, roles, memberships | Every service plan + roles/items/tasks/availability |
| | DMs, group DMs, event-chat threads, the Getting Started tour |
| | Notifications, admin broadcasts, tasks, reach-out requests |

The content sweep is deliberately **author-agnostic** — that is the actual fix. Deleting only what placeholder members authored is exactly what left the eleven events behind.

**Structure vs. content is the line**: a container or setting is structure and stays; anything with a position in a feed or on a calendar is content and goes. A channel the staff created survives (emptied); the messages inside it do not.

### The trade this makes

A church that scheduled a *real* event, posted a *real* prayer request, or rostered a *real* Sunday during the demo loses it, with no undo. That is a deliberate product decision in favour of a guaranteed-clean hand-over — so it is stated plainly **before** the pay button, in warning tint with an alert icon rather than as the quietest element on the screen. The tour's closing message and `/guides/create-your-community` say the same thing.

## Second bug: the demo prefix shipped to production

The slug stayed `demo-grace-fellowship`. Go-live flips `isPublic: true` and provisions the public landing page, so the URL a church texts to visitors was literally `togather.nyc/demo-grace-fellowship` — permanently, since there is no admin-facing slug rename. Conversion now drops the prefix (`liveSlugForDemo`), carries `searchText` with it, and falls back to a suffixed variant on collision.

---

# Review cycle

Four independent reviewers went over the first commit (correctness, test quality, data safety / spec fidelity, conventions). `ac12226` is the response. What they found:

### CRITICAL — a webhook redelivery could have wiped a live church

`handleCheckoutCompleted`'s race guard only catches a **different** subscription id. A same-id redelivery — Stripe is at-least-once, and support can re-send an event by hand weeks later — fell through and re-scheduled the purge. Harmless before this PR (the old purge only deleted demo-seed-flagged rows, long gone), **catastrophic with the author-agnostic sweep**: the second run would delete the live community's real events, prayers and messages. A hazard this PR introduced, and the surrounding comment asserted the opposite: *"Same-id retries fall through and re-apply idempotently."*

Closed in two places:
- **At the webhook** — `if (!existing?.isDemo) return`. Provably safe: the patch and the purge schedule commit in one transaction, so `isDemo === false` proves the first conversion completed.
- **Inside the purge** — `isDemo` is already false by then, so `demoCreatedById` (previously written and never read) became the "still holds demo residue" marker, cleared as the purge's final write. The mutation now refuses a community that was never a demo or is already purged, which also covers a mistyped id in the Convex dashboard.

Both verified load-bearing: each guard was disabled in turn and its test failed.

### A safety guard was removed while its comment still promised it

The tour channel was matched on slug + group + all-messages-bot-authored. The rewrite deletes messages first, so that third test became impossible and was dropped silently — meaning a church's own `getting-started` channel in the announcements group would have been deleted, while the comment claimed that couldn't happen. The tour is now stamped `isDemoSeed` at creation (the repo's existing convention on seven other tables), with a name-based fallback for demos already in flight. Both directions are tested.

### Residue in ten side tables

Worst was `notifications`: not community-scoped, and every payload deep-links to something the purge deletes — staff would open the live app to *"You've been assigned to Drums"* pointing at nothing. Also `memberFollowupScores`, which denormalizes name and avatar and is read **with no join**, so orphans render deleted placeholders straight into a leader's queue.

Now swept: `notifications`, `adminBroadcasts`, `memberFollowupScores`, `tasks` + `taskEvents`, `reachOutRequests`, `prayerReactions`, `chatThreadSubscriptions`, `eventTaskCompletions`, `sharedTaskCompletions`, `personalServingTasks`, `assignmentRequestLog`, `howToDocChecks`. Meetings also cancel their scheduled reminder/attendance jobs, matching the canonical delete path.

**Known gap, documented in code rather than papered over:** `availabilityRequests` is indexed only by channel, message and public token, so a standalone one cannot be enumerated by community or group. Closing it needs a schema change, deliberately not in this PR.

### Two tests proved nothing

Not argued — *measured*, by running the suite against a tree with the old handler body. The last-message-preview test passed either way (seeded messages were already deleted by the old per-user purge), and the idempotency test only asserted `purged === 0`, trivially true. Both now write real staff / post-go-live data and assert it survives.

Also: every new test lacked an explicit timeout, so the 5000ms default made them **fail deterministically under any filtered run** (`-t`, `.only`). Reproduced, then fixed.

Added: cross-community isolation (a neighbouring community is byte-for-byte untouched), webhook-redelivery regression, tour identification in both directions, staff-to-staff DM deletion, and exact structure counts instead of `> 0`.

### Also corrected

- `attendanceConfirmationTokens` — the comment claimed a cron "never runs against a demo's future events". It's a per-meeting `scheduler.runAt`, and demos aren't time-boxed. Reasoning corrected; the table genuinely has no by-meeting index.
- "Nothing you do here follows you" over-claimed — branding, groups, channels and the landing page all do follow. Now "nothing you **write** here follows you".
- Deliberate behaviour reversal called out: staff-to-staff DMs used to survive go-live and now don't. The existing test asserting the old guarantee had a title that contradicted the shipped behaviour.

## Verification

The eleven surviving events were found by **provisioning a demo, running a real conversion, and dumping every table** — not by reading code. Full Convex suite green: **184 files, 3510 tests**. `tsc` clean on convex + web; `GoLiveScreen` clean on mobile (pre-existing unrelated errors elsewhere). ESLint clean.

**Not verified:** the Go Live screen has not been rendered — that needs a live Convex backend and a real demo community. The change is text and `View`s only: no new dependencies, nothing native. There is also no test asserting the disclosure copy exists, which is worth adding given it is the condition the "always wipe" decision rests on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFpuzuJWvUV7dLZ1QiWZex