### PR TITLE
feat(birthday): birthday signifiers on chat icons and profiles, and a bot that actually @mentions people

### DIFF
--- a/apps/convex/__tests__/birthday-bot.test.ts
+++ b/apps/convex/__tests__/birthday-bot.test.ts
@@ -902,8 +902,11 @@ describe("Birthday Bot - Timezone Awareness", () => {
         message.content.includes("it's your turn to say happy birthday")
       );
       expect(botMessage).toBeDefined();
-      expect(botMessage?.content).toContain("Hey Test User");
+      // The leader is @mentioned so the reminder actually notifies them —
+      // `@[Name]` is the markup, `mentionedUserIds` is what drives the push.
+      expect(botMessage?.content).toContain("Hey @[Test User]");
       expect(botMessage?.content).not.toContain("[[leader_name]]");
+      expect(botMessage?.mentionedUserIds).toEqual([userId]);
     });
   });
 });

--- a/apps/convex/__tests__/birthdayToday.plumbing.test.ts
+++ b/apps/convex/__tests__/birthdayToday.plumbing.test.ts
@@ -1,0 +1,286 @@
+/**
+ * End-to-end coverage for the `isBirthdayToday` flag as it is actually served.
+ *
+ * The unit tests in `birthdays.test.ts` prove the date logic. These prove the
+ * flag survives the trip through the queries the UI calls — `users.getProfile`
+ * and `messaging.directMessages.getDirectInbox`. Without these, the helper
+ * could be correct while the queries hand the client a hardcoded `false` and
+ * every other test in the suite would still pass.
+ *
+ * They also pin the privacy boundary: the flag falls back to `dateOfBirth`,
+ * which is collected for the 13+ age check and is not something a member chose
+ * to share, so only a seated member of the community may see it — and the date
+ * itself must never appear in a response.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/birthdayToday.plumbing.test.ts
+ */
+
+import { convexTest } from "convex-test";
+import { describe, expect, test, vi } from "vitest";
+import schema from "../schema";
+import { api } from "../_generated/api";
+import { modules } from "../test.setup";
+import { generateTokens } from "../lib/auth";
+import type { Id } from "../_generated/dataModel";
+
+process.env.JWT_SECRET = "test-jwt-secret-for-unit-tests-minimum-32-chars";
+
+const MEMBERSHIP_ACTIVE = 1;
+
+/** Noon Eastern on 14 March 2026 — unambiguously the 14th in the test zone. */
+const TODAY = new Date("2026-03-14T16:00:00Z");
+/** A birthday on 14 March, stored the way `updateProfile` stores it. */
+const DOB_MAR_14 = Date.UTC(1994, 2, 14);
+
+async function seedCommunity(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const communityId = await ctx.db.insert("communities", {
+      name: "Birthday Plumbing",
+      slug: "bday-plumbing",
+      timezone: "America/New_York",
+      isPublic: true,
+    });
+    return communityId;
+  });
+}
+
+async function seedMember(
+  t: ReturnType<typeof convexTest>,
+  communityId: Id<"communities">,
+  fields: {
+    firstName: string;
+    dateOfBirth?: number;
+    birthdayMonth?: number;
+    birthdayDay?: number;
+  },
+) {
+  return await t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      firstName: fields.firstName,
+      lastName: "Tester",
+      phone: `+1555${Math.floor(Math.random() * 10_000_000)
+        .toString()
+        .padStart(7, "0")}`,
+      phoneVerified: true,
+      dateOfBirth: fields.dateOfBirth,
+      birthdayMonth: fields.birthdayMonth,
+      birthdayDay: fields.birthdayDay,
+      isActive: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await ctx.db.insert("userCommunities", {
+      userId,
+      communityId,
+      status: MEMBERSHIP_ACTIVE,
+      createdAt: Date.now(),
+    });
+    return userId;
+  });
+}
+
+describe("users.getProfile", () => {
+  test("serves isBirthdayToday=true from the private dateOfBirth", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TODAY);
+    const t = convexTest(schema, modules);
+    const communityId = await seedCommunity(t);
+    const birthdayUser = await seedMember(t, communityId, {
+      firstName: "Tadala",
+      dateOfBirth: DOB_MAR_14,
+    });
+    const viewer = await seedMember(t, communityId, { firstName: "Viewer" });
+    const { accessToken } = await generateTokens(viewer);
+
+    const profile = await t.query(api.functions.users.getProfile, {
+      token: accessToken,
+      userId: birthdayUser,
+      communityId,
+    });
+
+    expect(profile?.isBirthdayToday).toBe(true);
+    vi.useRealTimers();
+  });
+
+  test("serves isBirthdayToday=true from the public month/day pair", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TODAY);
+    const t = convexTest(schema, modules);
+    const communityId = await seedCommunity(t);
+    const birthdayUser = await seedMember(t, communityId, {
+      firstName: "Tadala",
+      birthdayMonth: 3,
+      birthdayDay: 14,
+    });
+    const viewer = await seedMember(t, communityId, { firstName: "Viewer" });
+    const { accessToken } = await generateTokens(viewer);
+
+    const profile = await t.query(api.functions.users.getProfile, {
+      token: accessToken,
+      userId: birthdayUser,
+      communityId,
+    });
+
+    expect(profile?.isBirthdayToday).toBe(true);
+    vi.useRealTimers();
+  });
+
+  test("is false on a day that is not their birthday", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T16:00:00Z"));
+    const t = convexTest(schema, modules);
+    const communityId = await seedCommunity(t);
+    const birthdayUser = await seedMember(t, communityId, {
+      firstName: "Tadala",
+      dateOfBirth: DOB_MAR_14,
+    });
+    const viewer = await seedMember(t, communityId, { firstName: "Viewer" });
+    const { accessToken } = await generateTokens(viewer);
+
+    const profile = await t.query(api.functions.users.getProfile, {
+      token: accessToken,
+      userId: birthdayUser,
+      communityId,
+    });
+
+    expect(profile?.isBirthdayToday).toBe(false);
+    vi.useRealTimers();
+  });
+
+  test("never returns the birth date itself, only the boolean", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TODAY);
+    const t = convexTest(schema, modules);
+    const communityId = await seedCommunity(t);
+    const birthdayUser = await seedMember(t, communityId, {
+      firstName: "Tadala",
+      dateOfBirth: DOB_MAR_14,
+    });
+    const viewer = await seedMember(t, communityId, { firstName: "Viewer" });
+    const { accessToken } = await generateTokens(viewer);
+
+    const profile = await t.query(api.functions.users.getProfile, {
+      token: accessToken,
+      userId: birthdayUser,
+      communityId,
+    });
+
+    expect(profile).not.toHaveProperty("dateOfBirth");
+    expect(JSON.stringify(profile)).not.toContain(String(DOB_MAR_14));
+    // The user never filled in the shareable pair, so it stays empty — the
+    // badge must not be a back door that populates it.
+    expect(profile?.birthdayMonth).toBeNull();
+    expect(profile?.birthdayDay).toBeNull();
+    vi.useRealTimers();
+  });
+
+  test("hides it from an anonymous viewer", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TODAY);
+    const t = convexTest(schema, modules);
+    const communityId = await seedCommunity(t);
+    const birthdayUser = await seedMember(t, communityId, {
+      firstName: "Tadala",
+      dateOfBirth: DOB_MAR_14,
+    });
+
+    const profile = await t.query(api.functions.users.getProfile, {
+      userId: birthdayUser,
+      communityId,
+    });
+
+    // The profile still renders for anonymous viewers (it is public by
+    // design) — but a caller with no token cannot poll this flag daily to
+    // recover a member's birth month and day.
+    expect(profile).not.toBeNull();
+    expect(profile?.isBirthdayToday).toBe(false);
+    vi.useRealTimers();
+  });
+
+  test("hides it from a viewer outside the community", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TODAY);
+    const t = convexTest(schema, modules);
+    const communityId = await seedCommunity(t);
+    const otherCommunityId = await t.run(async (ctx) =>
+      ctx.db.insert("communities", {
+        name: "Elsewhere",
+        slug: "elsewhere",
+        timezone: "America/New_York",
+        isPublic: true,
+      }),
+    );
+    const birthdayUser = await seedMember(t, communityId, {
+      firstName: "Tadala",
+      dateOfBirth: DOB_MAR_14,
+    });
+    const outsider = await seedMember(t, otherCommunityId, {
+      firstName: "Outsider",
+    });
+    const { accessToken } = await generateTokens(outsider);
+
+    const profile = await t.query(api.functions.users.getProfile, {
+      token: accessToken,
+      userId: birthdayUser,
+      communityId,
+    });
+
+    expect(profile?.isBirthdayToday).toBe(false);
+    vi.useRealTimers();
+  });
+});
+
+describe("messaging.directMessages.getDirectInbox", () => {
+  test("flags the birthday of the person on the other side of a DM", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TODAY);
+    const t = convexTest(schema, modules);
+    const communityId = await seedCommunity(t);
+    const me = await seedMember(t, communityId, { firstName: "Me" });
+    const them = await seedMember(t, communityId, {
+      firstName: "Tadala",
+      dateOfBirth: DOB_MAR_14,
+    });
+
+    await t.run(async (ctx) => {
+      const channelId = await ctx.db.insert("chatChannels", {
+        communityId,
+        channelType: "dm",
+        name: "DM",
+        slug: "dm-1",
+        isAdHoc: true,
+        isArchived: false,
+        createdById: me,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        lastMessageAt: Date.now(),
+        memberCount: 2,
+      });
+      for (const [userId, displayName] of [
+        [me, "Me Tester"],
+        [them, "Tadala Tester"],
+      ] as const) {
+        await ctx.db.insert("chatChannelMembers", {
+          channelId,
+          userId,
+          displayName,
+          role: "member",
+          isMuted: false,
+          requestState: "accepted",
+          joinedAt: Date.now(),
+        });
+      }
+    });
+
+    const { accessToken } = await generateTokens(me);
+    const inbox = await t.query(
+      api.functions.messaging.directMessages.getDirectInbox,
+      { token: accessToken, communityId },
+    );
+
+    const row = inbox.find((r) => r.otherMembers.length === 1);
+    expect(row).toBeDefined();
+    expect(row?.otherMembers[0]?.isBirthdayToday).toBe(true);
+    vi.useRealTimers();
+  });
+});

