### PR TITLE
fix(chat): composer input is untappable on Android

### DIFF
--- a/apps/mobile/features/chat/components/ChatInboxScreen.tsx
+++ b/apps/mobile/features/chat/components/ChatInboxScreen.tsx
@@ -1070,6 +1070,13 @@ export function ChatInboxScreen({
             </WaFloatingButton>
           )}
         </View>
+        {/* TODO: Investigate - `pointerEvents` is a no-op on <Text> on Android
+            (only `ReactViewGroup` implements `ReactPointerEventsView`), so this
+            title swallows taps in its rect there. `Text.d.ts` declares the prop,
+            which is why it typechecks. Fix needs an <Animated.View> wrapper with
+            the animated style moved onto it — device-verify the header
+            animation when doing it. Same defect as the composer hint fixed in
+            MessageInput.tsx; see the note there. */}
         <Animated.Text
           style={[styles.smallTitle, { color: colors.text }, smallTitleStyle]}
           numberOfLines={1}
@@ -1151,6 +1158,13 @@ export function ChatInboxScreen({
             {collapsingHeaderTitle}
           </Text>
         </Animated.View>
+        {/* TODO: Investigate - `pointerEvents` is a no-op on <Text> on Android
+            (only `ReactViewGroup` implements `ReactPointerEventsView`), so this
+            title swallows taps in its rect there. `Text.d.ts` declares the prop,
+            which is why it typechecks. Fix needs an <Animated.View> wrapper with
+            the animated style moved onto it — device-verify the header
+            animation when doing it. Same defect as the composer hint fixed in
+            MessageInput.tsx; see the note there. */}
         <Animated.Text
           style={[styles.smallTitle, { color: colors.text }, smallTitleStyle]}
           numberOfLines={1}

--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -1293,14 +1293,26 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, onReply
             editable={!uploading}
           />
           {text.length === 0 && (
-            <Text
-              pointerEvents="none"
-              numberOfLines={1}
-              ellipsizeMode="tail"
-              style={[styles.waHintOverlay, { color: themeColors.textTertiary }]}
-            >
-              {(placeholder ?? "").trim() || "Message..."}
-            </Text>
+            /* The tap-through opt-out lives on this <View>, NOT on the <Text>
+               inside it. The hint covers the whole tappable area of the
+               TextInput above, and on Android `pointerEvents` is only read off
+               views implementing `ReactPointerEventsView` — `ReactViewGroup`
+               (<View>) is the only one; `ReactTextView` isn't, and `TextProps`
+               doesn't even declare the prop. A bare <Text pointerEvents="none">
+               therefore stays the hit target (the sibling walk is topmost-first
+               with no fall-through), the EditText never focuses, and since the
+               hint only unmounts once the field is non-empty the composer is
+               permanently dead. See the regression test next door. */
+            <View pointerEvents="none" style={styles.waHintOverlay}>
+              <Text
+                testID="wa-composer-hint"
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                style={[styles.waHintOverlayText, { color: themeColors.textTertiary }]}
+              >
+                {(placeholder ?? "").trim() || "Message..."}
+              </Text>
+            </View>
           )}
           {/* Hidden without a KLIPY key — the documented degradation is "GIF
               picker hidden", matching the attachment-sheet option's gate. */}
@@ -1637,9 +1649,12 @@ const styles = StyleSheet.create({
     // paints the browser's focus outline around it. Ignored on native.
     outlineStyle: 'none',
   } as any,
-  /** Empty-field hint overlay: one quiet italic line, vertically centered
-   *  in the pill; sits behind taps (pointerEvents none) and clear of the
-   *  in-field sticker glyph. */
+  /** Empty-field hint overlay: the positioning box. Takes its height from the
+   *  single line of text inside it (`lineHeight` === the field height), and
+   *  with no `top`/`bottom` the wrap's `alignItems: 'flex-end'` seats it on the
+   *  field's baseline row — the geometry the hint Text used to own directly.
+   *  Carries `pointerEvents="none"` in the JSX; see the note there for why the
+   *  <Text> can't. */
   waHintOverlay: {
     position: 'absolute',
     left: 16,
@@ -1647,6 +1662,9 @@ const styles = StyleSheet.create({
     // padding + the wrap's 4pt right padding = 38, rounded up) — NOT the field
     // height, which this deliberately does not track.
     right: 44,
+  },
+  /** One quiet italic line, vertically centered in the pill by its line box. */
+  waHintOverlayText: {
     fontSize: 14,
     fontStyle: 'italic',
     lineHeight: WA_COMPOSER_FIELD_HEIGHT,

--- a/apps/mobile/features/chat/components/MessageInput.tsx
+++ b/apps/mobile/features/chat/components/MessageInput.tsx
@@ -1297,12 +1297,21 @@ export function MessageInput({ channelId, replyToMessage, onCancelReply, onReply
                inside it. The hint covers the whole tappable area of the
                TextInput above, and on Android `pointerEvents` is only read off
                views implementing `ReactPointerEventsView` — `ReactViewGroup`
-               (<View>) is the only one; `ReactTextView` isn't, and `TextProps`
-               doesn't even declare the prop. A bare <Text pointerEvents="none">
-               therefore stays the hit target (the sibling walk is topmost-first
-               with no fall-through), the EditText never focuses, and since the
-               hint only unmounts once the field is non-empty the composer is
-               permanently dead. See the regression test next door. */
+               (<View>) is the only one, `ReactTextView` isn't. So a bare
+               <Text pointerEvents="none"> stays the hit target (the sibling
+               walk is topmost-first with no fall-through), so the EditText
+               never focuses. The hint only unmounts once the field is
+               non-empty, so the state can't be typed out of. (Not quite 100%
+               dead: the hint stops at `right: 44`, so taps in that strip still
+               landed — when no KLIPY glyph is there to take them.)
+
+               The trap: `Text.d.ts` DOES declare the prop — "Similar to
+               `View`'s `pointerEvents`" — so the broken version typechecks and
+               ships green. Only the Flow `TextProps.js` omits it. Nothing but a
+               device catches this.
+               See: ReactAndroid/src/main/java/com/facebook/react/uimanager/
+               TouchTargetHelper.kt:317 (pointerEvents read) and :217 (the
+               topmost-first sibling walk). */
             <View pointerEvents="none" style={styles.waHintOverlay}>
               <Text
                 testID="wa-composer-hint"

--- a/apps/mobile/features/chat/components/__tests__/MessageInput.waComposer.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageInput.waComposer.test.tsx
@@ -246,36 +246,50 @@ describe('MessageInput WhatsApp composer (flag-on)', () => {
    * Android regression guard (device video, 2026-08-23: tapping the composer
    * never raised the keyboard, while '+' / camera / mic beside it all worked).
    *
-   * The empty-field hint is an absolutely-positioned overlay covering the
-   * whole tappable area of the TextInput underneath it, so it MUST be
-   * transparent to touches. `pointerEvents` on a <Text> only achieves that on
-   * iOS: on Android `TouchTargetHelper` reads pointerEvents solely off views
-   * implementing `ReactPointerEventsView`, and in RN 0.81 `ReactViewGroup`
-   * (<View>) is the only one — `ReactTextView` does not implement it, and
-   * `TextProps` does not even declare the prop. The hit test walks siblings
-   * topmost-first and returns the first hit with no fall-through, so a bare
-   * <Text pointerEvents="none"> swallows every tap on the field and the
-   * EditText never focuses. Since the hint only unmounts once the field is
-   * non-empty, that state is unrecoverable.
+   * Anything absolutely positioned over the pill is a hit target on Android
+   * unless it is a <View> that opts out. `pointerEvents` on a <Text> does not
+   * count: `Text.d.ts` declares the prop ("Similar to `View`'s"), so the broken
+   * version typechecks and ships green, but Android reads it only off
+   * `ReactViewGroup`. See the note at the hint in MessageInput.tsx.
    *
-   * So: the opt-out must live on a host <View>, never on the <Text>.
+   * Runs under Android because the bug is Android-only and the composer does
+   * render platform-dependently — under iOS a `Platform.OS === 'android'`
+   * branch could reintroduce exactly this bug and still pass.
+   *
+   * Structural guard only: RNTL runs no hit test, so this proves tree shape,
+   * never that a real tap focuses a real EditText. That needs a device. It also
+   * only sees the default render state (empty field, no reply preview /
+   * offline hint / pending request / GIF key).
    */
-  it('makes the empty-field hint tap-through via a View, not a Text (Android)', () => {
-    const { getByTestId, UNSAFE_root } = render(
+  it('keeps every overlay over the composer field tap-through (Android)', () => {
+    Platform.OS = 'android';
+
+    const { getByTestId } = render(
       <MessageInput channelId={'test-channel' as any} />
     );
 
+    const field = getByTestId('wa-composer-field');
     const hint = getByTestId('wa-composer-hint');
     expect(hint.type).toBe('Text');
+    expect(isInside(hint, field)).toBe(true);
 
-    // The hint sits over the input, inside the pill.
-    expect(isInside(hint, getByTestId('wa-composer-field'))).toBe(true);
+    /** Element name, whether the node is a host string or a composite. */
+    const nameOf = (node: any) =>
+      typeof node.type === 'string'
+        ? node.type
+        : node.type?.displayName ?? node.type?.name ?? '';
 
-    // Some ancestor View between the hint and the pill opts out of touches.
+    /** On Android only a View honors the opt-out — in prop or style form. */
+    const optsOutOfTouches = (node: any) =>
+      !/Text$/.test(nameOf(node)) &&
+      (node.props?.pointerEvents === 'none' ||
+        StyleSheet.flatten(node.props?.style)?.pointerEvents === 'none');
+
+    // The hint specifically is shielded by such a View before the pill.
     let node: any = hint.parent;
     let shield: any = null;
-    while (node && node !== getByTestId('wa-composer-field')) {
-      if (node.type === 'View' && node.props?.pointerEvents === 'none') {
+    while (node && node !== field) {
+      if (nameOf(node) === 'View' && optsOutOfTouches(node)) {
         shield = node;
         break;
       }
@@ -283,20 +297,47 @@ describe('MessageInput WhatsApp composer (flag-on)', () => {
     }
     expect(shield).not.toBeNull();
 
-    // ...and no <Text> anywhere in the composer relies on the prop Android drops.
-    for (const text of UNSAFE_root.findAllByType('Text' as any)) {
+    // The general invariant, not just this node: every absolutely-positioned
+    // child of the pill must be tap-through, or it steals the input's taps.
+    // Guards the naive next overlay (a character counter, an edit badge...).
+    for (const child of field.children) {
+      if (typeof child === 'string') continue;
+      const style = StyleSheet.flatten((child as any).props?.style);
+      if (style?.position !== 'absolute') continue;
+      expect(optsOutOfTouches(child)).toBe(true);
+    }
+
+    // No <Text> in the composer field relies on the prop Android drops.
+    // Scoped to the field: Ionicons renders its glyphs as <Text>, so a
+    // repo-wide sweep would fail on a vector-icons bump, not on this bug.
+    for (const text of (field as any).findAllByType('Text')) {
       expect(text.props?.pointerEvents).toBeUndefined();
     }
 
-    // Splitting the style across the two nodes must not move or restyle the
-    // hint: the box keeps the insets, the line keeps its italic line box.
+    // Splitting one style entry into two must not move or restyle the hint.
+    // `lineHeight` is what gives the box its height; `top`/`bottom` must stay
+    // unset so waFieldWrap's `alignItems: 'flex-end'` seats it on the baseline.
     const box = StyleSheet.flatten(shield.props.style);
     expect(box.position).toBe('absolute');
     expect(box.left).toBe(16);
     expect(box.right).toBe(44);
+    expect(box.top).toBeUndefined();
+    expect(box.bottom).toBeUndefined();
     const line = StyleSheet.flatten(hint.props.style);
+    expect(line.fontSize).toBe(14);
     expect(line.fontStyle).toBe('italic');
     expect(line.lineHeight).toBe(WA_FIELD_HEIGHT);
+  });
+
+  it('shows the hint only while the field is empty', () => {
+    // If the hint ever stopped unmounting it would sit over the typed text.
+    const { getByTestId, queryByTestId } = render(
+      <MessageInput channelId={'test-channel' as any} />
+    );
+    expect(getByTestId('wa-composer-hint').props.children).toBe('Message...');
+
+    fireEvent.changeText(getByTestId('wa-composer-input'), 'hello');
+    expect(queryByTestId('wa-composer-hint')).toBeNull();
   });
 
   it('hides the in-field sticker glyph while a DM request is pending', () => {

--- a/apps/mobile/features/chat/components/__tests__/MessageInput.waComposer.test.tsx
+++ b/apps/mobile/features/chat/components/__tests__/MessageInput.waComposer.test.tsx
@@ -242,6 +242,63 @@ describe('MessageInput WhatsApp composer (flag-on)', () => {
     expect(getByText('add')).toBeTruthy();
   });
 
+  /**
+   * Android regression guard (device video, 2026-08-23: tapping the composer
+   * never raised the keyboard, while '+' / camera / mic beside it all worked).
+   *
+   * The empty-field hint is an absolutely-positioned overlay covering the
+   * whole tappable area of the TextInput underneath it, so it MUST be
+   * transparent to touches. `pointerEvents` on a <Text> only achieves that on
+   * iOS: on Android `TouchTargetHelper` reads pointerEvents solely off views
+   * implementing `ReactPointerEventsView`, and in RN 0.81 `ReactViewGroup`
+   * (<View>) is the only one — `ReactTextView` does not implement it, and
+   * `TextProps` does not even declare the prop. The hit test walks siblings
+   * topmost-first and returns the first hit with no fall-through, so a bare
+   * <Text pointerEvents="none"> swallows every tap on the field and the
+   * EditText never focuses. Since the hint only unmounts once the field is
+   * non-empty, that state is unrecoverable.
+   *
+   * So: the opt-out must live on a host <View>, never on the <Text>.
+   */
+  it('makes the empty-field hint tap-through via a View, not a Text (Android)', () => {
+    const { getByTestId, UNSAFE_root } = render(
+      <MessageInput channelId={'test-channel' as any} />
+    );
+
+    const hint = getByTestId('wa-composer-hint');
+    expect(hint.type).toBe('Text');
+
+    // The hint sits over the input, inside the pill.
+    expect(isInside(hint, getByTestId('wa-composer-field'))).toBe(true);
+
+    // Some ancestor View between the hint and the pill opts out of touches.
+    let node: any = hint.parent;
+    let shield: any = null;
+    while (node && node !== getByTestId('wa-composer-field')) {
+      if (node.type === 'View' && node.props?.pointerEvents === 'none') {
+        shield = node;
+        break;
+      }
+      node = node.parent;
+    }
+    expect(shield).not.toBeNull();
+
+    // ...and no <Text> anywhere in the composer relies on the prop Android drops.
+    for (const text of UNSAFE_root.findAllByType('Text' as any)) {
+      expect(text.props?.pointerEvents).toBeUndefined();
+    }
+
+    // Splitting the style across the two nodes must not move or restyle the
+    // hint: the box keeps the insets, the line keeps its italic line box.
+    const box = StyleSheet.flatten(shield.props.style);
+    expect(box.position).toBe('absolute');
+    expect(box.left).toBe(16);
+    expect(box.right).toBe(44);
+    const line = StyleSheet.flatten(hint.props.style);
+    expect(line.fontStyle).toBe('italic');
+    expect(line.lineHeight).toBe(WA_FIELD_HEIGHT);
+  });
+
   it('hides the in-field sticker glyph while a DM request is pending', () => {
     const { queryByLabelText } = render(
       <MessageInput channelId={'test-channel' as any} recipientPending />


### PR DESCRIPTION
## The bug

Tapping the message field on Android never raised the keyboard. The `+`, camera and mic beside it all worked — only the field itself was inert. Since the field could never be typed into, the state couldn't be recovered from.

Reported via device video (2026-08-23): repeated taps on the composer do nothing, then a tap lands on `+` (attachment tray opens) and later on the mic (record-audio permission prompt) — confirming everything *around* the field is live.

## Root cause

The WhatsApp-shell composer draws its empty-field hint as an absolutely-positioned `Text` with `pointerEvents="none"`, layered over the `TextInput` and covering its whole tappable area. That opt-out works only on iOS.

On Android, in RN 0.81:

- `TouchTargetHelper.kt:317` reads `pointerEvents` **only** from views implementing `ReactPointerEventsView`. `ReactViewGroup` (the backing view for `View`) is the **only** implementer in the tree — `ReactTextView` is not one.
- The sibling hit test (`TouchTargetHelper.kt:217`) walks children topmost-first and returns the **first** hit, with no fall-through to lower siblings.
- `ReactEditText.kt:99`: *"ReactEditTexts have setFocusableInTouchMode set to false automatically because touches on the EditText are managed on the JS side."* Android focus therefore comes **only** from `TextInput.js:585-593` (`usePressability` → `inputRef.current.focus()`). Losing the JS hit test loses focus outright — native dispatch alone would never have focused the field either.

So the hint `Text` won the taps and the `ReactEditText` never focused. It only unmounts once `text.length > 0`, which requires typing, so the field couldn't be typed out of the broken state. (Not quite 100% dead: the hint stops at `right: 44`, so taps in that strip still landed when no KLIPY glyph was there to take them.)

**Why this shipped green:** `Text.d.ts:211-213` *does* declare `pointerEvents`, documented as *"Similar to `View`'s `pointerEvents`"*. Only the Flow `TextProps.js` omits it. So the broken version typechecks, passes tests, and renders correctly — nothing but a real device catches it.

The flag-off composer was never affected: it uses the native `placeholder` prop and has no overlay.

## The fix

Move the tap-through opt-out onto a wrapping `View` with `pointerEvents="none"`, which Android does honour. The style is split so the box keeps the absolute insets and the text keeps its italic line box.

Geometry is unchanged, verified against Yoga: `AbsoluteLayout.cpp:116` uses `resolveChildAlignment` for absolute children when the inset is undefined, so `waFieldWrap`'s `alignItems: 'flex-end'` still seats the box — and the box takes the same height from the child's `lineHeight`. The wrapper also can't be flattened away by Fabric: `ViewShadowNode.cpp:49` lists `pointerEvents == PointerEventsMode::None` as forcing `formsView`.

## Tests

The guard asserts the **invariant**, not just this node: every absolutely-positioned child of the pill must be tap-through, so the naive next overlay (a character counter, an edit badge) can't silently kill the composer the same way. It runs under `Platform.OS = 'android'`, accepts the opt-out in style or prop form, and is scoped to the composer field. A second test pins the hint's copy and that it unmounts once the field is non-empty.

Mutation-verified — each of these slips past a node-bound guard and fails against this one:

| Mutation | Result |
| --- | --- |
| `pointerEvents` moved back onto the `Text` | caught |
| wrapper kept, `pointerEvents` dropped | caught |
| a rogue absolute overlay `Text` added to the pill | **caught (was missed)** |
| `Platform.OS === 'android'` reintroduction of the original bug | **caught (was missed)** |
| unmodified code (control) | passes |

- `pnpm test` in `apps/mobile` → 252 suites, 2677 tests, all pass
- eslint clean via the pre-commit hook
- Pre-existing and untouched: `MessageInput.tsx` already fails typecheck on `main` at `:292`, `:306`, `:898` (TS2322) and `:1386` (TS2339)

## Review

Four parallel lenses (correctness, test adequacy, spec-fidelity, completeness), each instructed to refute the diagnosis, with findings posted in the review thread. The diagnosis survived. Six findings were addressed in ca432db — the most significant being that the original code comment stated the *opposite* of the load-bearing fact about `Text.d.ts`, and that the first version of the test couldn't catch two realistic regressions.

One claim from the first draft of this PR was **disproved** and is withdrawn: `behavior="padding"` on `KeyboardAvoidingView` is redundant on Android, not harmful — `KeyboardAvoidingView.js:107-109` computes from the measured frame, so under `adjustResize` the term collapses to ~0.

No `apps/web` guide update is owed (no chat/messaging row in the feature→guide map, and this restores intended behavior rather than changing it). No dependency surface touched — `native-deps.json`, `app.json`, both `package.json`s and the lockfile are all unchanged.

## Merge gate

CI structurally cannot validate this — the original defect shipped with a green suite, and RNTL runs no hit test, so these tests prove tree shape, never that a real tap focuses a real `EditText`. Per CLAUDE.md's native-safety rule, **this needs a device or staging-OTA pass on Android before merge**: open a chat, tap the empty composer, confirm the keyboard comes up.

## Follow-up (separate PR)

The same defect is live in `ChatInboxScreen`, and one instance is over a real button. `styles.smallTitle` (`:2814-2821`) is `position: absolute; left: 0; right: 0`, always mounted and only opacity-animated. Because the hit walk is reverse-index, the trailing `+` survives but the community-avatar button at index 0 is tested *after* the Text — so on Android roughly the middle half of "Open community page" is dead. (The file's own comment at `:946-950` already notes that an opacity-0 view still hit-tests on Android.) The second instance at `:1154-1160` is benign — the only interactive element in `navRow` is rendered after the Text.

ca432db adds `// TODO: Investigate` breadcrumbs at both sites. The fix needs an `Animated.View` wrapper with the animated style moved onto it, plus device verification of the header animation — hence a separate PR.

That PR should also carry an ESLint `no-restricted-syntax` rule banning `pointerEvents` as a JSX attribute on `Text`/`Animated.Text`. Since `Text.d.ts` declares the prop, **typecheck will never catch a recurrence**; a lint rule will. A repo-wide scan finds exactly 3 non-`.web` instances today — the one fixed here plus those two — so the rule lands clean once they're fixed.