--- a/apps/convex/__tests__/birthdays.test.ts
+++ b/apps/convex/__tests__/birthdays.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for the shared "is it their birthday today" helper.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/birthdays.test.ts
+ */
+
+import { expect, test, describe } from "vitest";
+import { isBirthdayToday, todayMonthDay } from "../lib/birthdays";
+
+/** 14 March 1994, stored the way `updateProfile` stores it (date-only, UTC). */
+const MAR_14_1994 = Date.UTC(1994, 2, 14);
+
+/** 14 March 2026, 15:00 UTC — same calendar day in New York and in London. */
+const MAR_14_AFTERNOON = Date.UTC(2026, 2, 14, 15, 0);
+
+describe("todayMonthDay", () => {
+  test("reads the date in UTC by default", () => {
+    expect(todayMonthDay(undefined, MAR_14_AFTERNOON)).toEqual({
+      month: 3,
+      day: 14,
+    });
+  });
+
+  test("reads the date in the given timezone", () => {
+    // 14 March 01:00 UTC is still 13 March in New York.
+    const justAfterUtcMidnight = Date.UTC(2026, 2, 14, 1, 0);
+    expect(todayMonthDay("America/New_York", justAfterUtcMidnight)).toEqual({
+      month: 3,
+      day: 13,
+    });
+    expect(todayMonthDay("UTC", justAfterUtcMidnight)).toEqual({
+      month: 3,
+      day: 14,
+    });
+  });
+
+  test("falls back to UTC for an unrecognised timezone instead of throwing", () => {
+    expect(todayMonthDay("Not/AZone", MAR_14_AFTERNOON)).toEqual({
+      month: 3,
+      day: 14,
+    });
+  });
+});
+
+describe("isBirthdayToday", () => {
+  test("matches the private dateOfBirth", () => {
+    expect(
+      isBirthdayToday({ dateOfBirth: MAR_14_1994 }, "UTC", MAR_14_AFTERNOON),
+    ).toBe(true);
+  });
+
+  test("matches the public month/day pair", () => {
+    expect(
+      isBirthdayToday(
+        { birthdayMonth: 3, birthdayDay: 14 },
+        "UTC",
+        MAR_14_AFTERNOON,
+      ),
+    ).toBe(true);
+  });
+
+  test("matches when only one of the two sources lines up", () => {
+    // Someone whose profile M/D says something different from their sign-up
+    // date still counts on both days — either is a real claim about them.
+    expect(
+      isBirthdayToday(
+        { dateOfBirth: Date.UTC(1994, 6, 2), birthdayMonth: 3, birthdayDay: 14 },
+        "UTC",
+        MAR_14_AFTERNOON,
+      ),
+    ).toBe(true);
+  });
+
+  test("is false on any other day", () => {
+    expect(
+      isBirthdayToday(
+        { dateOfBirth: MAR_14_1994, birthdayMonth: 3, birthdayDay: 14 },
+        "UTC",
+        Date.UTC(2026, 2, 15, 15, 0),
+      ),
+    ).toBe(false);
+  });
+
+  test("is false for a user with no birthday at all", () => {
+    expect(isBirthdayToday({}, "UTC", MAR_14_AFTERNOON)).toBe(false);
+  });
+
+  test("ignores a half-set profile pair", () => {
+    expect(
+      isBirthdayToday({ birthdayMonth: 3 }, "UTC", MAR_14_AFTERNOON),
+    ).toBe(false);
+    expect(isBirthdayToday({ birthdayDay: 14 }, "UTC", MAR_14_AFTERNOON)).toBe(
+      false,
+    );
+  });
+
+  test("ignores the birth year — only the month and day matter", () => {
+    expect(
+      isBirthdayToday(
+        { dateOfBirth: Date.UTC(1950, 2, 14) },
+        "UTC",
+        MAR_14_AFTERNOON,
+      ),
+    ).toBe(true);
+  });
+
+  test("uses the community timezone to decide which day it is", () => {
+    // 14 March 01:00 UTC — already the 14th in London, still the 13th in NY.
+    const justAfterUtcMidnight = Date.UTC(2026, 2, 14, 1, 0);
+    const user = { dateOfBirth: MAR_14_1994 };
+
+    expect(isBirthdayToday(user, "UTC", justAfterUtcMidnight)).toBe(true);
+    expect(isBirthdayToday(user, "America/New_York", justAfterUtcMidnight)).toBe(
+      false,
+    );
+  });
+
+  test("does not shift the date for a birth timestamp near midnight", () => {
+    // Stored date-only timestamps sit at 00:00 UTC; reading them locally on a
+    // negative-offset server would roll them back a day.
+    expect(
+      isBirthdayToday(
+        { dateOfBirth: Date.UTC(1994, 2, 14, 0, 0) },
+        "UTC",
+        MAR_14_AFTERNOON,
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/convex/__tests__/birthdays.test.ts
+++ b/apps/convex/__tests__/birthdays.test.ts
@@ -14,8 +14,17 @@ const MAR_14_1994 = Date.UTC(1994, 2, 14);
 const MAR_14_AFTERNOON = Date.UTC(2026, 2, 14, 15, 0);
 
 describe("todayMonthDay", () => {
-  test("reads the date in UTC by default", () => {
-    expect(todayMonthDay(undefined, MAR_14_AFTERNOON)).toEqual({
+  test("falls back to the community default zone, not UTC", () => {
+    // 14 March 02:00 UTC is still 13 March in Eastern. A community with no
+    // timezone set must land on the same day its birthday bot does, and the bot
+    // defaults `community.timezone` to America/New_York.
+    const justAfterUtcMidnight = Date.UTC(2026, 2, 14, 2, 0);
+
+    expect(todayMonthDay(undefined, justAfterUtcMidnight)).toEqual({
+      month: 3,
+      day: 13,
+    });
+    expect(todayMonthDay("UTC", justAfterUtcMidnight)).toEqual({
       month: 3,
       day: 14,
     });
@@ -34,10 +43,12 @@ describe("todayMonthDay", () => {
     });
   });
 
-  test("falls back to UTC for an unrecognised timezone instead of throwing", () => {
-    expect(todayMonthDay("Not/AZone", MAR_14_AFTERNOON)).toEqual({
+  test("falls back for an unrecognised timezone instead of throwing", () => {
+    // A bad `communities.timezone` value must never break an inbox query.
+    const justAfterUtcMidnight = Date.UTC(2026, 2, 14, 2, 0);
+    expect(todayMonthDay("Not/AZone", justAfterUtcMidnight)).toEqual({
       month: 3,
-      day: 14,
+      day: 13,
     });
   });
 });

--- a/apps/convex/__tests__/buildBirthdayBotMessage.test.ts
+++ b/apps/convex/__tests__/buildBirthdayBotMessage.test.ts
@@ -170,6 +170,64 @@ describe("name handling", () => {
   });
 });
 
+describe("mention metadata never outruns the visible markup", () => {
+  test("no birthday mention ids when the template drops [[birthday_names]]", () => {
+    const { message, mentionedUserIds } = buildBirthdayBotMessage({
+      template: "🎂 It's a birthday in [[group_name]] today!",
+      mode: "general_chat",
+      birthdays: [
+        { userId: userId("u1"), firstName: "Tadala", lastName: "Jumbe" },
+      ],
+      targetLeader: null,
+      groupName: "Young Adults",
+      communityName: "Togather NYC",
+    });
+
+    // Attaching the id anyway would send a "you were mentioned" push and email
+    // for a message that mentions nobody.
+    expect(message).not.toContain("@[");
+    expect(mentionedUserIds).toEqual([]);
+  });
+
+  test("no leader mention id when the template drops [[leader_name]]", () => {
+    const { message, mentionedUserIds } = buildBirthdayBotMessage({
+      template: "Someone should wish [[birthday_names]] a happy birthday!",
+      mode: "leader_reminder",
+      birthdays: [
+        { userId: userId("u1"), firstName: "Tadala", lastName: "Jumbe" },
+      ],
+      targetLeader: LEADER,
+      groupName: "Young Adults",
+      communityName: "Togather NYC",
+    });
+
+    expect(message).not.toContain("@[");
+    expect(mentionedUserIds).toEqual([]);
+  });
+
+  test("a name containing brackets cannot forge a second mention", () => {
+    const { message, mentionedUserIds } = buildBirthdayBotMessage({
+      template: "Happy birthday [[birthday_names]]!",
+      mode: "general_chat",
+      birthdays: [
+        {
+          userId: userId("u1"),
+          firstName: "Bob]",
+          lastName: "hi @[Pastor Dave",
+        },
+      ],
+      targetLeader: null,
+      groupName: "G",
+      communityName: "C",
+    });
+
+    // Exactly one mention span, and it is the real one.
+    expect(message.match(/@\[/g)).toHaveLength(1);
+    expect(message).toBe("Happy birthday @[Bob hi @Pastor Dave]!");
+    expect(mentionedUserIds).toEqual([userId("u1")]);
+  });
+});
+
 describe("placeholders", () => {
   test("fills group and community names", () => {
     const { message } = buildBirthdayBotMessage({

--- a/apps/convex/__tests__/buildBirthdayBotMessage.test.ts
+++ b/apps/convex/__tests__/buildBirthdayBotMessage.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Birthday Bot message-building tests.
+ *
+ * `buildBirthdayBotMessage` is the pure core of the birthday bot: it turns the
+ * configured template into the posted message plus the set of users to
+ * @mention. The two modes address different people, so they mention different
+ * people — that split is what these tests pin down.
+ *
+ * Run with: cd apps/convex && pnpm test __tests__/buildBirthdayBotMessage.test.ts
+ */
+
+import { expect, test, describe } from "vitest";
+import { buildBirthdayBotMessage } from "../functions/scheduledJobs";
+
+import type { Id } from "../_generated/dataModel";
+
+const userId = (n: string) => n as Id<"users">;
+
+const DEFAULT_TEMPLATE =
+  "🎂 Hey [[leader_name]], it's your turn to wish [[birthday_names]] a happy birthday in General chat! 🎉";
+
+const LEADER = { userId: userId("leader_1"), displayName: "Maria Okonkwo" };
+
+describe("general_chat mode", () => {
+  test("@mentions the birthday person by full name", () => {
+    const { message, mentionedUserIds } = buildBirthdayBotMessage({
+      template: "Happy birthday [[birthday_names]]! 🎉",
+      mode: "general_chat",
+      birthdays: [
+        { userId: userId("u1"), firstName: "Tadala", lastName: "Jumbe" },
+      ],
+      targetLeader: null,
+      groupName: "Young Adults",
+      communityName: "Togather NYC",
+    });
+
+    expect(message).toBe("Happy birthday @[Tadala Jumbe]! 🎉");
+    expect(mentionedUserIds).toEqual([userId("u1")]);
+  });
+
+  test("mentions every birthday person when several share a day", () => {
+    const { message, mentionedUserIds } = buildBirthdayBotMessage({
+      template: "Happy birthday [[birthday_names]]!",
+      mode: "general_chat",
+      birthdays: [
+        { userId: userId("u1"), firstName: "Tadala", lastName: "Jumbe" },
+        { userId: userId("u2"), firstName: "Joshua", lastName: "Irby-Shabazz" },
+      ],
+      targetLeader: null,
+      groupName: "Young Adults",
+      communityName: "Togather NYC",
+    });
+
+    expect(message).toBe(
+      "Happy birthday @[Tadala Jumbe], @[Joshua Irby-Shabazz]!",
+    );
+    expect(mentionedUserIds).toEqual([userId("u1"), userId("u2")]);
+  });
+
+  test("does not mention the leader when posting to general", () => {
+    const { message, mentionedUserIds } = buildBirthdayBotMessage({
+      template: DEFAULT_TEMPLATE,
+      mode: "general_chat",
+      birthdays: [
+        { userId: userId("u1"), firstName: "Tadala", lastName: "Jumbe" },
+      ],
+      targetLeader: LEADER,
+      groupName: "Young Adults",
+      communityName: "Togather NYC",
+    });
+
+    expect(message).toContain("@[Tadala Jumbe]");
+    expect(message).not.toContain("@[Maria Okonkwo]");
+    expect(mentionedUserIds).toEqual([userId("u1")]);
+  });
+});
+
+describe("leader_reminder mode", () => {
+  test("@mentions the leader and names the birthday person in full", () => {
+    const { message, mentionedUserIds } = buildBirthdayBotMessage({
+      template: DEFAULT_TEMPLATE,
+      mode: "leader_reminder",
+      birthdays: [
+        { userId: userId("u1"), firstName: "Tadala", lastName: "Jumbe" },
+      ],
+      targetLeader: LEADER,
+      groupName: "Young Adults",
+      communityName: "Togather NYC",
+    });
+
+    expect(message).toBe(
+      "🎂 Hey @[Maria Okonkwo], it's your turn to wish Tadala Jumbe a happy birthday in General chat! 🎉",
+    );
+    expect(mentionedUserIds).toEqual([userId("leader_1")]);
+  });
+
+  test("never mentions the birthday person — the nudge is private", () => {
+    const { message, mentionedUserIds } = buildBirthdayBotMessage({
+      template: DEFAULT_TEMPLATE,
+      mode: "leader_reminder",
+      birthdays: [
+        { userId: userId("u1"), firstName: "Tadala", lastName: "Jumbe" },
+      ],
+      targetLeader: LEADER,
+      groupName: "Young Adults",
+      communityName: "Togather NYC",
+    });
+
+    expect(message).not.toContain("@[Tadala Jumbe]");
+    expect(mentionedUserIds).not.toContain(userId("u1"));
+  });
+
+  test("falls back to 'leader' with no mention when the group has no leaders", () => {
+    const { message, mentionedUserIds } = buildBirthdayBotMessage({
+      template: DEFAULT_TEMPLATE,
+      mode: "leader_reminder",
+      birthdays: [
+        { userId: userId("u1"), firstName: "Tadala", lastName: "Jumbe" },
+      ],
+      targetLeader: null,
+      groupName: "Young Adults",
+      communityName: "Togather NYC",
+    });
+
+    expect(message).toContain("Hey leader,");
+    expect(message).not.toContain("@[");
+    expect(mentionedUserIds).toEqual([]);
+  });
+});
+
+describe("name handling", () => {
+  test("uses the first name alone when there is no last name", () => {
+    const { message } = buildBirthdayBotMessage({
+      template: "[[birthday_names]]",
+      mode: "leader_reminder",
+      birthdays: [{ userId: userId("u1"), firstName: "Tadala" }],
+      targetLeader: LEADER,
+      groupName: "G",
+      communityName: "C",
+    });
+
+    expect(message).toBe("Tadala");
+  });
+
+  test("falls back to 'a member' and skips the mention for a nameless user", () => {
+    const { message, mentionedUserIds } = buildBirthdayBotMessage({
+      template: "Happy birthday [[birthday_names]]!",
+      mode: "general_chat",
+      birthdays: [{ userId: userId("u1") }],
+      targetLeader: null,
+      groupName: "G",
+      communityName: "C",
+    });
+
+    expect(message).toBe("Happy birthday a member!");
+    expect(mentionedUserIds).toEqual([]);
+  });
+
+  test("a '$' in a name is inserted literally, not as a capture reference", () => {
+    const { message } = buildBirthdayBotMessage({
+      template: "[[birthday_names]]",
+      mode: "leader_reminder",
+      birthdays: [{ userId: userId("u1"), firstName: "A$AP", lastName: "Rocky" }],
+      targetLeader: LEADER,
+      groupName: "G",
+      communityName: "C",
+    });
+
+    expect(message).toBe("A$AP Rocky");
+  });
+});
+
+describe("placeholders", () => {
+  test("fills group and community names", () => {
+    const { message } = buildBirthdayBotMessage({
+      template: "[[group_name]] @ [[community_name]]",
+      mode: "general_chat",
+      birthdays: [{ userId: userId("u1"), firstName: "Tadala" }],
+      targetLeader: null,
+      groupName: "Young Adults",
+      communityName: "Togather NYC",
+    });
+
+    expect(message).toBe("Young Adults @ Togather NYC");
+  });
+
+  test("replaces a placeholder used more than once", () => {
+    const { message } = buildBirthdayBotMessage({
+      template: "[[birthday_names]] — happy birthday [[birthday_names]]!",
+      mode: "leader_reminder",
+      birthdays: [
+        { userId: userId("u1"), firstName: "Tadala", lastName: "Jumbe" },
+      ],
+      targetLeader: LEADER,
+      groupName: "G",
+      communityName: "C",
+    });
+
+    expect(message).toBe("Tadala Jumbe — happy birthday Tadala Jumbe!");
+  });
+});

--- a/apps/convex/__tests__/scheduledJobs.birthday-bot.test.ts
+++ b/apps/convex/__tests__/scheduledJobs.birthday-bot.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { convexTest } from "convex-test";
-import { expect, test, describe } from "vitest";
+import { expect, test, describe, vi } from "vitest";
 import schema from "../schema";
 import { internal } from "../_generated/api";
 import { modules } from "../test.setup";
@@ -464,5 +464,115 @@ describe("getMembersWithBirthdayToday", () => {
     expect(result).toHaveLength(2);
     const names = result.map((r: { firstName: string }) => r.firstName).sort();
     expect(names).toEqual(["Alice", "Bob"]);
+  });
+});
+
+// ============================================================================
+// processBirthdayBotBucket — the path the hourly cron actually runs
+// ============================================================================
+
+/**
+ * `crons.ts` calls `processBirthdayBotBucket`, not `runBirthdayBot`. Without
+ * these, the mention feature could be dropped from the scheduled path entirely
+ * and every other birthday test would stay green.
+ *
+ * Both cases seed the leader and the birthday person as DIFFERENT users, so
+ * `mentionedUserIds` can distinguish which one was mentioned.
+ */
+describe("processBirthdayBotBucket mentions", () => {
+  async function seedChannel(
+    t: ReturnType<typeof convexTest>,
+    groupId: Id<"groups">,
+    slug: string,
+    createdById: Id<"users">
+  ) {
+    return await t.run(async (ctx) => {
+      return await ctx.db.insert("chatChannels", {
+        groupId,
+        slug,
+        channelType: slug === "leaders" ? "leaders" : "general",
+        name: slug,
+        createdById,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isArchived: false,
+        memberCount: 2,
+      });
+    });
+  }
+
+  async function runBucket(
+    t: ReturnType<typeof convexTest>,
+    mode: string,
+    slug: string
+  ) {
+    const { groupId } = await seedCommunityAndGroup(t);
+    // 14 March in New York, the community's zone.
+    vi.setSystemTime(new Date("2026-03-14T16:00:00Z"));
+
+    const leader = await seedUser(t, {
+      firstName: "Maria",
+      lastName: "Okonkwo",
+    });
+    const birthdayUser = await seedUser(t, {
+      firstName: "Tadala",
+      lastName: "Jumbe",
+      dateOfBirth: Date.UTC(1994, 2, 14),
+    });
+    await addGroupMember(t, groupId, leader, "leader");
+    await addGroupMember(t, groupId, birthdayUser, "member");
+    await seedChannel(t, groupId, slug, leader);
+
+    const nowMs = Date.now();
+    await seedBotConfig(t, groupId, {
+      nextScheduledAt: nowMs,
+      config: { mode, targetChannelSlug: slug },
+    });
+
+    await t.action(
+      internal.functions.scheduledJobs.processBirthdayBotBucket,
+      {}
+    );
+
+    const messages = await t.run(async (ctx) =>
+      ctx.db.query("chatMessages").collect()
+    );
+    return { message: messages[0], leader, birthdayUser };
+  }
+
+  test("leader_reminder mentions the LEADER, not the birthday person", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { message, leader, birthdayUser } = await runBucket(
+      t,
+      "leader_reminder",
+      "leaders"
+    );
+
+    expect(message).toBeDefined();
+    expect(message.content).toContain("@[Maria Okonkwo]");
+    // Named in full so the leader knows who — but deliberately not pinged.
+    expect(message.content).toContain("Tadala Jumbe");
+    expect(message.content).not.toContain("@[Tadala Jumbe]");
+    expect(message.mentionedUserIds).toEqual([leader]);
+    expect(message.mentionedUserIds).not.toContain(birthdayUser);
+    vi.useRealTimers();
+  });
+
+  test("general_chat mentions the BIRTHDAY PERSON, not the leader", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const { message, leader, birthdayUser } = await runBucket(
+      t,
+      "general_chat",
+      "general"
+    );
+
+    expect(message).toBeDefined();
+    expect(message.content).toContain("@[Tadala Jumbe]");
+    expect(message.content).not.toContain("@[Maria Okonkwo]");
+    expect(message.mentionedUserIds).toEqual([birthdayUser]);
+    expect(message.mentionedUserIds).not.toContain(leader);
+    vi.useRealTimers();
   });
 });

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -20,6 +20,10 @@ import { requireAuth } from "../../lib/auth";
 import { checkRateLimit } from "../../lib/rateLimit";
 import { getDisplayName, getMediaUrl, normalizePhone } from "../../lib/utils";
 import { getUsersWithNotificationsDisabled } from "../../lib/notifications/enabledStatus";
+import {
+  getUsersWithBirthdayToday,
+  isBirthdayToday,
+} from "../../lib/birthdays";
 import { getLeaderDmRelationship } from "../../lib/leaderDm";
 
 // ============================================================================
@@ -1445,6 +1449,7 @@ export const getAdHocChannelMembers = query({
       displayName: string;
       profilePhoto: string | null;
       notificationsDisabled: boolean;
+      isBirthdayToday: boolean;
     }>;
     /** See `resolveFormerDirectMember` — 1:1 display fallback, never a member. */
     formerMember: FormerDirectMember | null;
@@ -1489,6 +1494,11 @@ export const getAdHocChannelMembers = query({
       ctx,
       otherIds,
     );
+    // The user docs are already loaded above, so this is a local check — see
+    // `lib/birthdays.ts` for why only the boolean may cross the wire.
+    const channelCommunity = channel.communityId
+      ? await ctx.db.get(channel.communityId)
+      : null;
     const otherMembers = others
       .map((m, i) => {
         const u = otherUsers[i];
@@ -1501,6 +1511,7 @@ export const getAdHocChannelMembers = query({
             "Member",
           profilePhoto: getMediaUrl(u.profilePhoto ?? m.profilePhoto) ?? null,
           notificationsDisabled: otherNotifsDisabled.has(m.userId),
+          isBirthdayToday: isBirthdayToday(u, channelCommunity?.timezone),
         };
       })
       .filter((x): x is NonNullable<typeof x> => x !== null);
@@ -1536,6 +1547,11 @@ export const getDirectInbox = query({
       )
       .collect();
 
+    // Birthdays are decided in the community's timezone, so the badge turns on
+    // and off on the same day the birthday bot posts.
+    const community = await ctx.db.get(args.communityId);
+    const communityTimezone = community?.timezone;
+
     const results: Array<{
       channelId: Id<"chatChannels">;
       channelType: "dm" | "group_dm";
@@ -1546,6 +1562,7 @@ export const getDirectInbox = query({
         displayName: string;
         profilePhoto: string | null;
         notificationsDisabled: boolean;
+        isBirthdayToday: boolean;
       }>;
       /** See `resolveFormerDirectMember` — 1:1 display fallback, never a member. */
       formerMember: FormerDirectMember | null;
@@ -1613,6 +1630,12 @@ export const getDirectInbox = query({
         ctx,
         idsToCheck,
       );
+      // Only the boolean reaches the client — see `lib/birthdays.ts`.
+      const rowBirthdays = await getUsersWithBirthdayToday(
+        ctx,
+        otherMemberIds,
+        communityTimezone,
+      );
       const otherMembers = otherMemberRows
         .filter((m) => m.userId !== userId)
         .map((m) => ({
@@ -1620,6 +1643,7 @@ export const getDirectInbox = query({
           displayName: m.displayName ?? "",
           profilePhoto: getMediaUrl(m.profilePhoto) ?? null,
           notificationsDisabled: rowNotifsDisabled.has(m.userId),
+          isBirthdayToday: rowBirthdays.has(m.userId),
         }));
 
       // A 1:1 whose counterpart left (expired request, decline, block) has no

--- a/apps/convex/functions/messaging/directMessages.ts
+++ b/apps/convex/functions/messaging/directMessages.ts
@@ -1547,10 +1547,13 @@ export const getDirectInbox = query({
       )
       .collect();
 
-    // Birthdays are decided in the community's timezone, so the badge turns on
-    // and off on the same day the birthday bot posts.
+    // Birthdays are decided in the community's timezone, the same basis the
+    // birthday bot uses. (The badge is a superset of what the bot announces —
+    // see `lib/birthdays.ts`.)
     const community = await ctx.db.get(args.communityId);
     const communityTimezone = community?.timezone;
+    /** Shared across rows — the same person recurs across conversations. */
+    const birthdayMemo = new Map<Id<"users">, boolean>();
 
     const results: Array<{
       channelId: Id<"chatChannels">;
@@ -1630,11 +1633,14 @@ export const getDirectInbox = query({
         ctx,
         idsToCheck,
       );
-      // Only the boolean reaches the client — see `lib/birthdays.ts`.
+      // Only the boolean reaches the client — see `lib/birthdays.ts`. The memo
+      // is shared across rows so someone you have both a 1:1 and two group DMs
+      // with costs one `users` read for the whole inbox, not three.
       const rowBirthdays = await getUsersWithBirthdayToday(
         ctx,
         otherMemberIds,
         communityTimezone,
+        birthdayMemo,
       );
       const otherMembers = otherMemberRows
         .filter((m) => m.userId !== userId)

--- a/apps/convex/functions/scheduledJobs.ts
+++ b/apps/convex/functions/scheduledJobs.ts
@@ -27,6 +27,7 @@ import { Id } from "../_generated/dataModel";
 import { notifyBatch } from "../lib/notifications/send";
 import { resolveChannelCommunityId } from "../lib/messaging/communityScope";
 import { now, getMediaUrlWithTransform, ImagePresets } from "../lib/utils";
+import { todayMonthDay } from "../lib/birthdays";
 import {
   calculateCommunicationBotNextSchedule,
   isScheduleDueNow,
@@ -118,7 +119,10 @@ function fullName(person: {
  * together.
  */
 function mention(displayName: string): string {
-  return `@[${displayName}]`;
+  // Strip brackets so a name can't terminate the markup early and forge a
+  // second, visible-but-inert mention of someone else. Names are free text —
+  // `updateProfile` does not restrict the characters in them.
+  return `@[${displayName.replace(/[[\]]/g, "")}]`;
 }
 
 /**
@@ -166,22 +170,33 @@ export function buildBirthdayBotMessage(params: {
   const isGeneralChat = mode === "general_chat";
   const mentionedUserIds: Id<"users">[] = [];
 
+  // A mention only counts if the reader can actually see it. `mentionedUserIds`
+  // is what drives the mention push *and email*, so attaching an id whose
+  // `@[Name]` markup never reached the message would tell someone they were
+  // mentioned in a message that does not mention them. Leaders can edit these
+  // templates and drop a placeholder, so collect ids only when the placeholder
+  // that renders them is actually present.
+  const namesAreRendered = template.includes("[[birthday_names]]");
+  const leaderIsRendered = template.includes("[[leader_name]]");
+
   const birthdayNames = birthdays
     .map((member) => {
       const name = fullName(member);
       if (!name) return "a member";
       if (!isGeneralChat) return name;
-      mentionedUserIds.push(member.userId);
+      if (namesAreRendered) mentionedUserIds.push(member.userId);
       return mention(name);
     })
     .join(", ");
 
   let leaderName = "leader";
-  if (!isGeneralChat && targetLeader) {
-    leaderName = mention(targetLeader.displayName);
-    mentionedUserIds.push(targetLeader.userId);
-  } else if (targetLeader) {
-    leaderName = targetLeader.displayName;
+  if (targetLeader) {
+    if (isGeneralChat) {
+      leaderName = targetLeader.displayName;
+    } else {
+      leaderName = mention(targetLeader.displayName);
+      if (leaderIsRendered) mentionedUserIds.push(targetLeader.userId);
+    }
   }
 
   let message = fillPlaceholder(template, "[[birthday_names]]", birthdayNames);
@@ -655,31 +670,10 @@ export const getMembersWithBirthdayToday = internalQuery({
     timezone: v.optional(v.string()),
   },
   handler: async (ctx, { groupId, timezone }) => {
-    // Use timezone to determine "today" (default to UTC for backwards compat)
-    const tz = timezone || "UTC";
-    const today = new Date();
-
-    let todayMonth: number;
-    let todayDate: number;
-
-    if (tz === "UTC") {
-      todayMonth = today.getUTCMonth();
-      todayDate = today.getUTCDate();
-    } else {
-      // Get current date in the community's timezone
-      const dateFormatter = new Intl.DateTimeFormat("en-US", {
-        timeZone: tz,
-        month: "numeric",
-        day: "numeric",
-      });
-      const parts = dateFormatter.formatToParts(today);
-      todayMonth =
-        parseInt(parts.find((p) => p.type === "month")?.value || "1", 10) - 1;
-      todayDate = parseInt(
-        parts.find((p) => p.type === "day")?.value || "1",
-        10,
-      );
-    }
+    // Shared with the avatar/profile badge (`lib/birthdays.ts`) so the bot and
+    // the badge can never land on different calendar days. Note `month` is
+    // 1-based here, unlike the `getUTCMonth()` it replaced.
+    const { month: todayMonth, day: todayDate } = todayMonthDay(timezone);
 
     const members = await ctx.db
       .query("groupMembers")
@@ -707,7 +701,7 @@ export const getMembersWithBirthdayToday = internalQuery({
 
       const birthday = new Date(user.dateOfBirth);
       if (
-        birthday.getUTCMonth() === todayMonth &&
+        birthday.getUTCMonth() + 1 === todayMonth &&
         birthday.getUTCDate() === todayDate
       ) {
         birthdayMembers.push({

--- a/apps/convex/functions/scheduledJobs.ts
+++ b/apps/convex/functions/scheduledJobs.ts
@@ -93,6 +93,105 @@ function resolveBirthdayReminderLeader(params: {
   return leaders[nextIndex];
 }
 
+export type BirthdayBotMember = {
+  userId: Id<"users">;
+  firstName?: string;
+  lastName?: string;
+};
+
+/** Full name from the first/last pair, or `null` when neither is set. */
+function fullName(person: {
+  firstName?: string;
+  lastName?: string;
+}): string | null {
+  const name = [person.firstName, person.lastName].filter(Boolean).join(" ");
+  return name || null;
+}
+
+/**
+ * `@[Display Name]` — the mention markup the chat client parses and styles.
+ * Must stay in sync with `mentionRegex` in
+ * `apps/mobile/features/shared/utils/linkify.tsx`.
+ *
+ * The markup only makes the name *look* like a mention; the recipient is
+ * notified via the message's `mentionedUserIds`, so the two are always built
+ * together.
+ */
+function mention(displayName: string): string {
+  return `@[${displayName}]`;
+}
+
+/**
+ * Replace every occurrence of a `[[placeholder]]`. Uses a replacer function so
+ * a `$` in someone's name is never treated as a capture-group reference.
+ */
+function fillPlaceholder(
+  template: string,
+  placeholder: string,
+  value: string,
+): string {
+  return template.split(placeholder).join(value);
+}
+
+/**
+ * Build the birthday bot's message body and the set of users it @mentions.
+ *
+ * The two modes address different people, so they mention different people:
+ * - `general_chat` posts to the whole group, so it **@mentions the birthday
+ *   people** — the message is addressed to them.
+ * - `leader_reminder` posts in the leaders channel asking one leader to go and
+ *   say happy birthday, so it **@mentions that leader** (they're the one who
+ *   needs to act) and names the birthday people in full — first and last — so
+ *   the leader knows exactly who is meant. The birthday people are deliberately
+ *   *not* mentioned here: it's a private nudge, and pinging them would give the
+ *   surprise away.
+ */
+export function buildBirthdayBotMessage(params: {
+  template: string;
+  mode?: string;
+  birthdays: BirthdayBotMember[];
+  targetLeader: BirthdayReminderLeader | null;
+  groupName: string;
+  communityName: string;
+}): { message: string; mentionedUserIds: Id<"users">[] } {
+  const {
+    template,
+    mode,
+    birthdays,
+    targetLeader,
+    groupName,
+    communityName,
+  } = params;
+
+  const isGeneralChat = mode === "general_chat";
+  const mentionedUserIds: Id<"users">[] = [];
+
+  const birthdayNames = birthdays
+    .map((member) => {
+      const name = fullName(member);
+      if (!name) return "a member";
+      if (!isGeneralChat) return name;
+      mentionedUserIds.push(member.userId);
+      return mention(name);
+    })
+    .join(", ");
+
+  let leaderName = "leader";
+  if (!isGeneralChat && targetLeader) {
+    leaderName = mention(targetLeader.displayName);
+    mentionedUserIds.push(targetLeader.userId);
+  } else if (targetLeader) {
+    leaderName = targetLeader.displayName;
+  }
+
+  let message = fillPlaceholder(template, "[[birthday_names]]", birthdayNames);
+  message = fillPlaceholder(message, "[[leader_name]]", leaderName);
+  message = fillPlaceholder(message, "[[group_name]]", groupName);
+  message = fillPlaceholder(message, "[[community_name]]", communityName);
+
+  return { message, mentionedUserIds };
+}
+
 // ============================================================================
 // BIRTHDAY BOT
 // ============================================================================
@@ -133,10 +232,6 @@ export const runBirthdayBot = internalAction({
           continue;
         }
 
-        const birthdayNames = birthdays
-          .map((m: { firstName?: string }) => m.firstName || "a member")
-          .join(", ");
-
         const targetLeader =
           config.mode === "leader_reminder"
             ? resolveBirthdayReminderLeader({
@@ -146,14 +241,15 @@ export const runBirthdayBot = internalAction({
                 lastLeaderIndex: config.lastLeaderIndex,
               })
             : null;
-        const leaderName = targetLeader?.displayName || "leader";
 
-        // Build message with placeholder replacement
-        const message = config.message
-          .replace("[[birthday_names]]", birthdayNames)
-          .replace("[[leader_name]]", leaderName)
-          .replace("[[group_name]]", config.groupName)
-          .replace("[[community_name]]", config.communityName);
+        const { message, mentionedUserIds } = buildBirthdayBotMessage({
+          template: config.message,
+          mode: config.mode,
+          birthdays,
+          targetLeader,
+          groupName: config.groupName,
+          communityName: config.communityName,
+        });
 
         // Determine target channel with backwards compatibility
         // Priority: 1) configured targetChannelSlug, 2) mode-based default
@@ -171,6 +267,7 @@ export const runBirthdayBot = internalAction({
           message: finalMessage,
           targetChannelSlug,
           botType: "birthday",
+          mentionedUserIds,
         });
 
         // Update state for round-robin
@@ -246,10 +343,6 @@ export const processBirthdayBotBucket = internalAction({
         );
 
         if (birthdays.length > 0) {
-          const birthdayNames = birthdays
-            .map((m: { firstName?: string }) => m.firstName || "a member")
-            .join(", ");
-
           const targetLeader =
             config.mode === "leader_reminder"
               ? resolveBirthdayReminderLeader({
@@ -259,13 +352,15 @@ export const processBirthdayBotBucket = internalAction({
                   lastLeaderIndex: config.lastLeaderIndex,
                 })
               : null;
-          const leaderName = targetLeader?.displayName || "leader";
 
-          const message = config.message
-            .replace("[[birthday_names]]", birthdayNames)
-            .replace("[[leader_name]]", leaderName)
-            .replace("[[group_name]]", config.groupName)
-            .replace("[[community_name]]", config.communityName);
+          const { message, mentionedUserIds } = buildBirthdayBotMessage({
+            template: config.message,
+            mode: config.mode,
+            birthdays,
+            targetLeader,
+            groupName: config.groupName,
+            communityName: config.communityName,
+          });
 
           // Determine target channel with backwards compatibility
           // Priority: 1) configured targetChannelSlug, 2) mode-based default
@@ -283,6 +378,7 @@ export const processBirthdayBotBucket = internalAction({
             message: finalMessage,
             targetChannelSlug,
             botType: "birthday",
+            mentionedUserIds,
           });
 
           if (
@@ -617,6 +713,9 @@ export const getMembersWithBirthdayToday = internalQuery({
         birthdayMembers.push({
           userId: member.userId,
           firstName: user.firstName,
+          // The bot names birthday people in full when it nudges a leader, so
+          // the leader knows which "Sarah" is meant.
+          lastName: user.lastName,
         });
       }
     }

--- a/apps/convex/functions/users.ts
+++ b/apps/convex/functions/users.ts
@@ -21,6 +21,7 @@ import {
   getOptionalAuth,
 } from "../lib/auth";
 import { parseDate } from "../lib/validation";
+import { isBirthdayToday } from "../lib/birthdays";
 import { COMMUNITY_ROLES, COMMUNITY_ADMIN_THRESHOLD } from "../lib/permissions";
 import { adjustEnabledCounter } from "../lib/notifications/enabledCounter";
 import {
@@ -175,6 +176,11 @@ export const getProfile = query({
 
     const notificationsDisabled = await isUserNotificationsDisabled(ctx, user._id);
 
+    // Decided in the community's timezone so the profile agrees with what the
+    // birthday bot announces. Only the boolean crosses the wire — `dateOfBirth`
+    // itself stays server-side.
+    const community = await ctx.db.get(args.communityId);
+
     return {
       _id: user._id,
       firstName: user.firstName,
@@ -186,6 +192,7 @@ export const getProfile = query({
       linkedinHandle: user.linkedinHandle ?? null,
       birthdayMonth: user.birthdayMonth ?? null,
       birthdayDay: user.birthdayDay ?? null,
+      isBirthdayToday: isBirthdayToday(user, community?.timezone),
       location: user.location ?? null,
       // Community-scoped:
       memberSince: membership.createdAt ?? null,

--- a/apps/convex/functions/users.ts
+++ b/apps/convex/functions/users.ts
@@ -131,7 +131,7 @@ export const getProfile = query({
   },
   handler: async (ctx, args) => {
     // Viewer auth is optional — we don't gate public fields on it.
-    await getOptionalAuth(ctx, args.token);
+    const viewerId = await getOptionalAuth(ctx, args.token);
 
     const user = await ctx.db.get(args.userId);
     if (!user || user.isActive === false) {
@@ -179,7 +179,28 @@ export const getProfile = query({
     // Decided in the community's timezone so the profile agrees with what the
     // birthday bot announces. Only the boolean crosses the wire — `dateOfBirth`
     // itself stays server-side.
-    const community = await ctx.db.get(args.communityId);
+    //
+    // Unlike the other fields here, this one is gated on the VIEWER being a
+    // seated member of this community. The rest of this query is public by
+    // design (`getOptionalAuth`, mirroring `getById`), and every other field is
+    // either already public or opt-in via the profile form. This one is neither:
+    // it falls back to `dateOfBirth`, which is collected for the 13+ age check
+    // and is not something the member chose to share. Left ungated, an
+    // unauthenticated caller could poll it daily to recover the exact month and
+    // day for any user id they hold.
+    const viewerMembership = viewerId
+      ? await ctx.db
+          .query("userCommunities")
+          .withIndex("by_user_community", (q) =>
+            q.eq("userId", viewerId).eq("communityId", args.communityId),
+          )
+          .filter((q) => q.eq(q.field("status"), 1))
+          .first()
+      : null;
+
+    const community = viewerMembership
+      ? await ctx.db.get(args.communityId)
+      : null;
 
     return {
       _id: user._id,
@@ -192,7 +213,9 @@ export const getProfile = query({
       linkedinHandle: user.linkedinHandle ?? null,
       birthdayMonth: user.birthdayMonth ?? null,
       birthdayDay: user.birthdayDay ?? null,
-      isBirthdayToday: isBirthdayToday(user, community?.timezone),
+      isBirthdayToday: viewerMembership
+        ? isBirthdayToday(user, community?.timezone)
+        : false,
       location: user.location ?? null,
       // Community-scoped:
       memberSince: membership.createdAt ?? null,

--- a/apps/convex/lib/birthdays.ts
+++ b/apps/convex/lib/birthdays.ts
@@ -13,6 +13,13 @@
  * announces from it — so a badge driven only by the profile pair would leave
  * people celebrated in chat with nothing on their icon.
  *
+ * NOTE the relationship with the bot is a **superset**, not equality:
+ * `getMembersWithBirthdayToday` reads `dateOfBirth` only, so someone who set
+ * just the profile month/day gets a badge and no bot post. That direction is
+ * harmless. The direction that would be wrong — announced in chat with a bare
+ * icon — is the one this union rules out. Matching the bot's *timezone* is what
+ * keeps the two on the same calendar day.
+ *
  * IMPORTANT: callers may send the resulting **boolean** to clients, and nothing
  * else. Returning the underlying date would leak the year that `dateOfBirth`
  * deliberately keeps server-side.
@@ -20,6 +27,7 @@
 
 import type { QueryCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
+import { resolveTimeZone } from "./localDay";
 
 export type BirthdayFields = {
   dateOfBirth?: number;
@@ -37,38 +45,31 @@ export type MonthDay = {
 /**
  * The month and day it is "now" in an IANA timezone.
  *
- * Falls back to UTC for a missing or unrecognised zone rather than throwing —
- * a bad community timezone should not take down an inbox query.
+ * A missing or unrecognised zone falls back to {@link DEFAULT_TIMEZONE} via the
+ * shared `resolveTimeZone`, which is the same fallback the birthday bot applies
+ * to `community.timezone` (`getDueBirthdayBotConfigs`). Falling back to UTC here
+ * instead would put a legacy community's badge on a different calendar day from
+ * its own bot post for the last hours of the day.
  */
 export function todayMonthDay(timezone?: string, nowMs?: number): MonthDay {
   const now = nowMs === undefined ? new Date() : new Date(nowMs);
 
-  if (timezone && timezone !== "UTC") {
-    try {
-      const parts = new Intl.DateTimeFormat("en-US", {
-        timeZone: timezone,
-        month: "numeric",
-        day: "numeric",
-      }).formatToParts(now);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: resolveTimeZone(timezone),
+    month: "numeric",
+    day: "numeric",
+  }).formatToParts(now);
 
-      const month = Number(parts.find((p) => p.type === "month")?.value);
-      const day = Number(parts.find((p) => p.type === "day")?.value);
-
-      if (Number.isFinite(month) && Number.isFinite(day)) {
-        return { month, day };
-      }
-    } catch {
-      // Unrecognised timezone — fall through to UTC.
-    }
-  }
-
-  return { month: now.getUTCMonth() + 1, day: now.getUTCDate() };
+  return {
+    month: Number(parts.find((p) => p.type === "month")?.value),
+    day: Number(parts.find((p) => p.type === "day")?.value),
+  };
 }
 
 /**
  * Whether it is this user's birthday on the given day, from either stored
- * birthday. `timezone` should be the community's, so the answer matches what
- * the birthday bot announces.
+ * birthday. `timezone` should be the community's, so this lands on the same
+ * calendar day the birthday bot uses.
  */
 export function isBirthdayToday(
   user: BirthdayFields,
@@ -102,19 +103,31 @@ export async function getUsersWithBirthdayToday(
   ctx: QueryCtx,
   userIds: ReadonlyArray<Id<"users">>,
   timezone?: string,
+  /**
+   * Optional memo shared across calls. A list query that calls this once per
+   * row should pass one — the same person appears in several conversations,
+   * and without it each appearance costs another `users` read.
+   */
+  cache?: Map<Id<"users">, boolean>,
 ): Promise<Set<Id<"users">>> {
   if (userIds.length === 0) return new Set();
 
+  const memo = cache ?? new Map<Id<"users">, boolean>();
   const unique = Array.from(new Set(userIds));
-  const users = await Promise.all(unique.map((userId) => ctx.db.get(userId)));
+  const unknown = unique.filter((id) => !memo.has(id));
 
-  const nowMs = Date.now();
+  if (unknown.length > 0) {
+    const users = await Promise.all(unknown.map((userId) => ctx.db.get(userId)));
+    const nowMs = Date.now();
+    unknown.forEach((userId, i) => {
+      const user = users[i];
+      memo.set(userId, !!user && isBirthdayToday(user, timezone, nowMs));
+    });
+  }
+
   const birthdays = new Set<Id<"users">>();
-  unique.forEach((userId, i) => {
-    const user = users[i];
-    if (user && isBirthdayToday(user, timezone, nowMs)) {
-      birthdays.add(userId);
-    }
-  });
+  for (const userId of unique) {
+    if (memo.get(userId)) birthdays.add(userId);
+  }
   return birthdays;
 }

--- a/apps/convex/lib/birthdays.ts
+++ b/apps/convex/lib/birthdays.ts
@@ -1,0 +1,120 @@
+/**
+ * Deciding whether it is someone's birthday today.
+ *
+ * Togather stores two birthdays, for two different reasons:
+ *
+ * - `dateOfBirth` — the full date collected at sign-up for the 13+ age check.
+ *   It is PII: it carries the year, and it is never returned to clients.
+ * - `birthdayMonth` / `birthdayDay` — an optional month-and-day people set on
+ *   their own profile, deliberately stored without a year so it is shareable.
+ *
+ * Either one marks a birthday, so `isBirthdayToday` reads both. Most people
+ * only have the first (it is collected at sign-up), and the birthday bot
+ * announces from it — so a badge driven only by the profile pair would leave
+ * people celebrated in chat with nothing on their icon.
+ *
+ * IMPORTANT: callers may send the resulting **boolean** to clients, and nothing
+ * else. Returning the underlying date would leak the year that `dateOfBirth`
+ * deliberately keeps server-side.
+ */
+
+import type { QueryCtx } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+
+export type BirthdayFields = {
+  dateOfBirth?: number;
+  birthdayMonth?: number;
+  birthdayDay?: number;
+};
+
+export type MonthDay = {
+  /** 1-12. */
+  month: number;
+  /** 1-31. */
+  day: number;
+};
+
+/**
+ * The month and day it is "now" in an IANA timezone.
+ *
+ * Falls back to UTC for a missing or unrecognised zone rather than throwing —
+ * a bad community timezone should not take down an inbox query.
+ */
+export function todayMonthDay(timezone?: string, nowMs?: number): MonthDay {
+  const now = nowMs === undefined ? new Date() : new Date(nowMs);
+
+  if (timezone && timezone !== "UTC") {
+    try {
+      const parts = new Intl.DateTimeFormat("en-US", {
+        timeZone: timezone,
+        month: "numeric",
+        day: "numeric",
+      }).formatToParts(now);
+
+      const month = Number(parts.find((p) => p.type === "month")?.value);
+      const day = Number(parts.find((p) => p.type === "day")?.value);
+
+      if (Number.isFinite(month) && Number.isFinite(day)) {
+        return { month, day };
+      }
+    } catch {
+      // Unrecognised timezone — fall through to UTC.
+    }
+  }
+
+  return { month: now.getUTCMonth() + 1, day: now.getUTCDate() };
+}
+
+/**
+ * Whether it is this user's birthday on the given day, from either stored
+ * birthday. `timezone` should be the community's, so the answer matches what
+ * the birthday bot announces.
+ */
+export function isBirthdayToday(
+  user: BirthdayFields,
+  timezone?: string,
+  nowMs?: number,
+): boolean {
+  const { month, day } = todayMonthDay(timezone, nowMs);
+
+  if (user.birthdayMonth === month && user.birthdayDay === day) {
+    return true;
+  }
+
+  if (user.dateOfBirth !== undefined && user.dateOfBirth !== null) {
+    // `dateOfBirth` is stored as a date-only timestamp, so read it back in UTC
+    // — reading it locally would shift the date for anyone born near midnight.
+    const dob = new Date(user.dateOfBirth);
+    if (dob.getUTCMonth() + 1 === month && dob.getUTCDate() === day) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Batched form for list queries — mirrors `getUsersWithNotificationsDisabled`.
+ * Returns the set of users whose birthday it is today, so a row can ask
+ * `birthdays.has(userId)` without holding any birthday data itself.
+ */
+export async function getUsersWithBirthdayToday(
+  ctx: QueryCtx,
+  userIds: ReadonlyArray<Id<"users">>,
+  timezone?: string,
+): Promise<Set<Id<"users">>> {
+  if (userIds.length === 0) return new Set();
+
+  const unique = Array.from(new Set(userIds));
+  const users = await Promise.all(unique.map((userId) => ctx.db.get(userId)));
+
+  const nowMs = Date.now();
+  const birthdays = new Set<Id<"users">>();
+  unique.forEach((userId, i) => {
+    const user = users[i];
+    if (user && isBirthdayToday(user, timezone, nowMs)) {
+      birthdays.add(userId);
+    }
+  });
+  return birthdays;
+}

--- a/apps/mobile/components/ui/Avatar.tsx
+++ b/apps/mobile/components/ui/Avatar.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { StyleSheet, View, ImageStyle, StyleProp } from 'react-native';
 import { AppImage } from './AppImage';
 import { NotificationsDisabledBadge } from './NotificationsDisabledBadge';
+import { BirthdayBadge } from './BirthdayBadge';
 import { getMediaUrlWithTransform } from '@/utils/media';
 
 interface AvatarProps {
@@ -29,6 +30,12 @@ interface AvatarProps {
    * theme `surface` when omitted.
    */
   notificationsBadgeRingColor?: string;
+  /**
+   * When true, overlays a gift badge in the top-right corner to signal that
+   * it is this user's birthday today. Uses the opposite corner from the
+   * slashed bell so a muted user still gets both badges on their birthday.
+   */
+  isBirthdayToday?: boolean;
 }
 
 export function Avatar({
@@ -40,6 +47,7 @@ export function Avatar({
   placeholderBackgroundColor,
   notificationsDisabled,
   notificationsBadgeRingColor,
+  isBirthdayToday,
 }: AvatarProps) {
   const safeSize = size && size > 0 ? size : 48;
 
@@ -71,18 +79,26 @@ export function Avatar({
     />
   );
 
-  if (!notificationsDisabled) {
+  if (!notificationsDisabled && !isBirthdayToday) {
     return image;
   }
 
-  // Wrap so the badge can be absolutely positioned over the avatar's corner.
+  // Wrap so the badges can be absolutely positioned over the avatar's corners.
   return (
     <View style={[styles.wrapper, { width: safeSize, height: safeSize }]}>
       {image}
-      <NotificationsDisabledBadge
-        avatarSize={safeSize}
-        ringColor={notificationsBadgeRingColor}
-      />
+      {isBirthdayToday && (
+        <BirthdayBadge
+          avatarSize={safeSize}
+          ringColor={notificationsBadgeRingColor}
+        />
+      )}
+      {notificationsDisabled && (
+        <NotificationsDisabledBadge
+          avatarSize={safeSize}
+          ringColor={notificationsBadgeRingColor}
+        />
+      )}
     </View>
   );
 }

--- a/apps/mobile/components/ui/BirthdayBadge.tsx
+++ b/apps/mobile/components/ui/BirthdayBadge.tsx
@@ -1,0 +1,96 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, View, ViewStyle, StyleProp } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/hooks/useTheme';
+
+/**
+ * The birthday accent — deliberately the same in light and dark.
+ *
+ * A celebration doesn't change meaning in the dark, and white-on-rose clears
+ * 4.6:1 on either ground. It is also kept clear of the palette's existing
+ * meanings: brand green is "leader", grey is "muted", red is "destructive".
+ */
+export const BIRTHDAY_COLOR = '#D6336C';
+
+interface BirthdayBadgeProps {
+  /**
+   * Diameter of the parent avatar in pixels. The badge scales relative to it
+   * so the gift stays legible on tiny stacked previews and on the large
+   * profile-header avatar.
+   */
+  avatarSize: number;
+  /**
+   * Optional style override — used to position the badge against a parent
+   * container.
+   */
+  style?: StyleProp<ViewStyle>;
+  /**
+   * Color used for the badge ring/contrast border. Defaults to
+   * `theme.surface`. Pass the actual surface the avatar sits on so the badge
+   * reads as an overlay rather than a free-floating dot.
+   */
+  ringColor?: string;
+  testID?: string;
+}
+
+/**
+ * Gift badge overlaid on a user avatar on their birthday. Renders nothing
+ * visual on its own — callsites mount it inside a `position: relative` parent
+ * (typically an Avatar) so it sits over the corner of the avatar.
+ *
+ * Sits in the **top-right** corner, unlike `NotificationsDisabledBadge` and the
+ * inbox's leader shield, which both own the bottom-right. Someone can be a
+ * leader with notifications off on their birthday, so the corners can't clash.
+ *
+ * The gift glyph matches how Togather already talks about birthdays — it's the
+ * same icon the profile's details card uses for the date itself.
+ *
+ * Sizing mirrors `NotificationsDisabledBadge` exactly, so when both badges are
+ * on one avatar they are the same size.
+ */
+export function BirthdayBadge({
+  avatarSize,
+  style,
+  ringColor,
+  testID = 'birthday-badge',
+}: BirthdayBadgeProps) {
+  const { colors } = useTheme();
+  const sizes = useMemo(() => {
+    const raw = Math.round(avatarSize * 0.42);
+    const badge = Math.max(11, Math.min(raw, 26));
+    const icon = Math.max(7, Math.round(badge * 0.65));
+    const border = badge >= 18 ? 1.5 : 1;
+    return { badge, icon, border };
+  }, [avatarSize]);
+
+  return (
+    <View
+      pointerEvents="none"
+      testID={testID}
+      style={[
+        styles.badge,
+        {
+          width: sizes.badge,
+          height: sizes.badge,
+          borderRadius: sizes.badge / 2,
+          backgroundColor: BIRTHDAY_COLOR,
+          borderColor: ringColor ?? colors.surface,
+          borderWidth: sizes.border,
+        },
+        style,
+      ]}
+    >
+      <Ionicons name="gift" size={sizes.icon} color="#FFFFFF" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    position: 'absolute',
+    top: -2,
+    right: -2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/mobile/components/ui/NotificationsDisabledBadge.tsx
+++ b/apps/mobile/components/ui/NotificationsDisabledBadge.tsx
@@ -21,6 +21,7 @@ interface NotificationsDisabledBadgeProps {
    * reads as an overlay rather than a free-floating dot.
    */
   ringColor?: string;
+  testID?: string;
 }
 
 /**
@@ -36,6 +37,7 @@ export function NotificationsDisabledBadge({
   avatarSize,
   style,
   ringColor,
+  testID = 'notifications-disabled-badge',
 }: NotificationsDisabledBadgeProps) {
   const { colors } = useTheme();
   const sizes = useMemo(() => {
@@ -49,6 +51,7 @@ export function NotificationsDisabledBadge({
   return (
     <View
       pointerEvents="none"
+      testID={testID}
       style={[
         styles.badge,
         {

--- a/apps/mobile/components/ui/__tests__/BirthdayBadge.test.tsx
+++ b/apps/mobile/components/ui/__tests__/BirthdayBadge.test.tsx
@@ -77,10 +77,30 @@ describe.each([
     expect(queryByTestId('birthday-badge')).toBeTruthy();
   });
 
-  it('shows the badge for a muted user too — the corners do not collide', () => {
-    const { queryByTestId } = render(
+  it('shows BOTH badges for a muted user on their birthday, in opposite corners', () => {
+    const { getByTestId } = render(
       renderAvatar({ isBirthdayToday: true, notificationsDisabled: true }),
     );
-    expect(queryByTestId('birthday-badge')).toBeTruthy();
+
+    const gift = flatten(getByTestId('birthday-badge').props.style);
+    const bell = flatten(
+      getByTestId('notifications-disabled-badge').props.style,
+    );
+
+    // Neither badge may be dropped to make room for the other, and they must
+    // stay on opposite vertical edges — that split is the whole reason the
+    // birthday badge is top-anchored.
+    expect(gift.top).toBe(-2);
+    expect(gift.bottom).toBeUndefined();
+    expect(bell.bottom).toBe(-2);
+    expect(bell.top).toBeUndefined();
+  });
+
+  it('shows only the bell when it is not their birthday', () => {
+    const { queryByTestId } = render(
+      renderAvatar({ notificationsDisabled: true }),
+    );
+    expect(queryByTestId('notifications-disabled-badge')).toBeTruthy();
+    expect(queryByTestId('birthday-badge')).toBeNull();
   });
 });

--- a/apps/mobile/components/ui/__tests__/BirthdayBadge.test.tsx
+++ b/apps/mobile/components/ui/__tests__/BirthdayBadge.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * The birthday gift badge, and how it shares an avatar with the slashed-bell
+ * badge. The corner split is the point: someone can be muted on their birthday,
+ * and both badges have to stay readable.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { BirthdayBadge, BIRTHDAY_COLOR } from '../BirthdayBadge';
+import { Avatar } from '../Avatar';
+import { WaAvatar } from '../../wa/WaAvatar';
+
+const flatten = (style: any): Record<string, any> =>
+  Array.isArray(style)
+    ? Object.assign({}, ...style.map(flatten))
+    : (style ?? {});
+
+describe('BirthdayBadge', () => {
+  it('sits in the top-right corner, opposite the slashed bell', () => {
+    const { getByTestId } = render(<BirthdayBadge avatarSize={56} />);
+    const style = flatten(getByTestId('birthday-badge').props.style);
+
+    expect(style.position).toBe('absolute');
+    expect(style.top).toBe(-2);
+    expect(style.right).toBe(-2);
+    expect(style.bottom).toBeUndefined();
+  });
+
+  it('uses the birthday accent, not a themed colour', () => {
+    const { getByTestId } = render(<BirthdayBadge avatarSize={56} />);
+    expect(flatten(getByTestId('birthday-badge').props.style).backgroundColor).toBe(
+      BIRTHDAY_COLOR,
+    );
+  });
+
+  it('scales with the avatar and stays a circle', () => {
+    const { getByTestId } = render(<BirthdayBadge avatarSize={56} />);
+    const style = flatten(getByTestId('birthday-badge').props.style);
+
+    // 56 * 0.42 -> 24, within the 11..26 clamp.
+    expect(style.width).toBe(24);
+    expect(style.height).toBe(24);
+    expect(style.borderRadius).toBe(12);
+  });
+
+  it('clamps so it stays legible on a tiny avatar and modest on a huge one', () => {
+    const tiny = render(<BirthdayBadge avatarSize={20} />);
+    expect(flatten(tiny.getByTestId('birthday-badge').props.style).width).toBe(11);
+
+    const huge = render(<BirthdayBadge avatarSize={200} />);
+    expect(flatten(huge.getByTestId('birthday-badge').props.style).width).toBe(26);
+  });
+
+  it('takes its contrast ring from the surface it is passed', () => {
+    const { getByTestId } = render(
+      <BirthdayBadge avatarSize={56} ringColor="#123456" />,
+    );
+    expect(flatten(getByTestId('birthday-badge').props.style).borderColor).toBe(
+      '#123456',
+    );
+  });
+});
+
+describe.each([
+  ['Avatar', (props: any) => <Avatar name="Tadala Jumbe" size={56} {...props} />],
+  [
+    'WaAvatar',
+    (props: any) => <WaAvatar label="Tadala Jumbe" size={56} {...props} />,
+  ],
+])('%s birthday wiring', (_name, renderAvatar) => {
+  it('shows no badge on an ordinary day', () => {
+    const { queryByTestId } = render(renderAvatar({}));
+    expect(queryByTestId('birthday-badge')).toBeNull();
+  });
+
+  it('shows the badge on their birthday', () => {
+    const { queryByTestId } = render(renderAvatar({ isBirthdayToday: true }));
+    expect(queryByTestId('birthday-badge')).toBeTruthy();
+  });
+
+  it('shows the badge for a muted user too — the corners do not collide', () => {
+    const { queryByTestId } = render(
+      renderAvatar({ isBirthdayToday: true, notificationsDisabled: true }),
+    );
+    expect(queryByTestId('birthday-badge')).toBeTruthy();
+  });
+});

--- a/apps/mobile/components/wa/WaAvatar.tsx
+++ b/apps/mobile/components/wa/WaAvatar.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { View, Text, StyleSheet, StyleProp, ViewStyle } from 'react-native';
 import { AppImage } from '@components/ui/AppImage';
 import { NotificationsDisabledBadge } from '@components/ui/NotificationsDisabledBadge';
+import { BirthdayBadge } from '@components/ui/BirthdayBadge';
 import { useTheme } from '@hooks/useTheme';
 import { waAvatarPalette, waAvatarInitials } from './waAvatarColor';
 
@@ -41,6 +42,11 @@ export interface WaAvatarProps {
   notificationsDisabled?: boolean;
   /** Surface the avatar sits on, so the badge's contrast ring blends in. */
   notificationsBadgeRingColor?: string;
+  /**
+   * Gift overlay for a user whose birthday it is today. Sits in the opposite
+   * corner from the slashed bell, so both can show at once.
+   */
+  isBirthdayToday?: boolean;
   style?: StyleProp<ViewStyle>;
   testID?: string;
 }
@@ -53,6 +59,7 @@ export function WaAvatar({
   size,
   notificationsDisabled,
   notificationsBadgeRingColor,
+  isBirthdayToday,
   style,
   testID,
 }: WaAvatarProps) {
@@ -84,12 +91,17 @@ export function WaAvatar({
     />
   );
 
-  if (!notificationsDisabled) return image;
+  if (!notificationsDisabled && !isBirthdayToday) return image;
 
   return (
     <View style={{ width: size, height: size }}>
       {image}
-      <NotificationsDisabledBadge avatarSize={size} ringColor={notificationsBadgeRingColor} />
+      {isBirthdayToday && (
+        <BirthdayBadge avatarSize={size} ringColor={notificationsBadgeRingColor} />
+      )}
+      {notificationsDisabled && (
+        <NotificationsDisabledBadge avatarSize={size} ringColor={notificationsBadgeRingColor} />
+      )}
     </View>
   );
 }

--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -2311,6 +2311,7 @@ type DirectInboxRowData = {
     displayName: string;
     profilePhoto: string | null;
     notificationsDisabled: boolean;
+    isBirthdayToday: boolean;
   }>;
   /** 1:1 counterpart who left (e.g. expired request) — display only. */
   formerMember: {
@@ -2407,6 +2408,7 @@ export function DirectMessageRow({ row, primaryColor, colors, whatsappShellEnabl
               members={displayMembers.map((m) => ({
                 name: m.displayName,
                 imageUrl: m.profilePhoto,
+                isBirthdayToday: m.isBirthdayToday,
               }))}
               surfaceColor={colors.surface}
               size={WA_ROW_AVATAR_SIZE}
@@ -2422,6 +2424,7 @@ export function DirectMessageRow({ row, primaryColor, colors, whatsappShellEnabl
               imageUrl={primaryAvatar?.profilePhoto ?? undefined}
               size={WA_ROW_AVATAR_SIZE}
               notificationsDisabled={primaryAvatar?.notificationsDisabled ?? false}
+              isBirthdayToday={primaryAvatar?.isBirthdayToday ?? false}
               notificationsBadgeRingColor={colors.surface}
             />
           )}
@@ -2459,6 +2462,7 @@ export function DirectMessageRow({ row, primaryColor, colors, whatsappShellEnabl
           members={displayMembers.map((m) => ({
             name: m.displayName,
             imageUrl: m.profilePhoto,
+            isBirthdayToday: m.isBirthdayToday,
           }))}
           surfaceColor={colors.surface}
         />
@@ -2468,6 +2472,7 @@ export function DirectMessageRow({ row, primaryColor, colors, whatsappShellEnabl
           imageUrl={primaryAvatar?.profilePhoto ?? undefined}
           size={56}
           notificationsDisabled={primaryAvatar?.notificationsDisabled ?? false}
+          isBirthdayToday={primaryAvatar?.isBirthdayToday ?? false}
           notificationsBadgeRingColor={colors.surface}
         />
       )}

--- a/apps/mobile/features/chat/components/ChatInfoScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInfoScreen.tsx
@@ -68,6 +68,7 @@ type Member = {
   isSelf: boolean;
   isInviter: boolean;
   notificationsDisabled: boolean;
+  isBirthdayToday: boolean;
 };
 
 const SEARCH_DEBOUNCE_MS = 200;
@@ -146,6 +147,7 @@ export function ChatInfoScreen({ channelId }: Props) {
       isSelf: false,
       isInviter: m.userId === creatorId,
       notificationsDisabled: m.notificationsDisabled,
+      isBirthdayToday: m.isBirthdayToday,
     }));
     const self: Member = {
       userId: currentUserId,
@@ -157,6 +159,10 @@ export function ChatInfoScreen({ channelId }: Props) {
       // have notifications" indicator — they already get the inbox banner
       // and Settings warning. Always render as enabled here.
       notificationsDisabled: false,
+      // `getDirectInbox` only reports birthdays for the OTHER side of a chat,
+      // so the viewer's own flag isn't available here. Not worth another query:
+      // you already know it's your birthday.
+      isBirthdayToday: false,
     };
     return [self, ...others];
   }, [inboxRow, currentUserId, creatorId, selfDisplayName, user]);
@@ -428,6 +434,7 @@ export function ChatInfoScreen({ channelId }: Props) {
                 imageUrl={m.profilePhoto}
                 size={40}
                 notificationsDisabled={m.notificationsDisabled}
+                isBirthdayToday={m.isBirthdayToday}
                 notificationsBadgeRingColor={colors.surfaceSecondary}
               />
               <View style={styles.memberRowText}>

--- a/apps/mobile/features/chat/components/ChatRoomHeader.tsx
+++ b/apps/mobile/features/chat/components/ChatRoomHeader.tsx
@@ -30,6 +30,8 @@ import { StackedMemberAvatars } from "./StackedMemberAvatars";
 type Member = {
   name: string;
   imageUrl: string | null;
+  /** Gift badge on their avatar when it's their birthday today. */
+  isBirthdayToday?: boolean;
 };
 
 type Props = {
@@ -124,6 +126,8 @@ export const ChatRoomHeader = memo(function ChatRoomHeader({
               name={otherMembers[0]?.name ?? titleLine}
               imageUrl={otherMembers[0]?.imageUrl ?? undefined}
               size={36}
+              isBirthdayToday={otherMembers[0]?.isBirthdayToday}
+              notificationsBadgeRingColor={colors.surface}
             />
           ) : (
             <StackedMemberAvatars

--- a/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
+++ b/apps/mobile/features/chat/components/ConvexChatRoomScreen.tsx
@@ -1144,13 +1144,17 @@ const ConvexChatRoomScreenInner: React.FC = () => {
     adHocChannelMembers?.formerMember,
   );
   const adHocOtherMembersKey = adHocDisplayedMembers
-    .map((m) => `${m.userId}|${m.profilePhoto ?? ""}|${m.displayName}`)
+    .map(
+      (m) =>
+        `${m.userId}|${m.profilePhoto ?? ""}|${m.displayName}|${m.isBirthdayToday ? 1 : 0}`,
+    )
     .join("\n");
   const adHocOtherMembers = useMemo(
     () =>
       adHocDisplayedMembers.map((m) => ({
         name: m.displayName,
         imageUrl: m.profilePhoto,
+        isBirthdayToday: m.isBirthdayToday,
       })),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [adHocOtherMembersKey],

--- a/apps/mobile/features/chat/components/StackedMemberAvatars.tsx
+++ b/apps/mobile/features/chat/components/StackedMemberAvatars.tsx
@@ -7,6 +7,8 @@ type StackMember = {
   imageUrl: string | null;
   /** When true, the slashed-bell badge overlays this avatar in the stack. */
   notificationsDisabled?: boolean;
+  /** When true, the gift badge overlays this avatar in the stack. */
+  isBirthdayToday?: boolean;
 };
 
 type Props = {
@@ -39,11 +41,18 @@ export function StackedMemberAvatars({
           imageUrl={m.imageUrl ?? undefined}
           size={size}
           notificationsDisabled={m.notificationsDisabled}
+          isBirthdayToday={m.isBirthdayToday}
           notificationsBadgeRingColor={surfaceColor}
         />
       </View>
     );
   }
+
+  // NOTE: the multi-member clusters below deliberately render no per-avatar
+  // badges — neither the slashed bell nor the birthday gift. Each sub-avatar is
+  // ~30pt inside a 2pt ring, so a corner badge would overlap its neighbours and
+  // the cluster would read as noise. A birthday in a group chat still shows on
+  // that person's own 1:1 row and on their profile.
 
   // Sizes are proportional to the bounding box so the cluster scales for
   // header (36), inbox (56), and info-hero (96) callers without re-tuning.

--- a/apps/mobile/features/chat/components/__tests__/ChatInboxScreen.formerMember.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/ChatInboxScreen.formerMember.test.tsx
@@ -69,6 +69,7 @@ describe("DirectMessageRow — departed 1:1 counterpart", () => {
           displayName: "David Walker",
           profilePhoto: null,
           notificationsDisabled: false,
+          isBirthdayToday: false,
         },
       ],
     });

--- a/apps/mobile/features/chat/utils/__tests__/adHocDisplayMembers.test.ts
+++ b/apps/mobile/features/chat/utils/__tests__/adHocDisplayMembers.test.ts
@@ -5,6 +5,7 @@ const active = {
   displayName: "Carol Chen",
   profilePhoto: "https://example.com/carol.jpg",
   notificationsDisabled: true,
+  isBirthdayToday: false,
 };
 
 const former = {
@@ -26,6 +27,8 @@ describe("adHocDisplayMembers", () => {
         profilePhoto: former.profilePhoto,
         // Someone who left is not a notification target — never badge them.
         notificationsDisabled: false,
+        // And `formerMember` is a snapshot, so it can't know their birthday.
+        isBirthdayToday: false,
       },
     ]);
   });

--- a/apps/mobile/features/chat/utils/adHocDisplayMembers.ts
+++ b/apps/mobile/features/chat/utils/adHocDisplayMembers.ts
@@ -20,6 +20,7 @@ type ActiveMember = {
   displayName: string;
   profilePhoto: string | null;
   notificationsDisabled: boolean;
+  isBirthdayToday: boolean;
 };
 
 type FormerMember = {
@@ -40,6 +41,9 @@ export function adHocDisplayMembers(
       // Someone who left this chat is not a notification target, so the
       // "notifications off" avatar badge would be misleading noise.
       notificationsDisabled: false,
+      // `formerMember` is a snapshot of who they were when they left, not a
+      // live user read — so it can't know, and shouldn't guess, their birthday.
+      isBirthdayToday: false,
     },
   ];
 }

--- a/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
+++ b/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
@@ -1034,11 +1034,18 @@ const styles = StyleSheet.create({
   editRow: { flexDirection: "row", alignItems: "center", gap: 4, paddingTop: 4 },
   editText: { fontSize: 14, fontWeight: "600" },
   row: { flexDirection: "row", gap: 10, borderRadius: 12, padding: 12, marginTop: 4 },
-  // 76 fits "10:00 AM" at 14pt/700. `toLocaleTimeString` separates the meridiem
-  // with U+202F (narrow no-break space), so an overflowing label cannot break at
-  // the space and breaks mid-word instead ("10:00 A" / "M") — hence the explicit
-  // width plus `numberOfLines={1}` on the label, which holds at larger font scales.
-  timeCol: { width: 76, flexShrink: 0 },
+  // A clock label that overflows this column used to break *mid-word* — "10:00
+  // AM" rendered as "10:00 A" / "M". Mid-word rather than at the space because
+  // current ICU builds separate the meridiem with a non-breaking character
+  // (U+202F, narrow no-break space) that the layout engine may not break at.
+  //
+  // `minWidth` rather than a fixed `width` because RN Text scales with the OS
+  // font-size setting: at a large accessibility scale every label grows, and a
+  // fixed column would only trade the mid-word break for a truncated time. The
+  // column keeps rows aligned at any one scale (every label is the same format)
+  // while still being free to grow. `numberOfLines={1}` is the belt to that
+  // brace, so the row height can never change.
+  timeCol: { minWidth: 76, flexShrink: 0 },
   timeText: { fontSize: 14, fontWeight: "700" },
   durationText: { fontSize: 11, marginTop: 1 },
   content: { flex: 1, gap: 4 },

--- a/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
+++ b/apps/mobile/features/leader-tools/components/NativeRunSheetView.tsx
@@ -873,11 +873,17 @@ function ReadOnlyRow({
       ]}
     >
       <View style={styles.timeCol}>
-        <Text style={[styles.timeText, { color: colors.text }]}>
+        <Text
+          style={[styles.timeText, { color: colors.text }]}
+          numberOfLines={1}
+        >
           {clockMs != null ? formatClockTime(clockMs) : "—"}
         </Text>
         {duration ? (
-          <Text style={[styles.durationText, { color: colors.textTertiary }]}>
+          <Text
+            style={[styles.durationText, { color: colors.textTertiary }]}
+            numberOfLines={1}
+          >
             {duration}
           </Text>
         ) : null}
@@ -1028,7 +1034,11 @@ const styles = StyleSheet.create({
   editRow: { flexDirection: "row", alignItems: "center", gap: 4, paddingTop: 4 },
   editText: { fontSize: 14, fontWeight: "600" },
   row: { flexDirection: "row", gap: 10, borderRadius: 12, padding: 12, marginTop: 4 },
-  timeCol: { width: 64 },
+  // 76 fits "10:00 AM" at 14pt/700. `toLocaleTimeString` separates the meridiem
+  // with U+202F (narrow no-break space), so an overflowing label cannot break at
+  // the space and breaks mid-word instead ("10:00 A" / "M") — hence the explicit
+  // width plus `numberOfLines={1}` on the label, which holds at larger font scales.
+  timeCol: { width: 76, flexShrink: 0 },
   timeText: { fontSize: 14, fontWeight: "700" },
   durationText: { fontSize: 11, marginTop: 1 },
   content: { flex: 1, gap: 4 },

--- a/apps/mobile/features/profile/components/UserProfileBadges.tsx
+++ b/apps/mobile/features/profile/components/UserProfileBadges.tsx
@@ -1,6 +1,8 @@
 /**
- * Role pills: Primary Admin, Community Admin, Group Leader.
- * Returns null when the user has no badges to show (keeps the layout tight).
+ * Standing pills under the profile name: "Birthday today", then the role pills
+ * (Primary Admin, Community Admin, Group Leader).
+ *
+ * Returns null when the user has no pills to show (keeps the layout tight).
  */
 
 import React from 'react';
@@ -8,6 +10,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@hooks/useTheme';
 import { useCommunityTheme } from '@hooks/useCommunityTheme';
+import { BIRTHDAY_COLOR } from '@components/ui/BirthdayBadge';
 
 import type { UserProfile } from '../hooks/useUserProfile';
 
@@ -21,12 +24,26 @@ export function UserProfileBadges({ profile }: UserProfileBadgesProps) {
 
   const isLeader = (profile.leaderGroupIds?.length ?? 0) > 0;
 
-  if (!profile.isPrimaryAdmin && !profile.isCommunityAdmin && !isLeader) {
+  if (
+    !profile.isBirthdayToday &&
+    !profile.isPrimaryAdmin &&
+    !profile.isCommunityAdmin &&
+    !isLeader
+  ) {
     return null;
   }
 
   return (
     <View style={styles.container}>
+      {/* Leads the row: it's the one pill that is only true today. */}
+      {profile.isBirthdayToday && (
+        <Pill
+          icon="gift"
+          label="Birthday today"
+          backgroundColor={BIRTHDAY_COLOR + '20'}
+          color={BIRTHDAY_COLOR}
+        />
+      )}
       {profile.isPrimaryAdmin && (
         <Pill
           icon="star"

--- a/apps/mobile/features/profile/components/UserProfileHeader.tsx
+++ b/apps/mobile/features/profile/components/UserProfileHeader.tsx
@@ -8,6 +8,7 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { AppImage } from '@components/ui';
 import { ImageViewer } from '@components/ui/ImageViewer';
 import { NotificationsDisabledBadge } from '@components/ui/NotificationsDisabledBadge';
+import { BirthdayBadge } from '@components/ui/BirthdayBadge';
 import { useTheme } from '@hooks/useTheme';
 
 import type { UserProfile } from '../hooks/useUserProfile';
@@ -53,6 +54,9 @@ export function UserProfileHeader({ profile }: UserProfileHeaderProps) {
               backgroundColor: '#E5E5E5',
             }}
           />
+          {profile.isBirthdayToday ? (
+            <BirthdayBadge avatarSize={96} ringColor={colors.surface} />
+          ) : null}
           {profile.notificationsDisabled ? (
             <NotificationsDisabledBadge
               avatarSize={96}

--- a/apps/mobile/features/profile/hooks/useUserProfile.ts
+++ b/apps/mobile/features/profile/hooks/useUserProfile.ts
@@ -27,8 +27,10 @@ export interface UserProfile {
   birthdayDay: number | null;
   /**
    * Decided on the server, in the community's timezone, from either stored
-   * birthday — so it agrees with what the birthday bot announces. The date
-   * behind it never leaves the server; see `apps/convex/lib/birthdays.ts`.
+   * birthday — a superset of what the birthday bot announces, on the same
+   * calendar day. The date behind it never leaves the server, and it is only
+   * populated for viewers who are seated members of the community; see
+   * `apps/convex/lib/birthdays.ts`.
    */
   isBirthdayToday: boolean;
   location: string | null;

--- a/apps/mobile/features/profile/hooks/useUserProfile.ts
+++ b/apps/mobile/features/profile/hooks/useUserProfile.ts
@@ -25,6 +25,12 @@ export interface UserProfile {
   linkedinHandle: string | null;
   birthdayMonth: number | null;
   birthdayDay: number | null;
+  /**
+   * Decided on the server, in the community's timezone, from either stored
+   * birthday — so it agrees with what the birthday bot announces. The date
+   * behind it never leaves the server; see `apps/convex/lib/birthdays.ts`.
+   */
+  isBirthdayToday: boolean;
   location: string | null;
   memberSince: number | null;
   communityRole: number;


### PR DESCRIPTION
Marks someone's birthday where you'd notice it — their chat icon and their profile — and fixes the birthday bot so the people it addresses are actually notified. Also fixes an unrelated run sheet layout bug reported alongside it.

**Design spec:** https://claude.ai/code/artifact/6b376308-ba98-48dc-820f-490f8b5f668a

> Review round 1 is complete — see [the summary comment](https://github.com/togathernyc/togather/pull/813#issuecomment-5307881727) for every finding and how it was resolved.

---

## 1. The signifier

A gift badge overlays the avatar in the inbox, the DM chat header, and the chat-info member list, plus a **"Birthday today"** pill under the profile name.

It takes the **top-right** corner. Bottom-right is already spoken for by the slashed-bell "muted" badge and the inbox's leader shield, and someone can be a muted leader on their birthday — so the corners are split rather than fought over. Sizing mirrors `NotificationsDisabledBadge` exactly, so two badges on one avatar always match. The gift glyph is what `UserProfileDetailsCard` already uses for a birthday date, so it isn't new vocabulary.

### Where the date comes from

Togather stores two birthdays:

| field | what it is |
| --- | --- |
| `dateOfBirth` | full date collected at sign-up for the 13+ check. Carries a year, treated as PII, never returned to clients. |
| `birthdayMonth` / `birthdayDay` | optional month-and-day people set on their own profile, deliberately without a year so it is shareable. |

New `apps/convex/lib/birthdays.ts` reads **both**. Most people only have the first — it is collected at sign-up, and the birthday bot announces from it — so a badge driven only by the profile pair would leave people celebrated in chat with a bare icon. The relationship with the bot is a deliberate **superset**: the bot reads only `dateOfBirth`, so a profile-only birthday gets a badge and no post. The harmful direction — announced in chat with a bare icon — is what the union rules out.

Two things protect the PII:

- **Only the resulting boolean crosses the wire.** `dateOfBirth` carries a year and stays server-side, exactly as before.
- **On the profile it is gated on the viewer being a seated member** of that community. `getProfile` is otherwise public by design (`getOptionalAuth`), and every other field on it is either already public or opt-in via the profile form. This one is neither, so left ungated an anonymous caller could poll it daily and recover anyone's birth month and day.

The day is decided in the **community's timezone**, via the same shared `resolveTimeZone`/`DEFAULT_TIMEZONE` the bot uses, so a badge and a bot post can't land on different calendar days.

## 2. The birthday bot

The bot named people in its messages but never passed `mentionedUserIds`. "Hey Maria" was plain text: it styled as nothing, linked to nobody, and sent no notification — **the leader it nudged was never told.**

Each mode now mentions the person it is actually talking to:

- **`general_chat`** posts to the whole group, so it @mentions the birthday people — the message is addressed to them.
- **`leader_reminder`** asks one leader to go and say happy birthday, so it @mentions that leader, and names the birthday people **in full, first and last**, so a leader with two Sarahs knows which one.

The birthday people are deliberately **not** mentioned in the leaders channel: it's a private nudge, and pinging them would give the surprise away.

Ids are attached only when the placeholder that renders them is actually in the template — a leader can edit these, and a "mention" push and email for a message that mentions nobody is worse than no mention at all. Names are bracket-stripped before interpolation so a name containing `]` can't close the markup early and forge a second mention.

Message building was duplicated verbatim between `runBirthdayBot` and `processBirthdayBotBucket`; it moves into a pure, directly testable `buildBirthdayBotMessage`. Extracting it also fixed a latent bug: placeholders were filled with non-global `String.replace`, so a template using `[[birthday_names]]` twice only ever had its first occurrence substituted.

## 3. Run sheet clock column

`timeCol` was a fixed `width: 64`, which "10:00 AM" overflows — and it broke **mid-word**, rendering as "10:00 A" / "M", because the meridiem separator is non-breaking so the engine couldn't break at the space.

Changed to `minWidth: 76` plus `numberOfLines={1}`. `minWidth` rather than a fixed width because RN `Text` scales with the OS font-size setting: at a large accessibility scale every label grows, and a fixed column would only have traded the mid-word break for a truncated time. Rows stay aligned because every label is the same format.

---

## Testing

**3545** convex tests and **2675** mobile tests pass; both typechecks clean.

New coverage worth calling out:

- `birthdayToday.plumbing.test.ts` — the flag end to end through `getProfile` and `getDirectInbox`, including the PII contract (the response must not contain the date) and the membership gate. Without this the queries could hand the client a hardcoded `false` and every other test in the repo would still pass.
- `scheduledJobs.birthday-bot.test.ts` — the **hourly cron path** (`processBirthdayBotBucket`) in both modes. The previous integration assertion exercised `runBirthdayBot`, which `crons.ts` does not call, so dropping `mentionedUserIds` from the scheduled path was invisible. The leader and the birthday person are seeded as different users so the assertions can tell them apart.
- `BirthdayBadge.test.tsx` — both badges survive together on opposite edges, not just that the gift renders.

Both new suites were mutation-checked: reverting each fix makes them fail.

One existing assertion was updated rather than worked around — `birthday-bot.test.ts` asserted the old plain-text leader name, and now asserts the mention markup **and** that `mentionedUserIds` carries the leader.

Run sheet verified on the backend-free `/ui-test/run-sheet-expand` harness: the column tracks the label from 76pt at 14px through 122pt at 28px with no clipping, and the existing expand/collapse e2e assertions still pass.

## Reviewer notes

Please confirm one behaviour change: **mentions add an email path the bot didn't have.** `mention` declares `defaultChannels: ['push', 'email']`; `new_message` is push-only. So birthday people and the nudged leader now get a transactional email as well as a push, fired by cron. That follows directly from "@mention the leader", but it's a new outbound-email path.

Deliberate limits:

1. **The bot still matches only on `dateOfBirth`.** Widening who gets *publicly announced* is a product call, not a review fix.
2. **Multi-member avatar clusters show no badge**, following the existing precedent there for the slashed bell — a corner badge on a ~30pt sub-avatar would overlap its neighbours.
3. **Group member lists, leader tools, and your own profile** don't show it — scope beyond "chat icon + profile page".
4. **Feb 29** produces no badge and no post in non-leap years. Pre-existing; badge and bot agree.
5. **Convex queries aren't time-reactive**, so the badge flips when the query re-runs (foreground, new message), not at midnight on a screen left open.

No dependency, `runtimeVersion`, `native-deps.json`, or lockfile changes, and no native media/view code touched. Still wants a device/staging check on the avatar badge before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B51DqgHa8Yx4gwYmdhhZ5g)_